### PR TITLE
124 Add log level into backend

### DIFF
--- a/packages/api/src/common/util/logger.ts
+++ b/packages/api/src/common/util/logger.ts
@@ -84,9 +84,9 @@ const logger =
       })
     : // "development", "test" 환경에서 사용되는 Logger 객체
       createLogger({
-        level: "info",
+        level: "debug",
         format: colorizedFormat,
-        defaultMeta: { service: "biseo" },
+        defaultMeta: { service: "clubs" },
         transports: [new transports.Console()],
         exceptionHandlers: [new transports.Console()],
       });

--- a/packages/api/src/feature/notice/controller/notice.controller.ts
+++ b/packages/api/src/feature/notice/controller/notice.controller.ts
@@ -7,6 +7,8 @@ import type {
   ApiNtc001ResponseOK,
 } from "@sparcs-clubs/interface/api/notice/endpoint/apiNtc001";
 
+import logger from "@sparcs-clubs/api/common/util/logger";
+
 import { NoticeService } from "../service/notice.service";
 
 @Controller()
@@ -24,10 +26,12 @@ export class NoticeController {
       pageOffset: Number(pageOffset),
       itemCount: Number(itemCount),
     });
-    // 백엔드도 동일하게 로그레벨 활용하나요?
-    // console.log(
-    //   `[/notices] getting notice with offset ${query.pageOffset}, count ${query.itemCount}`,
-    // );
+
+    // 로거 사용예시입니다.
+    logger.debug(
+      `[/notices] offset: ${query.pageOffset}, count: ${query.itemCount}`,
+    );
+
     const notices = await this.noticesService.getNotices(
       query.pageOffset,
       query.itemCount,


### PR DESCRIPTION
# 요약 \*

It closes #124
비서 세팅 가져오면서 winston이 포함되어 있는것을 확인했고,
"development", "test" 환경에서 사용 가능한 로그 레벨만 debug까지 올려 로그 출력까지 확인한 상태입니다.
사용예시는 notice controller에서 확인할 수 있습니다.

# 스크린샷

<img width="586" alt="스크린샷 2024-05-18 오후 3 59 12" src="https://github.com/academic-relations/ar-002-clubs/assets/69956347/ba398868-3841-43f9-ae7f-a997bcbc4892">
<img width="652" alt="스크린샷 2024-05-18 오후 3 58 48" src="https://github.com/academic-relations/ar-002-clubs/assets/69956347/6f5d9bf0-ca2e-4553-8c23-a8675390e03e">


# 이후 Task \*

- [] 배포시 로거 설정 확인하기
