### PR TITLE
StyledCard Refactoring

### DIFF
--- a/packages/web/src/common/components/Card.tsx
+++ b/packages/web/src/common/components/Card.tsx
@@ -3,17 +3,29 @@
 import React from "react";
 import styled from "styled-components";
 
-const Card: React.FC<React.PropsWithChildren> = styled.div<{
+interface CardProps {
   outline?: boolean;
+  padding?: string;
+  gap?: number;
+}
+
+const CardInner = styled.div<{
+  outline?: boolean;
+  padding?: string;
+  gap?: number;
 }>`
   display: flex;
   flex-direction: column;
   position: relative;
-  padding: 16px 20px;
+  align-self: stretch;
+  padding: ${({ padding }) => padding ?? `32px`};
+  gap: ${({ gap }) => (gap ? `${gap}px` : "inherit")};
+
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
   font-size: 16px;
   line-height: 20px;
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.REGULAR};
+
   color: ${({ theme }) => theme.colors.BLACK};
   background-color: ${({ theme }) => theme.colors.WHITE};
   border-radius: ${({ theme }) => theme.round.md};
@@ -22,5 +34,10 @@ const Card: React.FC<React.PropsWithChildren> = styled.div<{
   border: ${({ theme, outline }) =>
     outline ? `1px solid ${theme.colors.GRAY[200]}` : "inherit"};
 `;
+
+const Card: React.FC<React.PropsWithChildren<CardProps>> = ({
+  children = <div />,
+  ...props
+}) => <CardInner {...props}>{children}</CardInner>;
 
 export default Card;

--- a/packages/web/src/common/components/Card.tsx
+++ b/packages/web/src/common/components/Card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import styled from "styled-components";
 
 interface CardProps {
@@ -9,7 +8,7 @@ interface CardProps {
   gap?: number;
 }
 
-const CardInner = styled.div<CardProps>`
+const Card = styled.div<CardProps>`
   display: flex;
   flex-direction: column;
   position: relative;
@@ -30,10 +29,5 @@ const CardInner = styled.div<CardProps>`
   border: ${({ theme, outline }) =>
     outline ? `1px solid ${theme.colors.GRAY[200]}` : "inherit"};
 `;
-
-const Card: React.FC<React.PropsWithChildren<CardProps>> = ({
-  children = <div />,
-  ...props
-}) => <CardInner {...props}>{children}</CardInner>;
 
 export default Card;

--- a/packages/web/src/common/components/Card.tsx
+++ b/packages/web/src/common/components/Card.tsx
@@ -9,11 +9,7 @@ interface CardProps {
   gap?: number;
 }
 
-const CardInner = styled.div<{
-  outline?: boolean;
-  padding?: string;
-  gap?: number;
-}>`
+const CardInner = styled.div<CardProps>`
   display: flex;
   flex-direction: column;
   position: relative;

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoFirstFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoFirstFrame.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import React, { useEffect } from "react";
 
 import ItemNumberInput from "@sparcs-clubs/web/common/components/Forms/ItemNumberInput";
 
@@ -11,12 +10,6 @@ import Select from "@sparcs-clubs/web/common/components/Forms/Select";
 import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
 
 import { ActivityCertificateFrameProps } from "../ActivityCertificateNoticeFrame";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 40px;
-  align-self: stretch;
-`;
 
 const ActivityCertificateInfoFirstFrame: React.FC<
   ActivityCertificateFrameProps
@@ -65,7 +58,7 @@ const ActivityCertificateInfoFirstFrame: React.FC<
   }, [firstErrorStatus]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={40}>
       <Select
         label="동아리 이름"
         items={[
@@ -144,7 +137,7 @@ const ActivityCertificateInfoFirstFrame: React.FC<
           });
         }}
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoSecondFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoSecondFrame.tsx
@@ -1,21 +1,15 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import Info from "@sparcs-clubs/web/common/components/Info";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 
-import Icon from "@sparcs-clubs/web/common/components/Icon";
-import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
 import DateRangeInput from "@sparcs-clubs/web/common/components/Forms/DateRangeInput";
 import IconButton from "@sparcs-clubs/web/common/components/Forms/IconButton";
+import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import Icon from "@sparcs-clubs/web/common/components/Icon";
 import { ActivityCertificateFrameProps } from "../ActivityCertificateNoticeFrame";
 // eslint-disable-next-line no-restricted-imports
 import { ActivityDescription } from "../../types/activityCertificate";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
 
 const ActivityCertificateSecondFrameInner = styled.div`
   display: flex;
@@ -273,7 +267,7 @@ const ActivityCertificateInfoSecondFrame: React.FC<
   return (
     <ActivityCertificateSecondFrameInner>
       <Info text="활동 내역 최대 5개까지 입력 가능, 날짜 포함 => 워딩은 병찬이나 동연에서 고쳐주겟징~~" />
-      <StyledCard outline>
+      <Card outline gap={20}>
         {activityCertificate.detail.map(activityDescription => (
           <ActivityCertificateRow
             key={activityDescription.key}
@@ -362,7 +356,7 @@ const ActivityCertificateInfoSecondFrame: React.FC<
           buttonText="활동 내역 추가"
           iconType="add"
         />
-      </StyledCard>
+      </Card>
     </ActivityCertificateSecondFrameInner>
   );
 };

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoThirdFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoThirdFrame.tsx
@@ -1,20 +1,14 @@
+import Card from "@sparcs-clubs/web/common/components/Card";
+import Info from "@sparcs-clubs/web/common/components/Info";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React from "react";
 import styled from "styled-components";
-import Card from "@sparcs-clubs/web/common/components/Card";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
-import Info from "@sparcs-clubs/web/common/components/Info";
 import { ActivityCertificateFrameProps } from "../ActivityCertificateNoticeFrame";
 
 const ActivityCertificateThirdFrameInner = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 20px;
-  align-self: stretch;
-`;
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
   gap: 20px;
   align-self: stretch;
 `;
@@ -52,7 +46,7 @@ const ActivityCertificateInfoThirdFrame: React.FC<
   ActivityCertificateFrameProps
 > = ({ activityCertificate }) => (
   <ActivityCertificateThirdFrameInner>
-    <StyledCard outline>
+    <Card outline gap={20}>
       <BasicInfoSummaryFrameInner>
         <Typography
           type="p"
@@ -135,7 +129,7 @@ const ActivityCertificateInfoThirdFrame: React.FC<
           ))}
         </ActivityDescriptionSummaryFrameInner>
       </BasicInfoSummaryFrameInner>
-    </StyledCard>
+    </Card>
     <Info text="활동확인서 발급이 완료되면 이메일 또는 문자를 통해 (방법은 동연에서 정해주세요) 연락이 갈 것이라는 안내 문구" />
   </ActivityCertificateThirdFrameInner>
 );

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateNoticeFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateNoticeFrame.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
-import Button from "@sparcs-clubs/web/common/components/Button";
 import {
   ActivityCertificateInterface,
   ActivityCertificateProgress,
@@ -34,12 +34,6 @@ const ActivityCertificateNoticeFrameInner = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
-  align-self: stretch;
-`;
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 16px;
   align-self: stretch;
 `;
 
@@ -77,14 +71,14 @@ const ActivityCertificateNoticeFrame: React.FC<
 
   return (
     <ActivityCertificateNoticeFrameInner>
-      <StyledCard outline>
+      <Card outline gap={16}>
         <Typography type="h3">안내사항</Typography>
         <StyledTypography type="p">
           대충 활동확인서 발급에 대한 안내사항
           <br />
           기타 등등 안내 내용 -{">"} 이건 동연 측에서 준비해주겠죠?
         </StyledTypography>
-      </StyledCard>
+      </Card>
       <StyledBottom>
         <StyledCheckboxOuter>
           <Checkbox

--- a/packages/web/src/features/clubDetails/components/ClubDetailCard.tsx
+++ b/packages/web/src/features/clubDetails/components/ClubDetailCard.tsx
@@ -3,16 +3,12 @@
 import React from "react";
 import styled from "styled-components";
 
-import Card from "@sparcs-clubs/web/common/components/Card";
 import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
+import Card from "@sparcs-clubs/web/common/components/Card";
 
 interface ClubDetailCardProps {
   club: ApiClb002ResponseOK;
 }
-
-const ClubDetailCardInner = styled(Card)`
-  gap: 10px;
-`;
 
 const ClubDetailText = styled.div`
   width: 100%;
@@ -22,9 +18,9 @@ const ClubDetailText = styled.div`
 `;
 
 const ClubDetailCard: React.FC<ClubDetailCardProps> = ({ club }) => (
-  <ClubDetailCardInner>
+  <Card gap={10} padding="16px 20px">
     <ClubDetailText>{club.description}</ClubDetailText>
-  </ClubDetailCardInner>
+  </Card>
 );
 
 export default ClubDetailCard;

--- a/packages/web/src/features/clubDetails/components/ClubInfoCard.tsx
+++ b/packages/web/src/features/clubDetails/components/ClubInfoCard.tsx
@@ -9,18 +9,14 @@ import {
   getTagContentFromClubType,
 } from "@sparcs-clubs/web/types/clubdetail.types";
 
+import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
 import ClubInfoItem from "./ClubInfoItem";
 
 interface ClubInfoCardProps {
   club: ApiClb002ResponseOK;
 }
-
-const ClubInfoCardInner = styled(Card)`
-  gap: 16px;
-`;
 
 const ClubInfoRow = styled.div`
   display: flex;
@@ -32,7 +28,7 @@ const ClubInfoRow = styled.div`
 `;
 
 const ClubInfoCard: React.FC<ClubInfoCardProps> = ({ club }) => (
-  <ClubInfoCardInner>
+  <Card gap={16} padding="16px 20px">
     <ClubInfoRow>
       <ClubInfoItem
         title="동아리 지위"
@@ -56,7 +52,7 @@ const ClubInfoCard: React.FC<ClubInfoCardProps> = ({ club }) => (
       <ClubInfoItem title="설립 연도" content={`${club.foundingYear}년`} />
     </ClubInfoRow>
     <ClubInfoItem title="동아리방" content={club.room} />
-  </ClubInfoCardInner>
+  </Card>
 );
 
 export default ClubInfoCard;

--- a/packages/web/src/features/clubDetails/components/PersonInfoCard.tsx
+++ b/packages/web/src/features/clubDetails/components/PersonInfoCard.tsx
@@ -1,29 +1,24 @@
 "use client";
 
 import React from "react";
-import styled from "styled-components";
 
-import Card from "@sparcs-clubs/web/common/components/Card";
 import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
+import Card from "@sparcs-clubs/web/common/components/Card";
 import PersonInfoItem from "./PersonInfoItem";
 
 interface PersonInfoCardProps {
   club: ApiClb002ResponseOK;
 }
 
-const PersonInfoCardInner = styled(Card)`
-  gap: 16px;
-`;
-
 const PersonInfoCard: React.FC<PersonInfoCardProps> = ({ club }) => (
-  <PersonInfoCardInner>
+  <Card gap={16} padding="16px 20px">
     <PersonInfoItem title="총원" content={`${club.totalMemberCnt}명`} />
     <PersonInfoItem title="대표자" content={club.representative} />
     <PersonInfoItem
       title="지도교수"
       content={club.advisor ? club.advisor : "-"}
     />
-  </PersonInfoCardInner>
+  </Card>
 );
 
 export default PersonInfoCard;

--- a/packages/web/src/features/clubs/components/ClubCard.tsx
+++ b/packages/web/src/features/clubs/components/ClubCard.tsx
@@ -18,10 +18,6 @@ interface ClubCardProps {
   club: ApiClb001ResponseOK["divisions"][number]["clubs"][number];
 }
 
-const ClubCardInner = styled(Card)`
-  gap: 16px;
-`;
-
 const ClubCardRow = styled.div`
   width: 100%;
   white-space: nowrap;
@@ -57,7 +53,7 @@ const ClubMemberCount = styled.div`
 `;
 
 const ClubCard: React.FC<ClubCardProps> = ({ club }) => (
-  <ClubCardInner>
+  <Card gap={16} padding="16px 20px">
     <ClubCardNameRow>
       <ClubName>{club.name}</ClubName>
       <ClubMemberCount>
@@ -78,7 +74,7 @@ const ClubCard: React.FC<ClubCardProps> = ({ club }) => (
         {getClubType(club)}
       </Tag>
     </ClubCardRow>
-  </ClubCardInner>
+  </Card>
 );
 
 export default ClubCard;

--- a/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoFirstFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoFirstFrame.tsx
@@ -1,18 +1,11 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
 import Select, {
   SelectItem,
 } from "@sparcs-clubs/web/common/components/Forms/Select";
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
-import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
+import React, { useEffect, useState } from "react";
 import type { CommonSpaceFrameProps } from "../CommonSpaceNoticeFrame";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 40px;
-  align-self: stretch;
-`;
 
 const CommonSpaceInfoFirstFrame: React.FC<
   CommonSpaceFrameProps & { setNextEnabled: (enabled: boolean) => void }
@@ -52,7 +45,7 @@ const CommonSpaceInfoFirstFrame: React.FC<
   }, [selectedValue, phone, setCommonSpace]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={40}>
       <Select
         items={mockClubList}
         selectedValue={selectedValue}
@@ -68,7 +61,7 @@ const CommonSpaceInfoFirstFrame: React.FC<
         placeholder={mockPhone}
         setErrorStatus={setHasPhoneError}
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
@@ -29,14 +29,9 @@ const StyledCardOuter = styled.div`
   align-self: stretch;
 `;
 
-const StyledInfoCard = styled(Card)<{ outline: boolean }>`
-  display: flex;
-  padding: 32px;
-  flex-direction: column;
+const StyledInfoCard = styled(Card).attrs({ outline: true, gap: 20 })`
   align-items: flex-start;
   margin-top: 64px;
-  gap: 20px;
-  align-self: stretch;
 `;
 
 const CommonSpaceInfoSecondFrame: React.FC<
@@ -101,7 +96,7 @@ const CommonSpaceInfoSecondFrame: React.FC<
             />
             <StyledCardOuter>
               {dateTimeRange && (
-                <StyledInfoCard outline>
+                <StyledInfoCard>
                   <Typography type="p">선택 시간</Typography>
                   <Typography type="p">
                     {format(dateTimeRange[0], "M/d(E) ", { locale: ko })}

--- a/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
@@ -12,14 +12,6 @@ import { ko } from "date-fns/locale";
 import type { CommonSpaceFrameProps } from "../CommonSpaceNoticeFrame";
 import { mockCommonSpaceList } from "./mockCommonSpaceList";
 
-const StyledCard = styled(Card).attrs({
-  outline: true,
-  padding: "32px",
-  gap: 20,
-})`
-  flex-direction: row;
-`;
-
 const StyledCardOuter = styled.div`
   display: flex;
   flex-direction: column;
@@ -27,11 +19,6 @@ const StyledCardOuter = styled.div`
   gap: 20px;
   flex: 1 0 0;
   align-self: stretch;
-`;
-
-const StyledInfoCard = styled(Card).attrs({ outline: true, gap: 20 })`
-  align-items: flex-start;
-  margin-top: 64px;
 `;
 
 const CommonSpaceInfoSecondFrame: React.FC<
@@ -89,14 +76,14 @@ const CommonSpaceInfoSecondFrame: React.FC<
           <Info
             text={`${commonSpace.space}는 하루에 최대 4시간, 일주일에 최대 10시간 사용할 수 있습니다.`}
           />
-          <StyledCard>
+          <Card outline gap={20} style={{ flexDirection: "row" }}>
             <Timetable
               data={Array(7 * 48).fill(false)}
               setDateTimeRange={setDateTimeRange}
             />
             <StyledCardOuter>
               {dateTimeRange && (
-                <StyledInfoCard>
+                <Card outline gap={20} style={{ marginTop: 64 }}>
                   <Typography type="p">선택 시간</Typography>
                   <Typography type="p">
                     {format(dateTimeRange[0], "M/d(E) ", { locale: ko })}
@@ -105,10 +92,10 @@ const CommonSpaceInfoSecondFrame: React.FC<
                     {`${diffHours}시간`}
                     {diffMinutes! % 60 ? ` ${diffMinutes! % 60}분` : ""})
                   </Typography>
-                </StyledInfoCard>
+                </Card>
               )}
             </StyledCardOuter>
-          </StyledCard>
+          </Card>
         </>
       )}
     </>

