### PR TITLE
Fix dom element prop console error

### DIFF
--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  compiler: {
+    // Enables the styled-components SWC transform
+    styledComponents: true,
+  },
+};
 
 export default nextConfig;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@emotion/cache": "11.11.0",
+    "@emotion/is-prop-valid": "^1.2.2",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.0",
     "@mui/icons-material": "5.15.12",

--- a/packages/web/src/common/components/Calendar/_atomic/CalendarDate.tsx
+++ b/packages/web/src/common/components/Calendar/_atomic/CalendarDate.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled, { css } from "styled-components";
 import { DefaultTheme } from "styled-components/dist/types";
@@ -19,7 +20,9 @@ const getBackgroundColor = (
   return theme.colors.WHITE;
 };
 
-const ExistWrapper = styled.div<{
+const ExistWrapper = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{
   exist: boolean;
   type?: CalendarDateProps["type"];
 }>`
@@ -46,7 +49,9 @@ const ExistWrapper = styled.div<{
     `}
 `;
 
-const DateContainer = styled.div<CalendarDateProps>`
+const DateContainer = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<CalendarDateProps>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/web/src/common/components/Card.tsx
+++ b/packages/web/src/common/components/Card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import isPropValid from "@emotion/is-prop-valid";
 import styled from "styled-components";
 
 interface CardProps {
@@ -8,7 +9,9 @@ interface CardProps {
   gap?: number;
 }
 
-const Card = styled.div<CardProps>`
+const Card = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<CardProps>`
   display: flex;
   flex-direction: column;
   position: relative;

--- a/packages/web/src/common/components/Filter/_atomic/FilterButton.tsx
+++ b/packages/web/src/common/components/Filter/_atomic/FilterButton.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled from "styled-components";
 import Icon from "@sparcs-clubs/web/common/components/Icon";
@@ -11,7 +12,9 @@ interface FilterButtonProps {
   selectedSemesters: SemesterProps[];
 }
 
-const FilterButtonWrapper = styled.div<{ isOpen: boolean }>`
+const FilterButtonWrapper = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ isOpen: boolean }>`
   width: max-content;
   display: flex;
   height: 36px;

--- a/packages/web/src/common/components/FoldableSection.tsx
+++ b/packages/web/src/common/components/FoldableSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled from "styled-components";
 
@@ -27,7 +28,9 @@ const MoreInfo = styled.div`
   cursor: pointer;
 `;
 
-const ChildrenOuter = styled.div<{ margin?: string }>`
+const ChildrenOuter = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ margin?: string }>`
   margin-top: ${({ margin }) => margin};
 `;
 

--- a/packages/web/src/common/components/Forms/ItemNumberInput.tsx
+++ b/packages/web/src/common/components/Forms/ItemNumberInput.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React, {
   ChangeEvent,
   InputHTMLAttributes,
@@ -51,7 +52,9 @@ const InputContainer = styled.div`
   align-items: center;
 `;
 
-const RightContentWrapper = styled.div<{ hasError: boolean }>`
+const RightContentWrapper = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ hasError: boolean }>`
   position: absolute;
   right: 12px;
   display: flex;
@@ -65,7 +68,9 @@ const RightContentWrapper = styled.div<{ hasError: boolean }>`
     hasError ? theme.colors.RED[600] : theme.colors.GRAY[300]};
 `;
 
-const Input = styled.input<ItemNumberInputProps & { hasError: boolean }>`
+const Input = styled.input.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<ItemNumberInputProps & { hasError: boolean }>`
   display: block;
   width: 100%;
   padding: 8px 12px;

--- a/packages/web/src/common/components/Forms/Select.tsx
+++ b/packages/web/src/common/components/Forms/Select.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React, { useState, useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
@@ -31,7 +32,9 @@ const disabledStyle = css`
   pointer-events: none;
 `;
 
-const StyledSelect = styled.div<{
+const StyledSelect = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{
   hasError?: boolean;
   disabled?: boolean;
   isOpen?: boolean;
@@ -75,7 +78,9 @@ const Dropdown = styled.div`
   z-index: 1000; // Ensure the dropdown appears above other content
 `;
 
-const Option = styled.div<{ selectable?: boolean }>`
+const Option = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ selectable?: boolean }>`
   gap: 10px;
   border-radius: 4px;
   padding: 4px 12px;
@@ -125,7 +130,9 @@ const SelectWrapper = styled.div`
   gap: 4px;
 `;
 
-const SelectValue = styled.span<{ isSelected: boolean }>`
+const SelectValue = styled.span.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ isSelected: boolean }>`
   color: ${({ theme, isSelected }) =>
     isSelected ? theme.colors.BLACK : theme.colors.GRAY[200]};
 `;

