### PR TITLE
fix: fix blur error in safari

### DIFF
--- a/packages/web/src/common/components/Header/index.tsx
+++ b/packages/web/src/common/components/Header/index.tsx
@@ -51,6 +51,9 @@ const HeaderInner = styled.div`
   position: sticky;
   top: 0;
   z-index: 10;
+  -webkit-backdrop-filter: blur(
+    10px
+  ); /* Add this line first, it fixes blur for Safari*/
   backdrop-filter: blur(10px);
 `;
 


### PR DESCRIPTION
# 요약 \*

It closes #286 
사파리에서 헤더의 블러 속성이 적용되지 않는 이슈입니다.
-webkit-backdrop-filter 속성을 추가하여 해결했습니다.

https://www.reddit.com/r/css/comments/12jhh10/solution_backdrop_filter_blur_doesnt_work_in/?rdt=55566

# 스크린샷
- before
![image](https://github.com/academic-relations/ar-002-clubs/assets/69956347/ef826c51-1fc8-47b2-9755-09fd93d5b72b)
- after
<img width="932" alt="스크린샷 2024-06-02 오후 3 47 23" src="https://github.com/academic-relations/ar-002-clubs/assets/69956347/3456d61e-5014-4593-93d6-3cfa5125f587">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
