### PR TITLE
add modal and interface for rental business page

### DIFF
--- a/packages/web/src/common/components/Modal/CancellableModalContent.tsx
+++ b/packages/web/src/common/components/Modal/CancellableModalContent.tsx
@@ -6,6 +6,8 @@ import Typography from "../Typography";
 interface CancellableModalContentProps {
   onClose: () => void;
   onConfirm: () => void;
+  closeButtonText?: string;
+  confirmButtonText?: string;
   children: React.ReactNode;
 }
 
@@ -24,6 +26,8 @@ const CancellableModalContent: React.FC<CancellableModalContentProps> = ({
   onClose,
   onConfirm,
   children,
+  closeButtonText = "취소",
+  confirmButtonText = "확인",
 }) => (
   <ModalContentInner>
     <Typography fs={16} lh={28} fw="MEDIUM" style={{ textAlign: "center" }}>
@@ -31,10 +35,9 @@ const CancellableModalContent: React.FC<CancellableModalContentProps> = ({
     </Typography>
     <ButtonWrapper>
       <Button type="outlined" onClick={onClose}>
-        취소
+        {closeButtonText}
       </Button>
-      <Button onClick={onConfirm}>확인</Button>
-      {/* TODO: (필요시) 버튼 텍스트 수정할 수 있도록 */}
+      <Button onClick={onConfirm}>{confirmButtonText}</Button>
     </ButtonWrapper>
   </ModalContentInner>
 );

--- a/packages/web/src/common/components/Modal/CancellableModalContent.tsx
+++ b/packages/web/src/common/components/Modal/CancellableModalContent.tsx
@@ -1,0 +1,42 @@
+import Button from "@sparcs-clubs/web/common/components/Button";
+import React from "react";
+import styled from "styled-components";
+import Typography from "../Typography";
+
+interface CancellableModalContentProps {
+  onClose: () => void;
+  onConfirm: () => void;
+  children: React.ReactNode;
+}
+
+const ModalContentInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const CancellableModalContent: React.FC<CancellableModalContentProps> = ({
+  onClose,
+  onConfirm,
+  children,
+}) => (
+  <ModalContentInner>
+    <Typography fs={16} lh={28} fw="MEDIUM" style={{ textAlign: "center" }}>
+      {children}
+    </Typography>
+    <ButtonWrapper>
+      <Button type="outlined" onClick={onClose}>
+        취소
+      </Button>
+      <Button onClick={onConfirm}>확인</Button>
+      {/* TODO: (필요시) 버튼 텍스트 수정할 수 있도록 */}
+    </ButtonWrapper>
+  </ModalContentInner>
+);
+
+export default CancellableModalContent;

--- a/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
+++ b/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
@@ -1,0 +1,37 @@
+import Button from "@sparcs-clubs/web/common/components/Button";
+import React from "react";
+import styled from "styled-components";
+import Typography from "../Typography";
+
+interface ConfirmModalContentProps {
+  onConfirm: () => void;
+  children: React.ReactNode;
+}
+
+const ModalContentInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const ConfirmModalContent: React.FC<ConfirmModalContentProps> = ({
+  onConfirm,
+  children,
+}) => (
+  <ModalContentInner>
+    <Typography fs={16} lh={28} fw="MEDIUM" style={{ textAlign: "center" }}>
+      {children}
+    </Typography>
+    <ButtonWrapper>
+      <Button onClick={onConfirm}>확인</Button>
+      {/* TODO: (필요시) 버튼 텍스트 수정할 수 있도록 */}
+    </ButtonWrapper>
+  </ModalContentInner>
+);
+
+export default ConfirmModalContent;

--- a/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
+++ b/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
@@ -5,6 +5,7 @@ import Typography from "../Typography";
 
 interface ConfirmModalContentProps {
   onConfirm: () => void;
+  confirmButtonText?: string;
   children: React.ReactNode;
 }
 
@@ -22,14 +23,14 @@ const ButtonWrapper = styled.div`
 const ConfirmModalContent: React.FC<ConfirmModalContentProps> = ({
   onConfirm,
   children,
+  confirmButtonText = "확인",
 }) => (
   <ModalContentInner>
     <Typography fs={16} lh={28} fw="MEDIUM" style={{ textAlign: "center" }}>
       {children}
     </Typography>
     <ButtonWrapper>
-      <Button onClick={onConfirm}>확인</Button>
-      {/* TODO: (필요시) 버튼 텍스트 수정할 수 있도록 */}
+      <Button onClick={onConfirm}>{confirmButtonText}</Button>
     </ButtonWrapper>
   </ModalContentInner>
 );

--- a/packages/web/src/common/components/Typography.tsx
+++ b/packages/web/src/common/components/Typography.tsx
@@ -85,12 +85,6 @@ const P_B = styled(TypographyInner)`
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
 `;
 
-const P_B = styled(TypographyInner)`
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
-`;
-
 /**
  * ## Typography component.
  * @param {Object} props - Props for the Typography component.

--- a/packages/web/src/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar.tsx
+++ b/packages/web/src/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar.tsx
@@ -1,14 +1,17 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import SelectRange from "./_atomic/SelectRange";
 import RangeCalendar from "./_atomic/RangeCalendar";
 
 interface SelectRangeCalendarProps {
-  onDatesChange: (
-    rentalDate: Date | undefined,
-    returnDate: Date | undefined,
-  ) => void;
+  rentalDate: Date | undefined;
+  returnDate: Date | undefined;
+  setRentalDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
+  setReturnDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
   workDates?: Date[];
+  setShowPeriodModal: React.Dispatch<
+    React.SetStateAction<"none" | "reset" | "change">
+  >;
 }
 
 const SelectRangeCalendarWrapper = styled.div`
@@ -22,15 +25,17 @@ const SelectRangeCalendarWrapper = styled.div`
 `;
 
 const SelectRangeCalendar: React.FC<SelectRangeCalendarProps> = ({
-  onDatesChange,
+  rentalDate,
+  returnDate,
+  setRentalDate,
+  setReturnDate,
   workDates = [],
+  setShowPeriodModal,
 }) => {
-  const [rentalDate, setRentalDate] = useState<Date | undefined>();
-  const [returnDate, setReturnDate] = useState<Date | undefined>();
-
   useEffect(() => {
-    onDatesChange(rentalDate, returnDate);
-  }, [rentalDate, returnDate, onDatesChange]);
+    setRentalDate(rentalDate);
+    setReturnDate(returnDate);
+  }, [rentalDate, returnDate, setRentalDate, setReturnDate]);
 
   return (
     <SelectRangeCalendarWrapper>
@@ -40,12 +45,12 @@ const SelectRangeCalendar: React.FC<SelectRangeCalendarProps> = ({
         setRentalDate={setRentalDate}
         setReturnDate={setReturnDate}
         workDates={workDates}
+        setShowPeriodModal={setShowPeriodModal}
       />
       <SelectRange
         rentalDate={rentalDate}
         returnDate={returnDate}
-        setRentalDate={setRentalDate}
-        setReturnDate={setReturnDate}
+        setShowPeriodModal={setShowPeriodModal}
       />
     </SelectRangeCalendarWrapper>
   );

--- a/packages/web/src/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar.tsx
+++ b/packages/web/src/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar.tsx
@@ -12,6 +12,8 @@ interface SelectRangeCalendarProps {
   setShowPeriodModal: React.Dispatch<
     React.SetStateAction<"none" | "reset" | "change">
   >;
+  pendingDate: Date | undefined;
+  setPendingDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
 }
 
 const SelectRangeCalendarWrapper = styled.div`
@@ -31,11 +33,21 @@ const SelectRangeCalendar: React.FC<SelectRangeCalendarProps> = ({
   setReturnDate,
   workDates = [],
   setShowPeriodModal,
+  pendingDate,
+  setPendingDate,
 }) => {
   useEffect(() => {
     setRentalDate(rentalDate);
     setReturnDate(returnDate);
-  }, [rentalDate, returnDate, setRentalDate, setReturnDate]);
+    setPendingDate(pendingDate);
+  }, [
+    rentalDate,
+    returnDate,
+    pendingDate,
+    setRentalDate,
+    setReturnDate,
+    setPendingDate,
+  ]);
 
   return (
     <SelectRangeCalendarWrapper>
@@ -46,6 +58,7 @@ const SelectRangeCalendar: React.FC<SelectRangeCalendarProps> = ({
         setReturnDate={setReturnDate}
         workDates={workDates}
         setShowPeriodModal={setShowPeriodModal}
+        setPendingDate={setPendingDate}
       />
       <SelectRange
         rentalDate={rentalDate}

--- a/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/RangeCalendar.tsx
+++ b/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/RangeCalendar.tsx
@@ -9,6 +9,9 @@ interface RangeCalendarProps {
   setRentalDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
   setReturnDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
   workDates: Date[];
+  setShowPeriodModal: React.Dispatch<
+    React.SetStateAction<"none" | "reset" | "change">
+  >;
 }
 
 const RangeCalendar: React.FC<RangeCalendarProps> = ({
@@ -17,6 +20,7 @@ const RangeCalendar: React.FC<RangeCalendarProps> = ({
   setRentalDate,
   setReturnDate,
   workDates,
+  setShowPeriodModal,
 }) => {
   const [calendarSize, setCalendarSize] = useState<"sm" | "md" | "lg">("lg");
 
@@ -42,16 +46,18 @@ const RangeCalendar: React.FC<RangeCalendarProps> = ({
     return () => window.removeEventListener("resize", updateSize);
   }, [window, setCalendarSize]);
 
+  // TODO: 기간 변경될 경우 modal 띄우기
   const onDateClick = (date: Date) => {
     if (workDates.some(selectedDate => isSameDay(selectedDate, date))) {
       if (rentalDate && !returnDate && isAfter(date, rentalDate)) {
         setReturnDate(date);
-      } else {
-        setRentalDate(date);
-        setReturnDate(undefined);
+      } else if (!rentalDate) setRentalDate(date);
+      else {
+        setShowPeriodModal("change");
       }
     }
   };
+
   return (
     <Calendar
       size={calendarSize}

--- a/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/RangeCalendar.tsx
+++ b/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/RangeCalendar.tsx
@@ -12,6 +12,7 @@ interface RangeCalendarProps {
   setShowPeriodModal: React.Dispatch<
     React.SetStateAction<"none" | "reset" | "change">
   >;
+  setPendingDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
 }
 
 const RangeCalendar: React.FC<RangeCalendarProps> = ({
@@ -21,6 +22,7 @@ const RangeCalendar: React.FC<RangeCalendarProps> = ({
   setReturnDate,
   workDates,
   setShowPeriodModal,
+  setPendingDate,
 }) => {
   const [calendarSize, setCalendarSize] = useState<"sm" | "md" | "lg">("lg");
 
@@ -46,13 +48,13 @@ const RangeCalendar: React.FC<RangeCalendarProps> = ({
     return () => window.removeEventListener("resize", updateSize);
   }, [window, setCalendarSize]);
 
-  // TODO: 기간 변경될 경우 modal 띄우기
   const onDateClick = (date: Date) => {
     if (workDates.some(selectedDate => isSameDay(selectedDate, date))) {
       if (rentalDate && !returnDate && isAfter(date, rentalDate)) {
         setReturnDate(date);
       } else if (!rentalDate) setRentalDate(date);
       else {
+        setPendingDate(date);
         setShowPeriodModal("change");
       }
     }

--- a/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/SelectRange.tsx
+++ b/packages/web/src/features/rental-business/components/SelectRangeCalendar/_atomic/SelectRange.tsx
@@ -6,8 +6,9 @@ import SelectRangeInfo from "./SelectRangeInfo";
 interface SelectRangeProps {
   rentalDate?: Date;
   returnDate?: Date;
-  setRentalDate: (date: Date | undefined) => void;
-  setReturnDate: (date: Date | undefined) => void;
+  setShowPeriodModal: React.Dispatch<
+    React.SetStateAction<"none" | "reset" | "change">
+  >;
 }
 
 const RangeWrapper = styled.div`
@@ -21,14 +22,12 @@ const RangeWrapper = styled.div`
 const SelectRange: React.FC<SelectRangeProps> = ({
   rentalDate = undefined,
   returnDate = undefined,
-  setRentalDate,
-  setReturnDate,
+  setShowPeriodModal,
 }) => {
   const isButtonDisabled = !rentalDate && !returnDate;
 
   const handleReset = () => {
-    setRentalDate(undefined);
-    setReturnDate(undefined);
+    setShowPeriodModal("reset");
   };
 
   return (

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
@@ -83,27 +83,29 @@ const RentalInfoSecondFrame: React.FC<
   const [rentalDate, setRentalDate] = useState<Date | undefined>();
   const [returnDate, setReturnDate] = useState<Date | undefined>();
 
-  // TODO: 대여 기간 초기화 modal SelectRangeCalendar에서 처리
-  const [showPeriodModal, setShowPeriodModal] = useState(false);
+  const [showPeriodModal, setShowPeriodModal] = useState<
+    "none" | "reset" | "change"
+  >("none");
 
-  const onClosePeriod = () => setShowPeriodModal(false);
-
-  const onConfirmPeriod = useCallback(() => {
-    setShowPeriodModal(false);
-    setValue("none");
-    setRental({
-      agreement: rental.agreement,
-      info: rental.info,
-    });
-  }, [setShowPeriodModal, setValue, setRental, rental.agreement, rental.info]);
-
-  const handleDatesChange = (
-    rentalDateFromCal: Date | undefined,
-    returnDateFromCal: Date | undefined,
-  ) => {
-    setRentalDate(rentalDateFromCal);
-    setReturnDate(returnDateFromCal);
-    setValue(!rentalDateFromCal || !returnDateFromCal ? "none" : value);
+  const handleConfirm = () => {
+    if (showPeriodModal === "reset") {
+      setRentalDate(undefined);
+      setReturnDate(undefined);
+      setRental({
+        ...rental,
+        date: { start: undefined, end: undefined },
+      });
+    }
+    // else if (showPeriodModal === "change") {
+    //   setRentalDate(date);
+    //   setReturnDate(undefined);
+    // }
+    setShowPeriodModal("none");
+    // setRental({
+    //   agreement: rental.agreement,
+    //   info: rental.info,
+    //   date: { start: rentalDate, end: returnDate },
+    // });
   };
 
   useEffect(() => {
@@ -114,14 +116,11 @@ const RentalInfoSecondFrame: React.FC<
 
   useEffect(() => {
     if (!rentalDate || !returnDate) {
-      if (rental.date?.start && rental.date?.end) {
-        setShowPeriodModal(true);
-      }
-      // setValue("none");
-      // setRental({
-      //   agreement: rental.agreement,
-      //   info: rental.info,
-      // });
+      setValue("none");
+      setRental({
+        agreement: rental.agreement,
+        info: rental.info,
+      });
     } else {
       setRental({
         ...rental,
@@ -192,8 +191,12 @@ const RentalInfoSecondFrame: React.FC<
       <StyledCard type="outline">
         <Typography type="h3">대여 기간 선택</Typography>
         <SelectRangeCalendar
-          onDatesChange={handleDatesChange}
+          rentalDate={rentalDate}
+          returnDate={returnDate}
+          setRentalDate={setRentalDate}
+          setReturnDate={setReturnDate}
           workDates={mockExistDates}
+          setShowPeriodModal={setShowPeriodModal}
         />
       </StyledCard>
       <ItemButtonList value={value} onChange={itemOnChange} rental={rental} />
@@ -230,11 +233,11 @@ const RentalInfoSecondFrame: React.FC<
           <RentalList rental={rental} />
         </StyledCardInner>
       </StyledCard>
-      {showPeriodModal && (
+      {showPeriodModal !== "none" && (
         <Modal>
           <CancellableModalContent
-            onConfirm={onConfirmPeriod}
-            onClose={onClosePeriod}
+            onConfirm={handleConfirm}
+            onClose={() => setShowPeriodModal("none")}
           >
             대여 기간을 변경하면 입력한 대여 물품 정보가 모두 초기화됩니다.{" "}
             <br />

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -109,12 +109,6 @@ const RentalInfoSecondFrame: React.FC<
   };
 
   useEffect(() => {
-    const enableNext = !(!rental.date?.start || !rental.date?.end);
-    setNextEnabled(enableNext);
-  }, [rental, setNextEnabled]);
-  // TODO: 선택된 물건 없을 때도 안 넘어가게 하기
-
-  useEffect(() => {
     if (!rentalDate || !returnDate) {
       setValue("none");
       setRental({
@@ -150,12 +144,6 @@ const RentalInfoSecondFrame: React.FC<
     (!rental.handCart || Object.values(rental.handCart).every(val => !val)) &&
     !rental.mat &&
     (!rental.tool || Object.values(rental.tool).every(val => !val));
-
-  useEffect(() => {
-    const enableNext =
-      !isRentalListEmpty && !(!rental.date?.start || !rental.date?.end);
-    setNextEnabled(enableNext);
-  }, [rental, setNextEnabled]);
 
   const isCurrentItemEmpty = () => {
     switch (value) {

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -82,6 +82,7 @@ const RentalInfoSecondFrame: React.FC<
 
   const [rentalDate, setRentalDate] = useState<Date | undefined>();
   const [returnDate, setReturnDate] = useState<Date | undefined>();
+  const [pendingDate, setPendingDate] = useState<Date | undefined>();
 
   const [showPeriodModal, setShowPeriodModal] = useState<
     "none" | "reset" | "change"
@@ -95,17 +96,16 @@ const RentalInfoSecondFrame: React.FC<
         ...rental,
         date: { start: undefined, end: undefined },
       });
+    } else if (showPeriodModal === "change") {
+      setRentalDate(pendingDate);
+      setReturnDate(undefined);
+      setPendingDate(undefined);
+      setRental({
+        ...rental,
+        date: { start: rentalDate, end: undefined },
+      });
     }
-    // else if (showPeriodModal === "change") {
-    //   setRentalDate(date);
-    //   setReturnDate(undefined);
-    // }
     setShowPeriodModal("none");
-    // setRental({
-    //   agreement: rental.agreement,
-    //   info: rental.info,
-    //   date: { start: rentalDate, end: returnDate },
-    // });
   };
 
   useEffect(() => {
@@ -135,7 +135,6 @@ const RentalInfoSecondFrame: React.FC<
     rental.agreement,
     rental.info,
   ]);
-  // TODO: 대여 기간 초기화할 때 modal 띄우는거 추가
 
   const itemOnChange = (
     newValue: "easel" | "vacuum" | "handCart" | "mat" | "tool",
@@ -197,6 +196,8 @@ const RentalInfoSecondFrame: React.FC<
           setReturnDate={setReturnDate}
           workDates={mockExistDates}
           setShowPeriodModal={setShowPeriodModal}
+          pendingDate={pendingDate}
+          setPendingDate={setPendingDate}
         />
       </StyledCard>
       <ItemButtonList value={value} onChange={itemOnChange} rental={rental} />

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -176,6 +176,12 @@ const RentalInfoSecondFrame: React.FC<
     }
   };
 
+  useEffect(() => {
+    const enableNext =
+      !isCurrentItemEmpty() && !(!rental.date?.start || !rental.date?.end);
+    setNextEnabled(enableNext);
+  }, [rental, setNextEnabled, isCurrentItemEmpty]);
+
   const handleResetAll = () => {
     setRental({
       agreement: rental.agreement,

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -195,6 +195,7 @@ const RentalInfoSecondFrame: React.FC<
           setRentalDate={setRentalDate}
           setReturnDate={setReturnDate}
           workDates={mockExistDates}
+          // TODO: 상근일자 받아오기
           setShowPeriodModal={setShowPeriodModal}
           pendingDate={pendingDate}
           setPendingDate={setPendingDate}
@@ -240,7 +241,7 @@ const RentalInfoSecondFrame: React.FC<
             onConfirm={handleConfirm}
             onClose={() => setShowPeriodModal("none")}
           >
-            대여 기간을 변경하면 입력한 대여 물품 정보가 모두 초기화됩니다.{" "}
+            대여 기간을 변경하면 입력한 대여 물품 정보가 모두 초기화됩니다.
             <br />
             ㄱㅊ?
           </CancellableModalContent>

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -151,6 +151,12 @@ const RentalInfoSecondFrame: React.FC<
     !rental.mat &&
     (!rental.tool || Object.values(rental.tool).every(val => !val));
 
+  useEffect(() => {
+    const enableNext =
+      !isRentalListEmpty && !(!rental.date?.start || !rental.date?.end);
+    setNextEnabled(enableNext);
+  }, [rental, setNextEnabled]);
+
   const isCurrentItemEmpty = () => {
     switch (value) {
       case "easel":

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
@@ -12,6 +12,8 @@ import Mat from "@sparcs-clubs/web/features/rental-business//components/Rentals/
 import Tool from "@sparcs-clubs/web/features/rental-business//components/Rentals/Tool";
 import RentalList from "@sparcs-clubs/web/features/rental-business/components/RentalList";
 import TextButton from "@sparcs-clubs/web/common/components/TextButton";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import { mockExistDates } from "./_atomic/mockExistDate";
 
@@ -81,6 +83,20 @@ const RentalInfoSecondFrame: React.FC<
   const [rentalDate, setRentalDate] = useState<Date | undefined>();
   const [returnDate, setReturnDate] = useState<Date | undefined>();
 
+  // TODO: 대여 기간 초기화 modal SelectRangeCalendar에서 처리
+  const [showPeriodModal, setShowPeriodModal] = useState(false);
+
+  const onClosePeriod = () => setShowPeriodModal(false);
+
+  const onConfirmPeriod = useCallback(() => {
+    setShowPeriodModal(false);
+    setValue("none");
+    setRental({
+      agreement: rental.agreement,
+      info: rental.info,
+    });
+  }, [setShowPeriodModal, setValue, setRental, rental.agreement, rental.info]);
+
   const handleDatesChange = (
     rentalDateFromCal: Date | undefined,
     returnDateFromCal: Date | undefined,
@@ -98,11 +114,14 @@ const RentalInfoSecondFrame: React.FC<
 
   useEffect(() => {
     if (!rentalDate || !returnDate) {
-      setValue("none");
-      setRental({
-        agreement: rental.agreement,
-        info: rental.info,
-      });
+      if (rental.date?.start && rental.date?.end) {
+        setShowPeriodModal(true);
+      }
+      // setValue("none");
+      // setRental({
+      //   agreement: rental.agreement,
+      //   info: rental.info,
+      // });
     } else {
       setRental({
         ...rental,
@@ -211,6 +230,18 @@ const RentalInfoSecondFrame: React.FC<
           <RentalList rental={rental} />
         </StyledCardInner>
       </StyledCard>
+      {showPeriodModal && (
+        <Modal>
+          <CancellableModalContent
+            onConfirm={onConfirmPeriod}
+            onClose={onClosePeriod}
+          >
+            대여 기간을 변경하면 입력한 대여 물품 정보가 모두 초기화됩니다.{" "}
+            <br />
+            ㄱㅊ?
+          </CancellableModalContent>
+        </Modal>
+      )}
     </>
   );
 };

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
@@ -5,6 +5,7 @@ import StepProcess from "@sparcs-clubs/web/common/components/StepProcess/StepPro
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
+import { useRouter } from "next/navigation";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import RentalInfoFirstFrame from "./RentalInfoFirstFrame";
 import RentalInfoSecondFrame from "./RentalInfoSecondFrame";
@@ -87,10 +88,11 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
       setShowAssignModal(true);
     }
   }, [nextEnabled, step, setStep]);
+  const router = useRouter();
 
   const onConfirm = () => {
     setShowAssignModal(false);
-    window.location.href = "/my";
+    router.push("/my");
   };
 
   return (
@@ -106,7 +108,7 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
         </Button>
         {/* TODO: 백이랑 연결 */}
       </StyledBottom>
-      {showReturnModal && (
+      {showReturnModal ? (
         <Modal>
           <CancellableModalContent
             onConfirm={onConfirmReturn}
@@ -117,8 +119,8 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
             현재 단계에서 입력한 내용은 저장되지 않고 초기화됩니다.
           </CancellableModalContent>
         </Modal>
-      )}
-      {showAssignModal && (
+      ) : null}
+      {showAssignModal ? (
         <Modal>
           <ConfirmModalContent onConfirm={onConfirm}>
             신청이 완료되었습니다.
@@ -126,7 +128,7 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
             확인을 누르면 신청 내역 화면으로 이동합니다.
           </ConfirmModalContent>
         </Modal>
-      )}
+      ) : null}
     </RentalFrame>
   );
 };

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
@@ -61,7 +61,6 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
 
   const onConfirmReturn = useCallback(() => {
     setShowReturnModal(false);
-    setRental({ ...rental, agreement: false });
     setStep(step - 1);
   }, [step, setStep, rental, setRental]);
 
@@ -69,6 +68,9 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
 
   const onPrev = useCallback(() => {
     if (step === 0) {
+      setRental({ ...rental, agreement: false });
+    }
+    if (step === 1) {
       setShowReturnModal(true);
       return;
     }

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useState } from "react";
 import styled from "styled-components";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import StepProcess from "@sparcs-clubs/web/common/components/StepProcess/StepProcess";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import RentalInfoFirstFrame from "./RentalInfoFirstFrame";
 import RentalInfoSecondFrame from "./RentalInfoSecondFrame";
@@ -55,9 +57,19 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
   const [nextEnabled, setNextEnabled] = useState(true);
   const CurrentFrame = frames[step];
 
+  const [showReturnModal, setShowReturnModal] = useState(false);
+
+  const onConfirmReturn = useCallback(() => {
+    setShowReturnModal(false);
+    setRental({ ...rental, agreement: false });
+    setStep(step - 1);
+  }, [step, setStep, rental, setRental]);
+
+  const onCloseReturn = () => setShowReturnModal(false);
+
   const onPrev = useCallback(() => {
     if (step === 0) {
-      setRental({ ...rental, agreement: false });
+      setShowReturnModal(true);
       return;
     }
     setStep(step - 1);
@@ -77,13 +89,24 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
       </RentalNoticeFrameInner>
       <StyledBottom>
         <Button onClick={onPrev}>이전</Button>
-        {/* TODO: 2에서 1로 돌아가려고 하면 초기화 경고 modal */}
         <Button onClick={onNext} type={nextEnabled ? "default" : "disabled"}>
           {step === frames.length - 1 ? "신청" : "다음"}
         </Button>
         {/* TODO: 신청 완료 modal */}
         {/* TODO: 백이랑 연결 */}
       </StyledBottom>
+      {showReturnModal && (
+        <Modal>
+          <CancellableModalContent
+            onConfirm={onConfirmReturn}
+            onClose={onCloseReturn}
+          >
+            이전 단계로 이동할 경우
+            <br />
+            현재 단계에서 입력한 내용은 저장되지 않고 초기화됩니다.
+          </CancellableModalContent>
+        </Modal>
+      )}
     </RentalFrame>
   );
 };

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/index.tsx
@@ -4,6 +4,7 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import StepProcess from "@sparcs-clubs/web/common/components/StepProcess/StepProcess";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import RentalInfoFirstFrame from "./RentalInfoFirstFrame";
 import RentalInfoSecondFrame from "./RentalInfoSecondFrame";
@@ -58,6 +59,7 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
   const CurrentFrame = frames[step];
 
   const [showReturnModal, setShowReturnModal] = useState(false);
+  const [showAssignModal, setShowAssignModal] = useState(false);
 
   const onConfirmReturn = useCallback(() => {
     setShowReturnModal(false);
@@ -81,7 +83,15 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
     if (nextEnabled && step < frames.length - 1) {
       setStep(step + 1);
     }
+    if (step === frames.length - 1) {
+      setShowAssignModal(true);
+    }
   }, [nextEnabled, step, setStep]);
+
+  const onConfirm = () => {
+    setShowAssignModal(false);
+    window.location.href = "/my";
+  };
 
   return (
     <RentalFrame>
@@ -94,7 +104,6 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
         <Button onClick={onNext} type={nextEnabled ? "default" : "disabled"}>
           {step === frames.length - 1 ? "신청" : "다음"}
         </Button>
-        {/* TODO: 신청 완료 modal */}
         {/* TODO: 백이랑 연결 */}
       </StyledBottom>
       {showReturnModal && (
@@ -107,6 +116,15 @@ const RentalInfoFrame: React.FC<RentalFrameProps> = ({ rental, setRental }) => {
             <br />
             현재 단계에서 입력한 내용은 저장되지 않고 초기화됩니다.
           </CancellableModalContent>
+        </Modal>
+      )}
+      {showAssignModal && (
+        <Modal>
+          <ConfirmModalContent onConfirm={onConfirm}>
+            신청이 완료되었습니다.
+            <br />
+            확인을 누르면 신청 내역 화면으로 이동합니다.
+          </ConfirmModalContent>
         </Modal>
       )}
     </RentalFrame>

--- a/packages/web/src/features/rental-business/service/_mock/mockAvailableRental.ts
+++ b/packages/web/src/features/rental-business/service/_mock/mockAvailableRental.ts
@@ -1,0 +1,22 @@
+import type { ApiRnt001ResponseOK } from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt001";
+
+const mockupAvailableRental: ApiRnt001ResponseOK = {
+  objects: [
+    { id: 1, name: "Easel", maximum: 5 },
+    { id: 2, name: "Vacuum Corded", maximum: 1 },
+    { id: 3, name: "Vacuum Cordless", maximum: 1 },
+    { id: 4, name: "Hand Cart Rolltainer", maximum: 10 },
+    { id: 5, name: "Hand Cart Large", maximum: 8 },
+    { id: 6, name: "Hand Cart Medium", maximum: 15 },
+    { id: 7, name: "Hand Cart Small", maximum: 20 },
+    { id: 8, name: "Mat", maximum: 25 },
+    { id: 9, name: "Power Drill", maximum: 7 },
+    { id: 10, name: "Driver", maximum: 10 },
+    { id: 11, name: "Super Glue", maximum: 50 },
+    { id: 12, name: "Nipper", maximum: 12 },
+    { id: 13, name: "Plier", maximum: 12 },
+    { id: 14, name: "Long Nose Plier", maximum: 12 },
+  ],
+};
+
+export default mockupAvailableRental;

--- a/packages/web/src/features/rental-business/service/getAvailableRentals.ts
+++ b/packages/web/src/features/rental-business/service/getAvailableRentals.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import apiRnt001 from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt001";
+import type {
+  ApiRnt001RequestQuery,
+  ApiRnt001ResponseOK,
+} from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt001";
+
+import {
+  axiosClient,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+import mockupAvailableRental from "@sparcs-clubs/web/features/rental-business/service/_mock/mockAvailableRental";
+
+export const useGetAvailableRentals = (startDate: Date, endDate: Date) => {
+  const requestQuery: ApiRnt001RequestQuery = { startDate, endDate };
+
+  return useQuery<ApiRnt001ResponseOK, Error>({
+    queryKey: [apiRnt001.url(), requestQuery],
+    queryFn: async (): Promise<ApiRnt001ResponseOK> => {
+      const { data, status } = await axiosClient.get(apiRnt001.url(), {
+        params: requestQuery,
+      });
+
+      switch (status) {
+        case 200:
+          return apiRnt001.responseBodyMap[200].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+};
+
+defineAxiosMock(mock => {
+  mock.onGet(apiRnt001.url()).reply(() => [200, mockupAvailableRental]);
+});


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #52 

## 공용 컴포넌트 사용법

CancellableModalContent: modal에 확인/취소 등 두 개의 버튼 있을 때

```
        <Modal>
          <CancellableModalContent
            onConfirm={handleConfirm}
            onClose={() => setShowPeriodModal("none")}
            closeButtonText = "취소"
            confirmButtonText = "확인"
          >
            대여 기간을 변경하면 입력한 대여 물품 정보가 모두 초기화됩니다.
            <br />
            ㄱㅊ?
          </CancellableModalContent>
        </Modal>
```
ConfirmModalContent: 확인만 있는 modal
```
        <Modal>
          <ConfirmModalContent onConfirm={onConfirm} confirmButtonText = "확인">
            신청이 완료되었습니다.
            <br />
            확인을 누르면 신청 내역 화면으로 이동합니다.
          </ConfirmModalContent>
        </Modal>
```
# 스크린샷
<img width="576" alt="스크린샷 2024-05-11 오후 8 37 21" src="https://github.com/academic-relations/ar-002-clubs/assets/144689054/984afed5-d5c4-4e33-ba74-8cadca6ba216">
<img width="628" alt="스크린샷 2024-05-12 오전 2 45 53" src="https://github.com/academic-relations/ar-002-clubs/assets/144689054/b17eca56-89cb-41be-a23b-99422da0f652">

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="629" alt="스크린샷 2024-05-11 오후 9 20 34" src="https://github.com/academic-relations/ar-002-clubs/assets/144689054/3df51606-b6bb-484f-9660-5ca75f867a3c">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- api 마저 연결 (usr001, rnt001, rnt002) #144 