### PR TITLE
add responsive design to clubs page

### DIFF
--- a/packages/web/src/app/clubs/page.tsx
+++ b/packages/web/src/app/clubs/page.tsx
@@ -1,19 +1,8 @@
 "use client";
 
-import React from "react";
-
-import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import ClubsPageMainFrame from "@sparcs-clubs/web/features/clubs/frames/ClubsPageMainFrame";
 // import { DivisionType } from "@sparcs-clubs/web/types/divisions.types";
 
-const Clubs = () => (
-  <>
-    <PageHead
-      items={[{ name: "동아리 목록", path: "/clubs" }]}
-      title="동아리 목록"
-    />
-    <ClubsPageMainFrame />
-  </>
-);
+const Clubs = () => <ClubsPageMainFrame />;
 
 export default Clubs;

--- a/packages/web/src/features/clubs/components/ClubListGrid.tsx
+++ b/packages/web/src/features/clubs/components/ClubListGrid.tsx
@@ -15,26 +15,26 @@ interface ClubListGridItemProps {
 }
 
 const ClubListGridInner = styled.div`
-  width: 100%;
+  width: calc(100% - 48px);
   display: grid;
-  grid-template-columns: repeat(4, calc((100% - 48px) / 4));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
   padding-left: 24px;
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.xl}) {
-    grid-template-columns: repeat(4, calc((100% - 48px) / 4));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
-    grid-template-columns: repeat(3, calc((100% - 48px) / 3));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
-    grid-template-columns: repeat(2, calc((100% - 48px) / 2));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.xs}) {
-    grid-template-columns: calc((100% - 48px));
+    grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 `;
 

--- a/packages/web/src/features/clubs/components/ClubListGrid.tsx
+++ b/packages/web/src/features/clubs/components/ClubListGrid.tsx
@@ -20,6 +20,22 @@ const ClubListGridInner = styled.div`
   grid-template-columns: repeat(4, calc((100% - 48px) / 4));
   gap: 16px;
   padding-left: 24px;
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.xl}) {
+    grid-template-columns: repeat(4, calc((100% - 48px) / 4));
+  }
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
+    grid-template-columns: repeat(3, calc((100% - 48px) / 3));
+  }
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
+    grid-template-columns: repeat(2, calc((100% - 48px) / 2));
+  }
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.xs}) {
+    grid-template-columns: calc((100% - 48px));
+  }
 `;
 
 const ClubListGrid: React.FC<ClubListGridItemProps> = ({ clubList }) => (

--- a/packages/web/src/features/clubs/frames/ClubsPageMainFrame.tsx
+++ b/packages/web/src/features/clubs/frames/ClubsPageMainFrame.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import ClubsSectionFrame from "@sparcs-clubs/web/features/clubs/frames/ClubsSectionFrame";
 import { useGetClubsList } from "@sparcs-clubs/web/features/clubs/services/useGetClubsList";
 
@@ -11,6 +12,10 @@ const ClubsPageMainFrame: React.FC = () => {
   const { data, isLoading, isError } = useGetClubsList();
   return (
     <FlexWrapper direction="column" gap={60}>
+      <PageHead
+        items={[{ name: "동아리 목록", path: "/clubs" }]}
+        title="동아리 목록"
+      />
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper direction="column" gap={40}>
           {(data?.divisions ?? []).map(division => (


### PR DESCRIPTION
# 요약 \*

It closes #311 

- 동아리 목록 페이지 반응형 디자인 추가
- 관련 피그마: https://www.figma.com/design/gm0BeqvuY5dsA86XyRgEc3/%ED%95%99%EC%88%A0%ED%98%91%EB%A0%A5-02.-%5B%EB%8F%99%EC%97%B0%ED%98%91%EB%A0%A5%EC%82%AC%EC%97%85%5D?node-id=3973-64092&m=dev

# 스크린샷

<img width="881" alt="image" src="https://github.com/academic-relations/ar-002-clubs/assets/89931104/ac61567a-3798-4b59-b835-aa96dcac3619">


# 이후 Task \*

- 없음