--- a/packages/web/src/common/components/Icon.tsx
+++ b/packages/web/src/common/components/Icon.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled, { css } from "styled-components";
 import { Icon as MUIIcon } from "@mui/material";
@@ -13,7 +14,9 @@ interface IconProps {
   className?: string;
 }
 
-const IconInner = styled.div<{
+const IconInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{
   size: number;
   clickable: boolean;
 }>`

--- a/packages/web/src/common/components/NavTools/NavItem.tsx
+++ b/packages/web/src/common/components/NavTools/NavItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import isPropValid from "@emotion/is-prop-valid";
 import React, { useState } from "react";
 import Link from "next/link";
 import styled from "styled-components";
@@ -12,7 +13,9 @@ type Path = {
   highlight?: boolean;
 };
 
-const NavItemInner = styled.div<{ highlight?: boolean }>`
+const NavItemInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ highlight?: boolean }>`
   position: relative;
   display: inline-flex;
   justify-content: center;

--- a/packages/web/src/common/components/Radio/index.tsx
+++ b/packages/web/src/common/components/Radio/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import isPropValid from "@emotion/is-prop-valid";
 import styled from "styled-components";
 import React, { ReactElement, ReactNode, cloneElement } from "react";
 import RadioOption, { type RadioOptionProps } from "./RadioOption";
@@ -18,7 +19,9 @@ function isRadioOptionElement<T extends string>(
   return React.isValidElement(child) && "value" in child.props;
 }
 
-const StyledRadioInner = styled.div<{
+const StyledRadioInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{
   direction: "row" | "column";
   gap: string;
 }>`

--- a/packages/web/src/common/components/Timetable/_atomic/TimetableDateList.tsx
+++ b/packages/web/src/common/components/Timetable/_atomic/TimetableDateList.tsx
@@ -1,5 +1,6 @@
 import { addDays, format } from "date-fns";
 import { ko } from "date-fns/locale";
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled from "styled-components";
 
@@ -8,7 +9,9 @@ interface TimetableDateListProps {
   paddingLeft?: string;
 }
 
-const TimetableDateListInner = styled.div<{ paddingLeft: string }>`
+const TimetableDateListInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ paddingLeft: string }>`
   display: flex;
   width: 600px;
   justify-content: flex-end;

--- a/packages/web/src/common/components/Timetable/_atomic/TimetableTable.tsx
+++ b/packages/web/src/common/components/Timetable/_atomic/TimetableTable.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import TimetableCell, { type TimetableCellType } from "./TimetableCell";
@@ -8,7 +9,9 @@ interface TimetableTableProps {
   update?: string;
 }
 
-const TimetableTableInner = styled.div<{
+const TimetableTableInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{
   rows: number;
   columns: number;
 }>`

--- a/packages/web/src/common/components/Toggle.tsx
+++ b/packages/web/src/common/components/Toggle.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React, { useState } from "react";
 import styled from "styled-components";
 import Icon from "./Icon";
@@ -31,7 +32,9 @@ const ChildrenOuter = styled.div`
   align-self: stretch;
 `;
 
-const RotatableIcon = styled(Icon)<{ isOpen: boolean }>`
+const RotatableIcon = styled(Icon).withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ isOpen: boolean }>`
   transform: rotate(${({ isOpen }) => (isOpen ? 90 : 0)}deg);
   transition: transform 0.3s;
 `;