--- a/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoSecondFrame.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import Select from "@sparcs-clubs/web/common/components/Forms/Select";
 import Info from "@sparcs-clubs/web/common/components/Info";
 import Timetable from "@sparcs-clubs/web/common/components/Timetable";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import Select from "@sparcs-clubs/web/common/components/Forms/Select";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 
 import { differenceInHours, differenceInMinutes, format } from "date-fns";
 import { ko } from "date-fns/locale";
@@ -12,11 +12,11 @@ import { ko } from "date-fns/locale";
 import type { CommonSpaceFrameProps } from "../CommonSpaceNoticeFrame";
 import { mockCommonSpaceList } from "./mockCommonSpaceList";
 
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-  display: flex;
+const StyledCard = styled(Card).attrs({
+  outline: true,
+  padding: "32px",
+  gap: 20,
+})`
   flex-direction: row;
 `;
 
@@ -94,7 +94,7 @@ const CommonSpaceInfoSecondFrame: React.FC<
           <Info
             text={`${commonSpace.space}는 하루에 최대 4시간, 일주일에 최대 10시간 사용할 수 있습니다.`}
           />
-          <StyledCard outline>
+          <StyledCard>
             <Timetable
               data={Array(7 * 48).fill(false)}
               setDateTimeRange={setDateTimeRange}

