### PR TITLE
feat: impl user/my interface

### DIFF
--- a/packages/interface/src/api/user/endpoint/apiUsr001.ts
+++ b/packages/interface/src/api/user/endpoint/apiUsr001.ts
@@ -1,0 +1,58 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+/**
+ * @version v0.1
+ * @description 서비스를 신청하는 유저의 정보를 가져옵니다
+ */
+
+const url = () => `/user/my`;
+const method = "GET";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({
+    clubs: z.array(
+      z.object({
+        id: z.number().int().min(1),
+        name: z.string().max(30),
+      }),
+    ),
+    name: z.string().max(30),
+    email: z.string().max(50),
+    department: z.string().max(10),
+    studentNumber: z.number().int().min(20000000).max(30000000),
+    phoneNumber: z.string().max(20).optional(),
+  }),
+};
+
+const responseErrorMap = {};
+
+const apiUsr001 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiUsr001RequestParam = z.infer<typeof apiUsr001.requestParam>;
+type ApiUsr001RequestQuery = z.infer<typeof apiUsr001.requestQuery>;
+type ApiUsr001RequestBody = z.infer<typeof apiUsr001.requestBody>;
+type ApiUsr001ResponseOK = z.infer<(typeof apiUsr001.responseBodyMap)[200]>;
+
+export default apiUsr001;
+
+export type {
+  ApiUsr001RequestParam,
+  ApiUsr001RequestQuery,
+  ApiUsr001RequestBody,
+  ApiUsr001ResponseOK,
+};

--- a/packages/interface/src/api/user/index.ts
+++ b/packages/interface/src/api/user/index.ts
@@ -1,0 +1,1 @@
+import "./endpoint/apiUsr001";


### PR DESCRIPTION
# 요약 \*

It closes #80 
신청 관련 feature에서 활용하기 위한 유저 프로필(유저명, 연락처, 활동중인 동아리 등)을
가져올 수 있는 user/my API의 인터페이스 구현입니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
