### PR TITLE
Typography support custom styles and awesome types

### DIFF
--- a/packages/web/src/common/components/Typography.tsx
+++ b/packages/web/src/common/components/Typography.tsx
@@ -1,24 +1,66 @@
+import { Theme } from "@sparcs-clubs/web/styles/themes";
 import React from "react";
 import styled from "styled-components";
 
-interface TypographyProps extends React.HTMLAttributes<HTMLDivElement> {
+interface TypographyPropsBase extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  type?:
-    | "h1"
-    | "h2"
-    | "h3"
-    | "h4"
-    | "h5"
-    | "h6"
-    | "p"
-    | "p_b"
-    | "span"
-    | "h3_b";
 }
 
-const TypographyInner = styled.div`
-  color: "inherit";
+interface TypographyPropsWithType extends TypographyPropsBase {
+  type: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "p_b" | "span" | "h3_b";
+}
+
+type ColorKeys = keyof Theme["colors"];
+type NestedColorKeys<C extends ColorKeys> = C extends keyof Theme["colors"]
+  ? Theme["colors"][C] extends string | number
+    ? never
+    : keyof Theme["colors"][C] & (string | number)
+  : never;
+
+type NestedColors = {
+  [C in ColorKeys]: NestedColorKeys<C> extends never
+    ? never
+    : `${C}.${NestedColorKeys<C>}`;
+}[ColorKeys];
+
+type ThemeColors = ColorKeys | NestedColors;
+
+const getColorFromTheme = (theme: Theme, colorString: ThemeColors) => {
+  if (typeof colorString === "string" && colorString.includes(".")) {
+    const [colorKey, shade] = colorString.split(".");
+    const colorValue = theme.colors[colorKey as keyof Theme["colors"]];
+
+    if (typeof colorValue === "object" && shade in colorValue) {
+      return colorValue[shade as keyof typeof colorValue];
+    }
+  }
+
+  return theme.colors[colorString as keyof Theme["colors"]];
+};
+
+interface TypographyPropsWithCustomStyles extends TypographyPropsBase {
+  fs?: number;
+  lh?: number;
+  fw?: keyof Theme["fonts"]["WEIGHT"];
+  color?: ThemeColors;
+}
+
+type TypographyProps =
+  | (TypographyPropsWithType & {
+      fs?: never;
+      lh?: never;
+      fw?: never;
+      color?: never;
+    })
+  | (TypographyPropsWithCustomStyles & { type?: never });
+
+const TypographyInner = styled.div<TypographyPropsWithCustomStyles>`
+  color: ${({ color, theme }) =>
+    color ? getColorFromTheme(theme, color) : "inherit"};
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
+  font-size: ${({ fs }) => (fs ? `${fs}px` : "inherit")};
+  line-height: ${({ lh }) => (lh ? `${lh}px` : "inherit")};
+  font-weight: ${({ fw, theme }) => (fw ? theme.fonts.WEIGHT[fw] : "inherit")};
 `;
 
 const H3 = styled(TypographyInner)`
@@ -44,27 +86,50 @@ const P_B = styled(TypographyInner)`
 
 /**
  * ## Typography component.
- * @param {string} type - Type of typography.
- * ### Types and font sizes, line heights, and font weights:
- * - h3: 20px, 24px, medium (500)
- * - p: 16px, 20px, regular (400)
+ * @param {Object} props - Props for the Typography component.
+ * @param {("h1"|"h2"|"h3"|"h4"|"h5"|"h6"|"p"|"p_b"|"span"|"h3_b")} [props.type] - Type of typography.
+ * @param {React.ReactNode} props.children - Content to be rendered inside the typography element.
+ * @param {number} [props.fs] - Font size of the typography element in pixels.
+ * @param {number} [props.lh] - Line height of the typography element in pixels.
+ * @param {keyof Theme["fonts"]["WEIGHT"]} [props.fw] - Font weight of the typography element.
+ * @param {ThemeColors} [props.color] - Color of the typography element.
+ * @param {React.HTMLAttributes<HTMLDivElement>} [props.divProps] - Additional props to be passed to the underlying div element.
+ *
+ * The Typography component is a versatile component that allows rendering text with different styles and types.
+ * It accepts either a `type` prop to select a predefined style or individual style props (`fs`, `lh`, `fw`, `color`) to customize the appearance.
+ *
+ * ### Types and their corresponding styles:
+ * - h3: 20px font size, 24px line height, medium (500) font weight
+ * - h3_b: Same as h3 but with semibold (600) font weight
+ * - p: 16px font size, 20px line height, regular (400) font weight
+ * - p_b: Same as p but with medium (500) font weight
+ *
+ * The `color` prop accepts either a top-level color key from `Theme["colors"]` or a nested color key in the format `"ColorKey.NestedColorKey"`.
+ * The available color keys are defined in the `ThemeColors` type, which is generated based on the structure of `Theme["colors"]`.
+ *
+ * If no `type` prop is provided, the component will render a generic `TypographyInner` element with the specified style props.
  */
+
 const Typography: React.FC<TypographyProps> = ({
-  type = "h3",
-  children,
-  ...divProps
+  children = null,
+  ...rest
 }) => {
-  switch (type) {
-    case "h3":
-      return <H3 {...divProps}>{children}</H3>;
-    case "h3_b":
-      return <H3_B {...divProps}>{children}</H3_B>;
-    case "p":
-      return <P {...divProps}>{children}</P>;
-    case "p_b":
-      return <P_B {...divProps}>{children}</P_B>;
-    default:
-      return <TypographyInner {...divProps}>{children}</TypographyInner>;
+  if ("type" in rest) {
+    const { type, ...divProps } = rest;
+    switch (type) {
+      case "h3":
+        return <H3 {...divProps}>{children}</H3>;
+      case "h3_b":
+        return <H3_B {...divProps}>{children}</H3_B>;
+      case "p":
+        return <P {...divProps}>{children}</P>;
+      case "p_b":
+        return <P_B {...divProps}>{children}</P_B>;
+      default:
+        return <TypographyInner {...divProps}>{children}</TypographyInner>;
+    }
+  } else {
+    return <TypographyInner {...rest}>{children}</TypographyInner>;
   }
 };
 

--- a/packages/web/src/common/components/Typography.tsx
+++ b/packages/web/src/common/components/Typography.tsx
@@ -42,6 +42,7 @@ interface TypographyPropsWithCustomStyles extends TypographyPropsBase {
   fs?: number;
   lh?: number;
   fw?: keyof Theme["fonts"]["WEIGHT"];
+  ff?: keyof Theme["fonts"]["FAMILY"];
   color?: ThemeColors;
 }
 
@@ -57,7 +58,7 @@ type TypographyProps =
 const TypographyInner = styled.div<TypographyPropsWithCustomStyles>`
   color: ${({ color, theme }) =>
     color ? getColorFromTheme(theme, color) : "inherit"};
-  font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
+  font-family: ${({ theme, ff }) => (ff ? theme.fonts.FAMILY[ff] : "inherit")};
   font-size: ${({ fs }) => (fs ? `${fs}px` : "inherit")};
   line-height: ${({ lh }) => (lh ? `${lh}px` : "inherit")};
   font-weight: ${({ fw, theme }) => (fw ? theme.fonts.WEIGHT[fw] : "inherit")};


### PR DESCRIPTION
…ed colors

# 요약 \*

The `color` prop accepts either a top-level color key from `Theme["colors"]` or a nested color key in the format `"ColorKey.NestedColorKey"`.
The available color keys are defined in the `ThemeColors` type, which is generated based on the structure of `Theme["colors"]`.

It closes #125 

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
