### PR TITLE
fix background gradient uniform

### DIFF
--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -3,10 +3,10 @@
 :root {
   background: linear-gradient(
     180deg,
-    #eafafc 0%,
-    #ffffff 33.33%,
-    #ffffff 66.67%,
-    #ffffff 100%
+    #eafafc 0px,
+    #ffffff 100px,
+    #ffffff 200px,
+    #ffffff 300px
   );
   min-height: 100vh;
 }

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -1,13 +1,7 @@
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
 :root {
-  background: linear-gradient(
-    180deg,
-    #eafafc 0px,
-    #ffffff 339.67px,
-    #ffffff 679.33px,
-    #ffffff 1019px
-  );
+  background: linear-gradient(180deg, #eafafc 0px, #ffffff 339.67px);
   min-height: 100vh;
 }
 

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -4,9 +4,9 @@
   background: linear-gradient(
     180deg,
     #eafafc 0px,
-    #ffffff 100px,
-    #ffffff 200px,
-    #ffffff 300px
+    #ffffff 339.67px,
+    #ffffff 679.33px,
+    #ffffff 1019px
   );
   min-height: 100vh;
 }


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #150

Background Gradient 높이 설정이 상대적으로(%) 되어있어 피그마를 참고하여 px 단위로 바꾸었습니다.
피그마를 보면서 개발해본 게 처음이라 제가 맞게 했는지 확인해주시면 감사하겠습니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
상: 피그마 / 하: 개발
<img width="1441" alt="스크린샷 2024-07-13 오후 6 43 47" src="https://github.com/user-attachments/assets/61c89abd-cf42-4cda-b210-9bf54a17ee91">
<img width="1507" alt="스크린샷 2024-07-13 오후 6 44 03" src="https://github.com/user-attachments/assets/85bb7fb8-149a-4fb3-a79d-09b07bc4d7d6">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
