### PR TITLE
114 Impl Manage Club > Service Usage List Pages

### DIFF
--- a/packages/web/src/app/manage-club/rental-business/page.tsx
+++ b/packages/web/src/app/manage-club/rental-business/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from "react";
+
+import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
+import styled from "styled-components";
+import ManageClubTableMainFrame from "@sparcs-clubs/web/features/manageClubTable/frames/ManageClubTableMainFrame";
+
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const ManageClubRentalBusiness = () => (
+  <>
+    <PageHeadWrapper>
+      <BreadCrumb
+        items={[
+          { name: "대표 동아리 관리", path: "/manage-club" },
+          { name: "대여 사업 신청 내역", path: "/manage-club/rental-business" },
+        ]}
+      />
+      <PageTitle>대여 사업 신청 내역</PageTitle>
+    </PageHeadWrapper>
+    <ManageClubTableMainFrame />
+  </>
+);
+
+export default ManageClubRentalBusiness;

--- a/packages/web/src/features/manageClubTable/frames/ManageClubTableMainFrame.tsx
+++ b/packages/web/src/features/manageClubTable/frames/ManageClubTableMainFrame.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import TableCell from "@sparcs-clubs/web/common/components/Table/TableCell";
+import React, { useState } from "react";
+import styled from "styled-components";
+import NoticePagination from "@sparcs-clubs/web/features/notices/components/NoticePagination";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { tempHeaders } from "../types/ManageClubTableHeader";
+import { mockData } from "../types/mock";
+import {
+  dateAndTimeFormatKeys,
+  dateFormatKeys,
+  numberFormatKeys,
+  startEndTimeFormatKeys,
+} from "../types/ManageClubTable";
+
+const ManageClubTablePageMainFrameInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+  align-items: center;
+`;
+
+const TableFrameInner = styled.div`
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px #dddddd solid;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  display: inline-flex;
+  margin-bottom: 20px;
+`;
+
+const TableRowFrameInner = styled.div`
+  width: 100%;
+  align-items: flex-start;
+  display: grid;
+`;
+
+const TableCellInner = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+const formattedString = (
+  key: string,
+  value: Date | number | string,
+): string => {
+  const days = "일월화수목금토";
+
+  if (dateAndTimeFormatKeys.includes(key)) {
+    return `${(value as Date).getFullYear()}년 ${(value as Date).getMonth() + 1}월 ${(value as Date).getDate()}일 (${days[(value as Date).getDay()]}) ${(value as Date).getHours().toString().padStart(2, "0")}:${(value as Date).getMinutes().toString().padStart(2, "0")}`;
+  }
+  if (dateFormatKeys.includes(key)) {
+    return `${(value as Date).getFullYear()}년 ${(value as Date).getMonth() + 1}월 ${(value as Date).getDate()}일 (${days[(value as Date).getDay()]})`;
+  }
+  if (startEndTimeFormatKeys.includes(key)) {
+    return value as string;
+  }
+  if (numberFormatKeys.includes(key)) {
+    return `${value}매`;
+  }
+
+  return value as string;
+};
+
+const ManageClubTableMainFrame: React.FC = () => {
+  // TODO - 실제 API 연결 시 올바른 형식으로 실제 데이터 값 넣어주기
+
+  const [page, setPage] = useState<number>(1);
+  const data = mockData
+    .sort((a, b) => b.submitTime.getTime() - a.submitTime.getTime())
+    .slice((page - 1) * 10, page * 10);
+
+  return (
+    <ManageClubTablePageMainFrameInner>
+      <Typography
+        style={{
+          width: "100%",
+          marginBottom: "8px",
+          textAlign: "right",
+          color: "#555555",
+        }}
+        type="p"
+      >{`총 ${mockData.length}개`}</Typography>
+      <TableFrameInner>
+        <TableRowFrameInner
+          style={{
+            gridTemplateColumns: tempHeaders
+              .map(headerInfo => headerInfo.headerWidth)
+              .join(" "),
+          }}
+        >
+          {tempHeaders.map((headerInfo, index) => (
+            <TableCellInner
+              style={{ gridColumn: `${index + 1} / ${index + 2}` }}
+              key={headerInfo.headerName}
+            >
+              <TableCell type={headerInfo.headerType} width="100%">
+                {headerInfo.headerName}
+              </TableCell>
+            </TableCellInner>
+          ))}
+        </TableRowFrameInner>
+
+        {data.map(rowInfo => (
+          <TableRowFrameInner
+            style={{
+              gridTemplateColumns: tempHeaders
+                .map(headerInfo => headerInfo.headerWidth)
+                .join(" "),
+              borderBottom: "1px #EEEEEE solid",
+            }}
+          >
+            {Object.entries(rowInfo).map(([key, value], index) => (
+              <TableCellInner
+                style={{
+                  gridColumn: `${index + 1} / ${index + 2}`,
+                }}
+                key={key}
+              >
+                <TableCell type="Default" width="100%">
+                  {formattedString(key, value)}
+                </TableCell>
+              </TableCellInner>
+            ))}
+          </TableRowFrameInner>
+        ))}
+      </TableFrameInner>
+      {mockData.length > 1 ? (
+        <NoticePagination
+          totalPage={Math.ceil(mockData.length / 10)}
+          currentPage={page}
+          limit={10}
+          setPage={setPage}
+        />
+      ) : null}
+    </ManageClubTablePageMainFrameInner>
+  );
+};
+
+export default ManageClubTableMainFrame;

--- a/packages/web/src/features/manageClubTable/types/ManageClubTable.ts
+++ b/packages/web/src/features/manageClubTable/types/ManageClubTable.ts
@@ -1,0 +1,72 @@
+export enum ManageClubRentalBusinessStatus {
+  submit = "신청",
+  cancel = "취소",
+  approve = "승인",
+  rent = "대여",
+  return = "반납",
+}
+
+export interface ManageClubRentalBusinessData {
+  status: ManageClubRentalBusinessStatus;
+  submitTime: Date;
+  name: string;
+  phoneNumber: string;
+  rentTime?: Date;
+  returnTime?: Date;
+  rentProducts: string;
+}
+
+export enum ManageClubPrintingBusinessStatus {
+  submit = "신청",
+  cancel = "취소",
+  approve = "승인",
+  print = "출력",
+  receive = "수령",
+}
+
+export interface ManageClubPrintingBusinessData {
+  status: ManageClubPrintingBusinessStatus;
+  submitTime: Date;
+  name: string;
+  phoneNumber: string;
+  receiveTime?: Date;
+  printNumber: string;
+}
+
+export enum ManageClubActivityCertificateStatus {
+  submit = "신청",
+  cancel = "취소",
+  approve = "승인",
+  issue = "발급",
+  reject = "반려",
+}
+
+export interface ManageClubActivityCertificateData {
+  status: ManageClubActivityCertificateStatus;
+  submitTime: Date;
+  name: string;
+  phoneNumber: string;
+  issueNumber?: number;
+  note: string;
+}
+
+export enum ManageClubCommonSpaceStatus {
+  submit = "신청",
+  cancel = "취소",
+  use = "사용",
+}
+
+export interface ManageClubCommonSpaceData {
+  status: ManageClubCommonSpaceStatus;
+  submitTime: Date;
+  name: string;
+  phoneNumber: string;
+  reserveTime: Date;
+  reserveStartEndHour: string;
+  reserveRoom: string;
+}
+
+export const dateAndTimeFormatKeys = ["submitTime", "receiveTime"];
+export const dateFormatKeys = ["rentTime", "returnTime", "reserveTime"];
+export const startEndTimeFormatKeys = ["reserveStartEndHour"];
+export const numberFormatKeys = ["issueNumber"];

--- a/packages/web/src/features/manageClubTable/types/ManageClubTableHeader.ts
+++ b/packages/web/src/features/manageClubTable/types/ManageClubTableHeader.ts
@@ -1,0 +1,13 @@
+export const tempHeaders: {
+  headerName: string;
+  headerWidth: string;
+  headerType: "Header" | "HeaderSort";
+}[] = [
+  { headerName: "상태", headerWidth: "80px", headerType: "Header" },
+  { headerName: "신청 일시", headerWidth: "220px", headerType: "HeaderSort" },
+  { headerName: "신청자", headerWidth: "110px", headerType: "HeaderSort" },
+  { headerName: "연락처", headerWidth: "130px", headerType: "Header" },
+  { headerName: "대여 일자", headerWidth: "180px", headerType: "HeaderSort" },
+  { headerName: "반납 일자", headerWidth: "180px", headerType: "HeaderSort" },
+  { headerName: "대여 물품", headerWidth: "auto", headerType: "Header" },
+];

--- a/packages/web/src/features/manageClubTable/types/mock.ts
+++ b/packages/web/src/features/manageClubTable/types/mock.ts
@@ -1,0 +1,34 @@
+import {
+  ManageClubRentalBusinessData,
+  ManageClubRentalBusinessStatus,
+} from "./ManageClubTable";
+
+export const mockData: ManageClubRentalBusinessData[] = [
+  ...Array(8).fill({
+    status: ManageClubRentalBusinessStatus.rent,
+    submitTime: new Date("2024-03-04 21:00"),
+    name: "일지윤",
+    phoneNumber: "010-1234-5678",
+    rentTime: new Date("2024-03-11 00:00"),
+    returnTime: new Date("2024-03-18 00:00"),
+    rentProducts: "돗자리 3개 외 2항목",
+  }),
+  ...Array(9).fill({
+    status: ManageClubRentalBusinessStatus.rent,
+    submitTime: new Date("2024-03-06 09:00"),
+    name: "이지윤",
+    phoneNumber: "010-1234-5678",
+    rentTime: new Date("2024-03-11 00:00"),
+    returnTime: new Date("2024-03-18 00:00"),
+    rentProducts: "돗자리 3개 외 2항목",
+  }),
+  ...Array(6).fill({
+    status: ManageClubRentalBusinessStatus.rent,
+    submitTime: new Date("2024-03-01 00:00"),
+    name: "삼지윤",
+    phoneNumber: "010-1234-5678",
+    rentTime: new Date("2024-03-11 00:00"),
+    returnTime: new Date("2024-03-18 00:00"),
+    rentProducts: "돗자리 3개 외 2항목",
+  }),
+];


### PR DESCRIPTION
# 요약 \*

Implements the list (table) pages including /manage-club/rental-business, /manage-club/printing-business, /manage-club/activity-certificate, and /manage-club/common-space.

It closes #114

<img width="865" alt="스크린샷 2024-05-10 오전 1 49 04" src="https://github.com/academic-relations/ar-002-clubs/assets/43981717/ea2a1ac1-a8ca-4321-93fe-94b5286ae516">


# 이후 Task \*

- [ ] Build status tags
- [ ] Build sorting feature
- [ ] Make this table available for all 4 pages
- [ ] Move on to #115
- [ ] Link API
