### PR TITLE
feat: add bread crumb to notice page

### DIFF
--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateMainFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateMainFrame.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
 import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 import React, { useState } from "react";
 import styled from "styled-components";
@@ -9,8 +10,8 @@ import {
   FirstErrorStatus,
   SecondErrorStatus,
 } from "../types/activityCertificate";
-import ActivityCertificateNoticeFrame from "./ActivityCertificateNoticeFrame";
 import ActivityCertificateInfoFrame from "./ActivityCertificateInfoFrame";
+import ActivityCertificateNoticeFrame from "./ActivityCertificateNoticeFrame";
 
 const ActivityCertificatePageMainFrameInner = styled.div`
   width: 100%;
@@ -20,6 +21,12 @@ const ActivityCertificatePageMainFrameInner = styled.div`
   align-items: flex-start;
   gap: 60px;
   display: inline-flex;
+`;
+
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 `;
 
 const ActivityCertificateMainFrame: React.FC = () => {
@@ -78,7 +85,12 @@ const ActivityCertificateMainFrame: React.FC = () => {
 
   return (
     <ActivityCertificatePageMainFrameInner>
-      <PageTitle>활동확인서 발급</PageTitle>
+      <PageHeadWrapper>
+        <BreadCrumb
+          items={[{ name: "활동확인서 발급", path: "/activity-certificate" }]}
+        />
+        <PageTitle>활동확인서 발급</PageTitle>
+      </PageHeadWrapper>
       {activityCertificateProgress.agreement ? (
         <ActivityCertificateInfoFrame {...props} />
       ) : (

--- a/packages/web/src/features/common-space/frames/CommonSpaceMainFrame.tsx
+++ b/packages/web/src/features/common-space/frames/CommonSpaceMainFrame.tsx
@@ -1,14 +1,21 @@
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
+import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 import React from "react";
 import styled from "styled-components";
-import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 import type { CommonSpaceInterface } from "../types/commonSpace";
-import CommonSpaceNoticeFrame from "./CommonSpaceNoticeFrame";
 import CommonSpaceInfoFrame from "./CommonSpaceInfoFrame";
+import CommonSpaceNoticeFrame from "./CommonSpaceNoticeFrame";
 
 const CommonSpaceMainFrameInner = styled.div`
   display: flex;
   flex-direction: column;
   gap: 60px;
+`;
+
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 `;
 
 const CommonSpaceMainFrame: React.FC = () => {
@@ -18,7 +25,12 @@ const CommonSpaceMainFrame: React.FC = () => {
   const props = { commonSpace, setCommonSpace };
   return (
     <CommonSpaceMainFrameInner>
-      <PageTitle>공용공간 비정기사용</PageTitle>
+      <PageHeadWrapper>
+        <BreadCrumb
+          items={[{ name: "공용공간 비정기사용", path: "/common-space" }]}
+        />
+        <PageTitle>공용공간 비정기사용</PageTitle>
+      </PageHeadWrapper>
       {commonSpace.agreement ? (
         <CommonSpaceInfoFrame {...props} />
       ) : (

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportCreateFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportCreateFrame.tsx
@@ -1,6 +1,6 @@
 import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
-import Card from "@sparcs-clubs/web/common/components/Card";
 import Button from "@sparcs-clubs/web/common/components/Button";
+import Card from "@sparcs-clubs/web/common/components/Card";
 import FileUpload from "@sparcs-clubs/web/common/components/FileUpload";
 // import DateRangeInput from "@sparcs-clubs/web/common/components/Forms/DateRangeInput";
 import Select from "@sparcs-clubs/web/common/components/Forms/Select";
@@ -9,8 +9,8 @@ import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import React from "react";
 import styled from "styled-components";
-import SelectParticipant from "../components/SelectParticipant";
 import { mockParticipantData } from "../_mock/mock";
+import SelectParticipant from "../components/SelectParticipant";
 
 const ActivityReportMainFrameInner = styled.div`
   display: flex;
@@ -56,6 +56,7 @@ const ActivityReportCreateFrame: React.FC = () => (
           { name: "대표 동아리 관리", path: "/manage-club" },
           { name: "활동 보고서", path: "/manage-club/activity-report" },
         ]}
+        enableLast
       />
       <PageTitle>활동 보고서 작성</PageTitle>
     </PageTitleOuter>

--- a/packages/web/src/features/notices/frames/NoticePageMainFrame.tsx
+++ b/packages/web/src/features/notices/frames/NoticePageMainFrame.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React from "react";
 import styled from "styled-components";
 
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
 import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
-
 import NoticeListAndPaginationFrame from "@sparcs-clubs/web/features/notices/frames/NoticeListAndPaginationFrame";
 
 const NoticePageMainFrameInner = styled.div`
@@ -16,9 +15,18 @@ const NoticePageMainFrameInner = styled.div`
   row-gap: 60px;
 `;
 
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
 const NoticePageMainFrame = () => (
   <NoticePageMainFrameInner>
-    <PageTitle>공지사항</PageTitle>
+    <PageHeadWrapper>
+      <BreadCrumb items={[{ name: "공지사항", path: "/notice" }]} />
+      <PageTitle>공지사항</PageTitle>
+    </PageHeadWrapper>
     <NoticeListAndPaginationFrame />
   </NoticePageMainFrameInner>
 );

--- a/packages/web/src/features/printing-business/frame/PrintingBusinessMainFrame.tsx
+++ b/packages/web/src/features/printing-business/frame/PrintingBusinessMainFrame.tsx
@@ -1,19 +1,19 @@
+import { setHours, setMinutes, setSeconds } from "date-fns";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import { setHours, setMinutes, setSeconds } from "date-fns";
 
 import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 
-import useGetUserProfile from "@sparcs-clubs/web/features/printing-business/service/getUserProfile";
-import _postBusinessPrintingOrder from "@sparcs-clubs/web/features/printing-business/service/postBusinessPrintingOrder";
 import type {
-  ApiPrt002RequestParam,
   ApiPrt002RequestBody,
+  ApiPrt002RequestParam,
 } from "@sparcs-clubs/interface/api/promotional-printing/endpoint/apiPrt002";
 import { PromotionalPrintingSizeEnum } from "@sparcs-clubs/interface/common/enum/promotionalPrinting.enum";
+import useGetUserProfile from "@sparcs-clubs/web/features/printing-business/service/getUserProfile";
 
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
 import PrintingBusinessNotice from "@sparcs-clubs/web/features/printing-business/component/PrintingBusinessNotice";
 import PrintingBusinessForm from "../component/PrintingBusinessForm";
 
@@ -21,6 +21,12 @@ const PrintingBusinessMainFrameInner = styled.div`
   display: flex;
   flex-direction: column;
   gap: 60px;
+`;
+
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 `;
 
 const PrintingBusinessMainFrame: React.FC = () => {
@@ -72,7 +78,12 @@ const PrintingBusinessMainFrame: React.FC = () => {
 
   return (
     <PrintingBusinessMainFrameInner>
-      <PageTitle>홍보물 인쇄</PageTitle>
+      <PageHeadWrapper>
+        <BreadCrumb
+          items={[{ name: "홍보물 인쇄", path: "/printing-business" }]}
+        />
+        <PageTitle>홍보물 인쇄</PageTitle>
+      </PageHeadWrapper>
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         {agreement ? (
           <PrintingBusinessForm

--- a/packages/web/src/features/rental-business/frames/RentalMainFrame.tsx
+++ b/packages/web/src/features/rental-business/frames/RentalMainFrame.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import styled from "styled-components";
 import PageTitle from "@sparcs-clubs/web/common/components/PageTitle";
 import RentalInfoFrame from "@sparcs-clubs/web/features/rental-business/frames/RentalInfoFrame";
+import React from "react";
+import styled from "styled-components";
 
+import BreadCrumb from "@sparcs-clubs/web/common/components/BreadCrumb";
 import type { RentalInterface } from "../types/rental";
 import RentalNoticeFrame from "./RentalNoticeFrame";
 
@@ -12,6 +13,12 @@ const RentalMainFrameInner = styled.div`
   gap: 60px;
 `;
 
+const PageHeadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
 const RentalMainFrame: React.FC = () => {
   const [rental, setRental] = React.useState<RentalInterface>({
     agreement: false,
@@ -19,7 +26,10 @@ const RentalMainFrame: React.FC = () => {
   const props = { rental, setRental };
   return (
     <RentalMainFrameInner>
-      <PageTitle>대여 사업</PageTitle>
+      <PageHeadWrapper>
+        <BreadCrumb items={[{ name: "대여 사업", path: "/rental-business" }]} />
+        <PageTitle>대여 사업</PageTitle>
+      </PageHeadWrapper>
       {rental.agreement ? (
         <RentalInfoFrame {...props} />
       ) : (


### PR DESCRIPTION
# 요약 \*

It closes #219 

변경사항:
1. notice 페이지 BreadCrumb 추가
2. 활동보고서 작성 페이지의 BreadCrumb에 enableLast가 빠진 것 같아 추가하였습니다

# 스크린샷

![image](https://github.com/academic-relations/ar-002-clubs/assets/89931104/01a1a3ea-c373-4982-9ab1-a46aa70c4d35)
<img width="454" alt="image" src="https://github.com/academic-relations/ar-002-clubs/assets/89931104/144d0354-4353-4bed-8798-7e85300ca1c3">


# 이후 Task \*

아직 구현되지 않은 페이지인 것 같아요: 
1. /notice/[id] -> 공지사항 상세페이지 
3. 활동보고서 수정
4. 지원금 신청
5. 지원금 수정

