### PR TITLE
fix: update club detail page responsive design

### DIFF
--- a/packages/web/src/features/clubDetails/frames/ClubDetailMainFrame.tsx
+++ b/packages/web/src/features/clubDetails/frames/ClubDetailMainFrame.tsx
@@ -26,7 +26,7 @@ const MoreInfoWrapper = styled.div`
   flex-direction: row;
   gap: 60px;
 
-  @media (max-width: 1200px) {
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
     flex-direction: column;
   }
 `;


### PR DESCRIPTION
# 요약 \*

It closes #312 

# 이슈사항
다음과 같이 500 아래로 내려가면 카드 레이아웃이 깨지는데 괜찮나요? 
<img width="478" alt="image" src="https://github.com/academic-relations/ar-002-clubs/assets/89931104/0bfc12b7-7f82-4cb3-ba94-f8816fec33de">


# 이후 Task \*

- 없음