--- a/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoThirdFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceInfoFrame/CommonSpaceInfoThirdFrame.tsx
@@ -1,18 +1,12 @@
+import Card from "@sparcs-clubs/web/common/components/Card";
+import Info from "@sparcs-clubs/web/common/components/Info";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React from "react";
 import styled from "styled-components";
-import Card from "@sparcs-clubs/web/common/components/Card";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
-import Info from "@sparcs-clubs/web/common/components/Info";
 
 import { differenceInHours, differenceInMinutes, format } from "date-fns";
 import { ko } from "date-fns/locale";
 import type { CommonSpaceFrameProps } from "../CommonSpaceNoticeFrame";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
 
 const StyledTypography = styled(Typography)`
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
@@ -51,7 +45,7 @@ const CommonSpaceInfoThirdFrame: React.FC<CommonSpaceFrameProps> = ({
 
   return (
     <>
-      <StyledCard outline>
+      <Card outline gap={20}>
         <CardInner>
           <StyledTypography type="p">신청자 정보</StyledTypography>
           <StyledList>
@@ -69,7 +63,7 @@ const CommonSpaceInfoThirdFrame: React.FC<CommonSpaceFrameProps> = ({
             {diffMinutes! % 60 ? ` ${diffMinutes! % 60}분` : ""})
           </Typography>
         </ReservationInfo>
-      </StyledCard>
+      </Card>
       <Info text="먼가 넣을 것이 없을까나" />
     </>
   );

--- a/packages/web/src/features/common-space/frames/CommonSpaceNoticeFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceNoticeFrame.tsx
@@ -1,9 +1,9 @@
+import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
-import Button from "@sparcs-clubs/web/common/components/Button";
 import { CommonSpaceInterface } from "../types/commonSpace";
 
 export interface CommonSpaceFrameProps {
@@ -16,12 +16,6 @@ const CommonSpaceNoticeFrameInner = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
-  align-self: stretch;
-`;
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 16px;
   align-self: stretch;
 `;
 
@@ -57,14 +51,14 @@ const CommonSpaceNoticeFrame: React.FC<CommonSpaceFrameProps> = ({
 
   return (
     <CommonSpaceNoticeFrameInner>
-      <StyledCard outline>
+      <Card outline gap={16}>
         <Typography type="h3">안내사항</Typography>
         <StyledTypography type="p">
           대충 공용공간 비정기사용에 대한 안내사항
           <br />
           기타 등등 안내 내용 -{">"} 이건 동연 측에서 준비해주겠죠?
         </StyledTypography>
-      </StyledCard>
+      </Card>
       <StyledBottom>
         <StyledCheckboxOuter>
           <Checkbox

--- a/packages/web/src/features/landing/components/ServiceCard.tsx
+++ b/packages/web/src/features/landing/components/ServiceCard.tsx
@@ -11,12 +11,9 @@ interface ServiceCardProps {
   serviceLink: string;
 }
 
-const ServiceCardInner = styled(Card)`
-  gap: 16px;
-  display: flex;
+const ServiceCardInner = styled(Card).attrs({ padding: "12px 20px", gap: 16 })`
   flex-direction: row;
   flex: 1;
-  padding: 12px 20px;
   align-items: center;
 `;
 

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormFirst.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormFirst.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import React, { useEffect, useState } from "react";
 
