### PR TITLE
feat: add Modal component

### DIFF
--- a/packages/web/src/common/components/Modal/Modal.tsx
+++ b/packages/web/src/common/components/Modal/Modal.tsx
@@ -39,7 +39,7 @@ const ModalBlockContainer = styled.div`
 
 const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
   onClose = () => {},
-  children = <div>{}</div>,
+  children = <div />,
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
 

--- a/packages/web/src/common/components/Modal/Modal.tsx
+++ b/packages/web/src/common/components/Modal/Modal.tsx
@@ -1,0 +1,61 @@
+import React, { FC, useRef } from "react";
+import styled from "styled-components";
+
+export interface ModalProps {
+  onClose?: () => void;
+}
+
+const ModalBlockBackground = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+
+  box-sizing: border-box;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(85, 85, 85, 0.1);
+
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+`;
+
+const ModalBlockContainer = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  overflow: auto;
+  overflow-x: hidden;
+
+  height: max-content;
+  max-width: 600px;
+  max-height: 300px;
+
+  background-color: ${({ theme }) => theme.colors.WHITE};
+  border-radius: ${({ theme }) => theme.round.md};
+  box-shadow: ${({ theme }) => theme.shadow.md};
+`;
+
+const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
+  onClose = () => {},
+  children = <div>{}</div>,
+}) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <ModalBlockBackground
+      ref={ref}
+      onClick={e => {
+        if (e.target !== ref.current) {
+          return;
+        }
+        onClose();
+      }}
+    >
+      <ModalBlockContainer>{children}</ModalBlockContainer>
+    </ModalBlockBackground>
+  );
+};
+
+export default Modal;

--- a/packages/web/src/common/components/Modal/ModalExample.tsx
+++ b/packages/web/src/common/components/Modal/ModalExample.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import Modal from "./Modal";
 
 import Button from "../Button";
+import Modal from ".";
 
 const ModalBody = styled.div`
   display: inline-flex;
-  padding: 32px;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/packages/web/src/common/components/Modal/ModalExample.tsx
+++ b/packages/web/src/common/components/Modal/ModalExample.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Modal from "./Modal";
+
+import Button from "../Button";
+
+const ModalBody = styled.div`
+  display: inline-flex;
+  padding: 32px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const ModalExample = () => {
+  const [modalVisible, setModalVisible] = useState(false);
+  return (
+    <>
+      {modalVisible && (
+        <Modal onClose={() => setModalVisible(false)}>
+          <ModalBody>
+            <div>신청이 완료되었습니다.</div>
+            <div style={{ width: 400, height: 800, backgroundColor: "gray" }} />
+            <Button onClick={() => setModalVisible(false)}>확인</Button>
+          </ModalBody>
+        </Modal>
+      )}
+      <Button onClick={() => setModalVisible(!modalVisible)}>오픈 모달</Button>
+    </>
+  );
+};
+
+export default ModalExample;

--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -5,7 +5,7 @@ export interface ModalProps {
   onClose?: () => void;
 }
 
-const ModalBlockBackground = styled.div`
+const ModalBackground = styled.div`
   position: fixed;
   left: 0;
   top: 0;
@@ -22,11 +22,11 @@ const ModalBlockBackground = styled.div`
   z-index: 100;
 `;
 
-const ModalBlockContainer = styled.div`
+const ModalContainer = styled.div`
   display: flex;
-  flex-flow: column nowrap;
-  overflow: auto;
-  overflow-x: hidden;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 
   height: max-content;
   max-width: 600px;
@@ -37,6 +37,15 @@ const ModalBlockContainer = styled.div`
   box-shadow: ${({ theme }) => theme.shadow.md};
 `;
 
+const ModalScrollContainer = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  overflow: auto;
+  overflow-x: hidden;
+
+  padding: 32px;
+`;
+
 const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
   onClose = () => {},
   children = <div />,
@@ -44,7 +53,7 @@ const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
   const ref = useRef<HTMLDivElement | null>(null);
 
   return (
-    <ModalBlockBackground
+    <ModalBackground
       ref={ref}
       onClick={e => {
         if (e.target !== ref.current) {
@@ -53,8 +62,10 @@ const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
         onClose();
       }}
     >
-      <ModalBlockContainer>{children}</ModalBlockContainer>
-    </ModalBlockBackground>
+      <ModalContainer>
+        <ModalScrollContainer>{children}</ModalScrollContainer>
+      </ModalContainer>
+    </ModalBackground>
   );
 };
 


### PR DESCRIPTION
# 요약 

#57 Modal Component 추가

# 컴포넌트 사용방법
1. Modal 열고 닫는 상태관리는 Modal 밖에서 조정 가능하게 구현하였습니다. Modal을 사용하려는 컴포넌트(ex.ModalExample)에서 상태 관리 해주시면 될 것 같습니다.
2. max-height 300px 로 되어 있고 overflow시 스크롤 됩니다.
3. 컴포넌트 사용예시: `ModalExample`


# 스크린샷
<img width="1293" alt="image" src="https://github.com/academic-relations/ar-002-clubs/assets/89931104/d688f773-00cd-48eb-acda-2a969de1ccab">

# 테스트 방법: 
common > components > Modal 폴더 하위에 `ModalExample` 라는 예제 파일 추가하였습니다.
테스트 시 notice 페이지에 `ModalExample` 컴포넌트를 추가하여 테스트 하면 될 것 같습니다.

`const Notice = () => (
  <>
    <ModalExample />
    <NoticePageMainFrame />
  </>
);`

# 이후 Task \*

- 없음