--- a/packages/web/src/common/components/Typography.tsx
+++ b/packages/web/src/common/components/Typography.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import { Theme } from "@sparcs-clubs/web/styles/themes";
 import React from "react";
 import styled from "styled-components";
@@ -55,7 +56,9 @@ type TypographyProps =
     })
   | (TypographyPropsWithCustomStyles & { type?: never });
 
-const TypographyInner = styled.div<TypographyPropsWithCustomStyles>`
+const TypographyInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<TypographyPropsWithCustomStyles>`
   color: ${({ color, theme }) =>
     color ? getColorFromTheme(theme, color) : "inherit"};
   font-family: ${({ theme, ff }) => (ff ? theme.fonts.FAMILY[ff] : "inherit")};

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoThirdFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoThirdFrame.tsx
@@ -49,51 +49,86 @@ const ActivityCertificateInfoThirdFrame: React.FC<
     <Card outline gap={20}>
       <BasicInfoSummaryFrameInner>
         <Typography
+          key="orderUserInfo"
           type="p"
           style={{ whiteSpace: "pre-wrap", fontWeight: 500 }}
         >
           신청자 정보
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderUserName"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  이름: ${activityCertificate.applicant}`}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderUserDepartment"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  학과: ${activityCertificate.department}`}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderUserStudentNumber"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  학번: ${activityCertificate.studentNumber}`}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderUserPhoneNumber"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  연락처: ${activityCertificate.krPhoneNumber}`}
         </Typography>
         <Typography
+          key="orderInfo"
           type="p"
           style={{ whiteSpace: "pre-wrap", fontWeight: 500 }}
         >
           활동확인서 발급 신청 정보
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderInfoClub"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  동아리: ${activityCertificate.clubId!}`}{" "}
           {/* TODO - 실제 클럽 이름으로 바꾸기 */}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderInfoDuration"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  활동 기간: ${activityCertificate.startMonth} ~ ${activityCertificate.endMonth}`}
           {/* TODO - DB 형식에 의거해서 startMonth endMonth 형식으로 있다면 포맷하고 string이라면 그냥 넣기 */}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderInfoIssueCount"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  발급 매수: ${activityCertificate.issuedNumber!}매`}
         </Typography>