+import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
 import Select from "@sparcs-clubs/web/common/components/Forms/Select";
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
-import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
 
 import type { SelectItem } from "@sparcs-clubs/web/common/components/Forms/Select";
 
@@ -19,12 +18,6 @@ type PrintingBusinessFormFirstProps = Pick<
   | "requestForm"
   | "setRequestForm"
 > & { setFormError: React.Dispatch<React.SetStateAction<boolean>> };
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
 
 const PrintingBusinessFormFirst: React.FC<PrintingBusinessFormFirstProps> = ({
   username,
@@ -64,7 +57,7 @@ const PrintingBusinessFormFirst: React.FC<PrintingBusinessFormFirstProps> = ({
   }, [clubIdSelectionError, usernameError, phoneNumberError]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={20}>
       <Select
         items={clubSelection}
         label="동아리 이름"
@@ -86,7 +79,7 @@ const PrintingBusinessFormFirst: React.FC<PrintingBusinessFormFirstProps> = ({
         onChange={setPhoneNumber}
         setErrorStatus={setPhoneNumberError}
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormSecond.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormSecond.tsx
@@ -26,12 +26,6 @@ const PrintingBusinessFormSecondInner = styled.div`
   gap: 20px;
 `;
 
-const StyledCard = styled(Card).attrs({
-  outline: true,
-  padding: "32px",
-  gap: 20,
-})``;
-
 const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
   requestForm,
   setRequestForm,
@@ -84,7 +78,7 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
     <PrintingBusinessFormSecondInner>
       {/* todo!: 이후 동아리의 홍보물 인쇄가능 매수 확인 API 추가후 수정이 필요합니다. */}
       <Info text={leftoverPrintsInfoText("술박스", 45, 45)} />
-      <StyledCard>
+      <Card outline gap={20}>
         <Typography>인쇄 매수</Typography>
         <ItemNumberInput
           label="A3"
@@ -106,8 +100,8 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
             setA4PrintCount(Number(value));
           }}
         />
-      </StyledCard>
-      <StyledCard>
+      </Card>
+      <Card outline gap={20}>
         <Typography>인쇄 설정</Typography>
         <BinaryRadio
           label="색상"
@@ -130,12 +124,12 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
           isFirstOptionSelected={!requireMarginChopping}
           setIsFirstOptionSelected={value => setRequireMarginChopping(!value)}
         />
-      </StyledCard>
-      <StyledCard>
+      </Card>
+      <Card outline gap={20}>
         <Typography>인쇄 파일 업로드</Typography>
         {/* todo!: 파일 업로드 api 완성 이후 적용이 필요합니다. */}
         <FileUpload />
-      </StyledCard>
+      </Card>
     </PrintingBusinessFormSecondInner>
   );
 };

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormSecond.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormSecond.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Card from "@sparcs-clubs/web/common/components/Card";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
-import Info from "@sparcs-clubs/web/common/components/Info";
 import ItemNumberInput from "@sparcs-clubs/web/common/components/Forms/ItemNumberInput";
+import Info from "@sparcs-clubs/web/common/components/Info";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import FileUpload from "@sparcs-clubs/web/features/printing-business/component/FileUpload";
 
@@ -26,11 +26,11 @@ const PrintingBusinessFormSecondInner = styled.div`
   gap: 20px;
 `;
 
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
+const StyledCard = styled(Card).attrs({
+  outline: true,
+  padding: "32px",
+  gap: 20,
+})``;
 
 const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
   requestForm,
@@ -84,7 +84,7 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
     <PrintingBusinessFormSecondInner>
       {/* todo!: 이후 동아리의 홍보물 인쇄가능 매수 확인 API 추가후 수정이 필요합니다. */}
       <Info text={leftoverPrintsInfoText("술박스", 45, 45)} />
-      <StyledCard outline>
+      <StyledCard>
         <Typography>인쇄 매수</Typography>
         <ItemNumberInput
           label="A3"
@@ -107,7 +107,7 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
           }}
         />
       </StyledCard>
-      <StyledCard outline>
+      <StyledCard>
         <Typography>인쇄 설정</Typography>
         <BinaryRadio
           label="색상"
@@ -131,7 +131,7 @@ const PrintingBusinessFormSecond: React.FC<PrintingBusinessFormSecondProps> = ({
           setIsFirstOptionSelected={value => setRequireMarginChopping(!value)}
         />
       </StyledCard>
-      <StyledCard outline>
+      <StyledCard>
         <Typography>인쇄 파일 업로드</Typography>
         {/* todo!: 파일 업로드 api 완성 이후 적용이 필요합니다. */}
         <FileUpload />

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormThird.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/PrintingBusinessFormThird.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
-import { setHours } from "date-fns";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import { setHours } from "date-fns";
+import React, { useEffect, useState } from "react";
 
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
 
@@ -16,12 +15,6 @@ type PrintingBusinessFormThirdProps = Pick<
   PrintingBusinessFormProps,
   "username" | "clubs" | "requestParam" | "requestForm" | "setRequestForm"
 > & { setFormError: React.Dispatch<React.SetStateAction<boolean>> };
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
 
 const PrintingBusinessFormThird: React.FC<PrintingBusinessFormThirdProps> = ({
   username,
@@ -41,7 +34,7 @@ const PrintingBusinessFormThird: React.FC<PrintingBusinessFormThirdProps> = ({
   }, [printingPurpose]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={20}>
       <FormCheck
         label={printingBusinessOrderSteps[0].label}
         formContents={[
@@ -105,7 +98,7 @@ const PrintingBusinessFormThird: React.FC<PrintingBusinessFormThirdProps> = ({
           })
         }
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/printing-business/component/PrintingBusinessNotice.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessNotice.tsx
@@ -1,9 +1,9 @@
+import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
-import Button from "@sparcs-clubs/web/common/components/Button";
 
 // 공지사항을 단순이 디스플레이하는 덤 컴포넌트라고 생각되어 컴포넌트단에서 구현했습니다.
 // 후에 공지 수정 기능이 추가되면 frame으로 옮기거나 속성을 추가해야 할 것 같아요.
@@ -18,12 +18,6 @@ const PrintingBusinessNoticeInner = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
-  align-self: stretch;
-`;
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 16px;
   align-self: stretch;
 `;
 
@@ -52,7 +46,7 @@ const PrintingBusinessNotice: React.FC<PrintingBusinessNoticeProps> = ({
 
   return (
     <PrintingBusinessNoticeInner>
-      <StyledCard outline>
+      <Card outline gap={16}>
         <Typography type="h3">안내사항</Typography>
         <StyledTypography type="p">
           동연 소속 회원 모두 홍보물 신청 가능~ 한 번의 신청은 하나의 파일에
@@ -60,7 +54,7 @@ const PrintingBusinessNotice: React.FC<PrintingBusinessNoticeProps> = ({
           <br />
           기타 등등 안내 내용 -{">"} 이건 동연 측에서 준비해주겠죠?
         </StyledTypography>
-      </StyledCard>
+      </Card>
       <StyledBottom>
         <StyledCheckboxOuter>
           <Checkbox

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoFirstFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoFirstFrame.tsx
@@ -1,18 +1,11 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
 import Select, {
   SelectItem,
 } from "@sparcs-clubs/web/common/components/Forms/Select";
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
-import PhoneInput from "@sparcs-clubs/web/common/components/Forms/PhoneInput";
+import React, { useEffect, useState } from "react";
 import { RentalFrameProps } from "../RentalNoticeFrame";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 40px;
-  align-self: stretch;
-`;
 
 const RentalInfoFirstFrame: React.FC<
   RentalFrameProps & { setNextEnabled: (enabled: boolean) => void }
@@ -48,7 +41,7 @@ const RentalInfoFirstFrame: React.FC<
   }, [selectedValue, phone, setRental]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={40}>
       <Select
         items={mockClubList}
         selectedValue={selectedValue}
@@ -64,7 +57,7 @@ const RentalInfoFirstFrame: React.FC<
         placeholder={mockPhone}
         setErrorStatus={setHasPhoneError}
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -1,27 +1,27 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
 import Info from "@sparcs-clubs/web/common/components/Info";
-import ItemButtonList from "@sparcs-clubs/web/features/rental-business/components/ItemButtonList";
-import SelectRangeCalendar from "@sparcs-clubs/web/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import TextButton from "@sparcs-clubs/web/common/components/TextButton";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 import Easel from "@sparcs-clubs/web/features/rental-business//components/Rentals/Easel";
-import Vacuum from "@sparcs-clubs/web/features/rental-business//components/Rentals/Vacuum";
 import HandCart from "@sparcs-clubs/web/features/rental-business//components/Rentals/HandCart";
 import Mat from "@sparcs-clubs/web/features/rental-business//components/Rentals/Mat";
 import Tool from "@sparcs-clubs/web/features/rental-business//components/Rentals/Tool";
+import Vacuum from "@sparcs-clubs/web/features/rental-business//components/Rentals/Vacuum";
+import ItemButtonList from "@sparcs-clubs/web/features/rental-business/components/ItemButtonList";
 import RentalList from "@sparcs-clubs/web/features/rental-business/components/RentalList";
-import TextButton from "@sparcs-clubs/web/common/components/TextButton";
-import Modal from "@sparcs-clubs/web/common/components/Modal";
-import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import SelectRangeCalendar from "@sparcs-clubs/web/features/rental-business/components/SelectRangeCalendar/SelectRangeCalendar";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import { mockExistDates } from "./_atomic/mockExistDate";
 
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 40px;
-  align-self: stretch;
-`;
+const StyledCard = styled(Card).attrs({
+  outline: true,
+  padding: "32px",
+  gap: 40,
+})``;
 
 const StyledCardInner = styled.div`
   display: flex;
@@ -187,7 +187,7 @@ const RentalInfoSecondFrame: React.FC<
 
   return (
     <>
-      <StyledCard outline>
+      <StyledCard>
         <Typography type="h3">대여 기간 선택</Typography>
         <SelectRangeCalendar
           rentalDate={rentalDate}
@@ -204,7 +204,7 @@ const RentalInfoSecondFrame: React.FC<
       <ItemButtonList value={value} onChange={itemOnChange} rental={rental} />
       <Info text={rentals[value].info} />
       {value !== "none" && (
-        <StyledCard outline>
+        <StyledCard>
           <StyledCardInner>
             <ResetTitleWrapper>
               <FlexGrowTypography>
@@ -220,7 +220,7 @@ const RentalInfoSecondFrame: React.FC<
           </StyledCardInner>
         </StyledCard>
       )}
-      <StyledCard outline>
+      <StyledCard>
         <StyledCardInner>
           <ResetTitleWrapper>
             <FlexGrowTypography>

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoSecondFrame.tsx
@@ -17,12 +17,6 @@ import styled from "styled-components";
 import { RentalFrameProps } from "../RentalNoticeFrame";
 import { mockExistDates } from "./_atomic/mockExistDate";
 
-const StyledCard = styled(Card).attrs({
-  outline: true,
-  padding: "32px",
-  gap: 40,
-})``;
-
 const StyledCardInner = styled.div`
   display: flex;
   flex-direction: column;
@@ -187,7 +181,7 @@ const RentalInfoSecondFrame: React.FC<
 
   return (
     <>
-      <StyledCard>
+      <Card outline gap={40}>
         <Typography type="h3">대여 기간 선택</Typography>
         <SelectRangeCalendar
           rentalDate={rentalDate}
@@ -200,11 +194,11 @@ const RentalInfoSecondFrame: React.FC<
           pendingDate={pendingDate}
           setPendingDate={setPendingDate}
         />
-      </StyledCard>
+      </Card>
       <ItemButtonList value={value} onChange={itemOnChange} rental={rental} />
       <Info text={rentals[value].info} />
       {value !== "none" && (
-        <StyledCard>
+        <Card outline gap={40}>
           <StyledCardInner>
             <ResetTitleWrapper>
               <FlexGrowTypography>
@@ -218,9 +212,9 @@ const RentalInfoSecondFrame: React.FC<
             </ResetTitleWrapper>
             <Rental {...props} />
           </StyledCardInner>
-        </StyledCard>
+        </Card>
       )}
-      <StyledCard>
+      <Card outline gap={40}>
         <StyledCardInner>
           <ResetTitleWrapper>
             <FlexGrowTypography>
@@ -234,7 +228,7 @@ const RentalInfoSecondFrame: React.FC<
           </ResetTitleWrapper>
           <RentalList rental={rental} />
         </StyledCardInner>
-      </StyledCard>
+      </Card>
       {showPeriodModal !== "none" && (
         <Modal>
           <CancellableModalContent

--- a/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoThirdFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalInfoFrame/RentalInfoThirdFrame.tsx
@@ -1,18 +1,12 @@
-import React, { useEffect, useState } from "react";
-import { format } from "date-fns";
-import { ko } from "date-fns/locale";
-import styled from "styled-components";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import RentalList from "@sparcs-clubs/web/features/rental-business/components/RentalList";
-import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import { RentalFrameProps } from "../RentalNoticeFrame";
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 20px;
-  align-self: stretch;
-`;
 
 const StyledTypography = styled(Typography)`
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
@@ -89,7 +83,7 @@ const RentalInfoThirdFrame: React.FC<
   }, [rental, purposeTouched, setNextEnabled, setNoPurposeError]);
 
   return (
-    <StyledCard outline>
+    <Card outline gap={20}>
       <CardInner>
         <StyledTypography type="p">신청자 정보</StyledTypography>
         <UserInfoListContainer>
@@ -121,7 +115,7 @@ const RentalInfoThirdFrame: React.FC<
         errorMessage={noPurposeError}
         onBlur={handlePurposeTouched}
       />
-    </StyledCard>
+    </Card>
   );
 };
 

--- a/packages/web/src/features/rental-business/frames/RentalNoticeFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalNoticeFrame.tsx
@@ -1,9 +1,9 @@
+import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Checkbox from "@sparcs-clubs/web/common/components/Checkbox";
-import Button from "@sparcs-clubs/web/common/components/Button";
 import type { RentalInterface } from "../types/rental";
 
 export interface RentalFrameProps {
@@ -16,12 +16,6 @@ const RentalNoticeFrameInner = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
-  align-self: stretch;
-`;
-
-const StyledCard = styled(Card)<{ outline: boolean }>`
-  padding: 32px;
-  gap: 16px;
   align-self: stretch;
 `;
 
@@ -57,7 +51,7 @@ const RentalNoticeFrame: React.FC<RentalFrameProps> = ({
 
   return (
     <RentalNoticeFrameInner>
-      <StyledCard outline>
+      <Card outline gap={16}>
         <Typography type="h3">안내사항</Typography>
         <StyledTypography type="p">
           모든 대여 사업은 동연 소속 동아리를 대상으로 하며, 신청은 각 동아리의
@@ -65,7 +59,7 @@ const RentalNoticeFrame: React.FC<RentalFrameProps> = ({
           <br />
           기타 등등 안내 내용 -{">"} 이건 동연 측에서 준비해주겠죠?
         </StyledTypography>
-      </StyledCard>
+      </Card>
       <StyledBottom>
         <StyledCheckboxOuter>
           <Checkbox


### PR DESCRIPTION
# 요약 \*

#169 StyledCard Refactoring

1. 기존의 StyledCard 만들어서 사용하는 부분 대부분 삭제하고 Card 컴포넌트에 optinal props padding, gap 추가 함
2. Card 컴포넌트 'align-self: stretch' 추가 함 (모든 Card 사용하는 곳에서 다 넣어서 사용하고 있었음)

# 스크린샷
예시 페이지 
<img width="929" alt="image" src="https://github.com/academic-relations/ar-002-clubs/assets/89931104/c6539f00-05f7-4b8f-ba87-ce73ac706e93">

# 테스트
그 외 파일 수정이 들어간 모든 페이지 기존과 스타일이 같은지 확인 부탁드립니다.

# 이후 Task \*
- 없음