-        <Typography type="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography
+          key="orderInfoText"
+          type="p"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
           {`  •  활동 내역`}
         </Typography>
         <ActivityDescriptionSummaryFrameInner>
           {activityCertificate.detail.map(activityDescription => (
-            <ActivityDescriptionSummaryRow>
+            <ActivityDescriptionSummaryRow key={activityDescription.key}>
               {activityDescription.startMonth.split(".")[0] ===
                 activityDescription.endMonth.split(".")[0] &&
               parseInt(activityDescription.startMonth.split(".")[1]) ===
                 parseInt(activityDescription.endMonth.split(".")[1]) ? (
                 <Typography
+                  key={`${activityDescription.key}_start`}
                   type="p"
                   style={{
                     whiteSpace: "pre-wrap",
@@ -105,6 +140,7 @@ const ActivityCertificateInfoThirdFrame: React.FC<
                 </Typography>
               ) : (
                 <Typography
+                  key={`${activityDescription.key}_end`}
                   type="p"
                   style={{
                     whiteSpace: "pre-wrap",
@@ -117,6 +153,7 @@ const ActivityCertificateInfoThirdFrame: React.FC<
               )}
 
               <Typography
+                key={`${activityDescription.key}_description`}
                 type="p"
                 style={{
                   whiteSpace: "pre-wrap",

--- a/packages/web/src/features/printing-business/component/DesiredPickUpTimeSelection/DesiredPickUpTimeSelection.tsx
+++ b/packages/web/src/features/printing-business/component/DesiredPickUpTimeSelection/DesiredPickUpTimeSelection.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -34,7 +35,9 @@ const StyledLabel = styled.label`
   text-align: left;
 `;
 
-const CalendarAndTimeSlot = styled.div<{ calendarSize: "sm" | "md" | "lg" }>`
+const CalendarAndTimeSlot = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ calendarSize: "sm" | "md" | "lg" }>`
   width: 100%;
 
   /* Auto layout */

--- a/packages/web/src/features/printing-business/component/DesiredPickUpTimeSelection/_atomic/TimeSlotList.tsx
+++ b/packages/web/src/features/printing-business/component/DesiredPickUpTimeSelection/_atomic/TimeSlotList.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid";
 import React from "react";
 import styled from "styled-components";
 import { getHours, getMinutes, setHours, setMinutes } from "date-fns";
@@ -10,7 +11,9 @@ interface TimeSlotListProps {
   onDatesChange: (date: Date) => void;
 }
 
-const TimeSlotListInner = styled.div<{ calendarSize: "sm" | "md" | "lg" }>`
+const TimeSlotListInner = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ calendarSize: "sm" | "md" | "lg" }>`
   width: ${({ calendarSize }) => (calendarSize === "lg" ? "300px" : "100%")};
   flex: none;
   order: 1;
@@ -22,7 +25,9 @@ const TimeSlotListInner = styled.div<{ calendarSize: "sm" | "md" | "lg" }>`
   gap: 12px;
 `;
 
-const TimeSlotSelection = styled.button<{ isSelected: boolean }>`
+const TimeSlotSelection = styled.button.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ isSelected: boolean }>`
   /* Auto layout */
   display: flex;
   flex-direction: row;

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/_atomic/BinaryRadio.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/_atomic/BinaryRadio.tsx
@@ -49,8 +49,12 @@ const BinaryRadio: React.FC<BinaryRadioProps> = ({
       }
     >
       {[
-        <RadioOption value="true">{firstOptionLabel}</RadioOption>,
-        <RadioOption value="false">{secondOptionLabel}</RadioOption>,
+        <RadioOption key={`${label}_true`} value="true">
+          {firstOptionLabel}
+        </RadioOption>,
+        <RadioOption key={`${label}_false`} value="false">
+          {secondOptionLabel}
+        </RadioOption>,
       ]}
     </Radio>
   </BinaryRadioInner>

--- a/packages/web/src/features/rental-business/components/ItemButton.tsx
+++ b/packages/web/src/features/rental-business/components/ItemButton.tsx
@@ -3,6 +3,8 @@ import Typography from "@sparcs-clubs/web/common/components/Typography";
 import React from "react";
 import styled, { css } from "styled-components";
 
+import isPropValid from "@emotion/is-prop-valid";
+
 interface ItemButtonProps {
   image?: string;
   name: string;
@@ -29,7 +31,9 @@ const ImageContent = styled.img`
   max-width: 100%;
   max-height: 100%;
 `;
-const HaveIndicator = styled.div<{ have: boolean; selected: boolean }>`
+const HaveIndicator = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ have: boolean; selected: boolean }>`
   width: 16px;
   height: 16px;
   border-radius: 50%;

--- a/packages/web/src/features/rental-business/components/RentalList.tsx
+++ b/packages/web/src/features/rental-business/components/RentalList.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+
 import { RentalInterface } from "../types/rental";
 
 interface RentalListProps {
@@ -10,14 +13,6 @@ const RentalListContainer = styled.ul`
   list-style: none;
   padding: 0;
   margin: 0;
-`;
-
-const EmptyListWrapper = styled.text`
-  font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.REGULAR};
-  font-size: 16px;
-  line-height: 20px;
-  color: ${({ theme }) => theme.colors.GRAY[300]};
 `;
 
 const RentalListItem = styled.li`
@@ -96,7 +91,9 @@ const RentalList: React.FC<RentalListProps> = ({ rental }) => {
       {itemList.length > 0 ? (
         listItems
       ) : (
-        <EmptyListWrapper>선택한 물품이 없습니다</EmptyListWrapper>
+        <Typography fs={16} lh={20} color="GRAY.300">
+          선택한 물품이 없습니다
+        </Typography>
       )}
     </RentalListContainer>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@emotion/cache':
         specifier: 11.11.0
         version: 11.11.0
+      '@emotion/is-prop-valid':
+        specifier: ^1.2.2
+        version: 1.2.2
       '@emotion/react':
         specifier: 11.11.4
         version: 11.11.4(@types/react@18.2.64)(react@18.2.0)
@@ -899,6 +902,12 @@ packages:
       '@emotion/memoize': 0.8.1
     dev: false
 
+  /@emotion/is-prop-valid@1.2.2:
+    resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+    dev: false
+
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
     requiresBuild: true
@@ -956,7 +965,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@emotion/babel-plugin': 11.11.0
-      '@emotion/is-prop-valid': 1.2.1
+      '@emotion/is-prop-valid': 1.2.2
       '@emotion/react': 11.11.4(@types/react@18.2.64)(react@18.2.0)
       '@emotion/serialize': 1.1.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)


### PR DESCRIPTION
# 요약 \*

It closes #224 

브라우저에서 확인되는 자잘한 에러들에 관한 수정이 포함되어 있습니다.

- 반복되는 컴포넌트에 key가 포함되어 있지 않은 경우
- typography로 변경해야 하는 컴포넌트
- https://stackoverflow.com/questions/51791163/warning-prop-classname-did-not-match-when-using-styled-components-with-seman
위와 유사한 에러를 겪에서 SWC 옵션을 추가했습니다.
- styled-component prop 관련 에러
아래 공지를 확인해주세요
styled-component 관련하여 확인해야할 사항이 하나 정리되어서 올려봅니다!
먼저 문제상황은 styled componenet에 아래와 같이 속성을 추가할 때 발생하는데요,
```js
styled.div<{ have: boolean; selected: boolean }>
```
이렇게 속성을 추가하게되면 `have` attribute가 DOM을 통해 전달되며 리액트 경고가 발생하게 됩니다. 이와 유사한 방법으로 구현된 컴포넌트들에 대해 해결책으로 두가지 정도의 방법이 있습니다.
1. transent-prop으로 prop을 변경한다.
2. `shouldForwardProp` 을 해당 컴포넌트들에 추가한다
1번 방법이 가장 정석적인 방법으로, 위 예시에선 `have` 대신 `$have` 를 propName으로 이용하는 것이 해결책입니다. 다만 그렇게 되면 해당 common 컴포넌트를 사용하는 모든 코드들에 대해 propName을 변경해야 하는 불편함이 있습니다.
2번 방법은 아래와 같이 컴포넌트에 config를 추가할 수 있습니다.
```js
const HaveIndicator = styled.div.withConfig({
  shouldForwardProp: prop => isPropValid(prop),
})<{ have: boolean; selected: boolean }>`
```
`isPropValid` 는 `@emotion/is-prop-valid` 라는 라이브러리에서 제공하는 hrml 표준 prop인지? 검사해주는 함수입니다. 이를 이용해서 우리가 임의로 선언한 prop들이 DOM을 통해 전달되지 않도록 필터링해 준다고? 합니다!
1번 방법을 전체 코드에 적용하고 싶은 욕심이 있는데, 어제 몇시간정도 수정하다보니 너무 시간이 오래 걸리는 작업 같아서, 일단 해당 경고들이 발생하는 컴포넌트들에 대해 2번 방법을 적용하고, 앞으로의 코드는 1번 방법을 지켜서 작성하는 것이 좋을 것 같은데, 
 확인하고 의견 남겨주세요!

위 토의에서 제안한 대로 2번 방법을 적용하고, 앞으로의 코드는 1번 방법을 지켜서 작성하는 방향으로 수정했습니다.

# 스크린샷

# 이후 Task \*

- 앞으로는 styled-component를 위한, DOM을 통해 전파되지 않아야 하는 prop에 대해 transient-prop 사용하기
