### PR TITLE
369 impl auth moudle interface and detail

### DIFF
--- a/packages/api/src/feature/auth/controller/auth.controller.ts
+++ b/packages/api/src/feature/auth/controller/auth.controller.ts
@@ -1,7 +1,25 @@
-import { Controller, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+  UsePipes,
+} from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
+import apiAut001, {
+  ApiAut001ResponseOk,
+} from "@sparcs-clubs/interface/api/auth/endpoint/apiAut001";
+import apiAut002, {
+  ApiAut002ResponseOk,
+} from "@sparcs-clubs/interface/api/auth/endpoint/apiAut002";
+import apiAut003, {
+  ApiAut003ResponseOk,
+} from "@sparcs-clubs/interface/api/auth/endpoint/apiAut003";
 import { Response } from "express";
 
+import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
 import logger from "@sparcs-clubs/api/common/util/logger";
 
 import {
@@ -14,21 +32,35 @@ import { AuthService } from "../service/auth.service";
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Post("/auth/signin")
-  // @UsePipes(new ZodPipe(apiAth001))
-  async postAuthSignin(@Res() res: Response) {
+  @Post("/auth/sign-in")
+  @UsePipes(new ZodPipe(apiAut001))
+  async postAuthSignin(
+    @Res() res: Response,
+  ): Promise<Response<ApiAut001ResponseOk>> {
     const token = await this.authService.postAuthSignin();
     res.setHeader("Set-Cookie", `refreshToken=${token.refreshToken}`);
-    res.json({ accessToken: token.accessToken });
+    return res.json({ accessToken: token.accessToken });
   }
 
   @UseGuards(AuthGuard("refresh"))
   @Post("/auth/refresh")
-  getAuthRefresh(@Req() req: Request & UserRefreshTokenPayload) {
-    logger.debug(req.user);
-    // return this.authService.postAuthRefresh({ user: req.user });
+  @UsePipes(new ZodPipe(apiAut002))
+  async postAuthRefresh(
+    @Req() req: Request & UserRefreshTokenPayload,
+  ): Promise<ApiAut002ResponseOk> {
+    return this.authService.postAuthRefresh(req.user);
   }
 
+  @UseGuards(AuthGuard("access"))
+  @Post("/auth/sign-out")
+  @UsePipes(new ZodPipe(apiAut003))
+  postAuthSignout(
+    @Req() req: Request & UserRefreshTokenPayload,
+  ): Promise<ApiAut003ResponseOk> {
+    return this.authService.postAuthSignout(req.user);
+  }
+
+  // test용 API, 실제 사용하지 않음
   @UseGuards(AuthGuard("access"))
   @Get("/auth/test")
   test(@Req() req: Request & UserAccessTokenPayload) {

--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -5,7 +5,9 @@ import { MySql2Database } from "drizzle-orm/mysql2";
 import { takeUnique } from "@sparcs-clubs/api/common/util/util";
 import { SemesterD } from "@sparcs-clubs/api/drizzle/schema/club.schema";
 import {
+  Employee,
   Executive,
+  Professor,
   Student,
   StudentT,
   User,
@@ -24,7 +26,34 @@ export class AuthRepository {
     name: string,
     type: string,
     department: string,
-  ) {
+  ): Promise<{
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+    undergraduate?: {
+      id: number;
+      number: number;
+    };
+    master?: {
+      id: number;
+      number: number;
+    };
+    doctor?: {
+      id: number;
+      number: number;
+    };
+    executive?: {
+      id: number;
+      studentId: number;
+    };
+    professor?: {
+      id: number;
+    };
+    employee?: {
+      id: number;
+    };
+  }> {
     // User table에 해당 email이 있는지 확인 후 upsert
     let user = await this.db
       .select()
@@ -71,11 +100,9 @@ export class AuthRepository {
       };
       professor?: {
         id: number;
-        email: string;
       };
       employee?: {
         id: number;
-        email: string;
       };
     } = {
       id: user.id,
@@ -243,6 +270,142 @@ export class AuthRepository {
     // professor_t에서 해당 professor_id이 있는지 확인 후 upsert
     // type이 "Employee"를 포함하는 경우 Employee table에서 해당 email이 있는지 확인 후 upsert
     // employee_t에서 해당 employee_id이 있는지 확인 후 upsert
+
+    return result;
+  }
+
+  async findUserById(id: number): Promise<{
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+    undergraduate?: {
+      id: number;
+      number: number;
+    };
+    master?: {
+      id: number;
+      number: number;
+    };
+    doctor?: {
+      id: number;
+      number: number;
+    };
+    executive?: {
+      id: number;
+      studentId: number;
+    };
+    professor?: {
+      id: number;
+      email: string;
+    };
+    employee?: {
+      id: number;
+      email: string;
+    };
+  }> {
+    const user = await this.db
+      .select()
+      .from(User)
+      .where(eq(User.id, id))
+      .then(takeUnique);
+
+    const result: {
+      id: number;
+      sid: string;
+      name: string;
+      email: string;
+      undergraduate?: {
+        id: number;
+        number: number;
+      };
+      master?: {
+        id: number;
+        number: number;
+      };
+      doctor?: {
+        id: number;
+        number: number;
+      };
+      executive?: {
+        id: number;
+        studentId: number;
+      };
+      professor?: {
+        id: number;
+        email: string;
+      };
+      employee?: {
+        id: number;
+        email: string;
+      };
+    } = {
+      id: user.id,
+      sid: user.sid,
+      name: user.name,
+      email: user.email,
+    };
+
+    const students = this.db
+      .select()
+      .from(Student)
+      .where(eq(Student.userId, id));
+
+    // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/no-shadow
+    for (const student of await students) {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      let studentEnum = 3;
+      if (student.number % 10000 < 2000) studentEnum = 1;
+      else if (student.number % 10000 < 6000) studentEnum = 2;
+      else if (student.number % 10000 < 7000) studentEnum = 1;
+
+      if (studentEnum === 1) {
+        result.undergraduate = { id: student.id, number: student.number };
+      } else if (studentEnum === 2) {
+        result.master = { id: student.id, number: student.number };
+      } else if (studentEnum === 3) {
+        result.doctor = { id: student.id, number: student.number };
+      }
+    }
+
+    const executive = await this.db
+      .select()
+      .from(Executive)
+      .where(eq(Executive.userId, id))
+      .then(takeUnique);
+
+    if (executive) {
+      result.executive = {
+        id: executive.id,
+        studentId: executive.studentId,
+      };
+    }
+
+    const professor = await this.db
+      .select()
+      .from(Professor)
+      .where(eq(Professor.userId, id))
+      .then(takeUnique);
+
+    if (professor) {
+      result.professor = {
+        id: professor.id,
+        email: professor.email,
+      };
+    }
+
+    const employee = await this.db
+      .select()
+      .from(Employee)
+      .where(eq(Employee.userId, id))
+      .then(takeUnique);
+
+    if (employee) {
+      result.employee = {
+        id: employee.id,
+        email: employee.email,
+      };
+    }
 
     return result;
   }

--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -61,14 +61,12 @@ export class AuthRepository {
       .where(eq(User.email, email))
       .then(takeUnique);
     if (user) {
-      // eslint-disable-next-line prefer-destructuring
       await this.db
         .update(User)
         .set({ name })
         .where(eq(User.id, user.id))
         .execute();
     } else {
-      // eslint-disable-next-line prefer-destructuring
       await this.db.insert(User).values({ sid, name, email }).execute();
     }
     user = await this.db
@@ -114,21 +112,18 @@ export class AuthRepository {
     // type이 "Student"인 경우 student table에서 해당 studentNumber이 있는지 확인 후 upsert
     // student_t에서 이번 학기의 해당 student_id이 있는지 확인 후 upsert
     if (type === "Student") {
-      // eslint-disable-next-line prefer-destructuring
       let student = await this.db
         .select()
         .from(Student)
         .where(eq(Student.number, parseInt(studentNumber)))
         .then(takeUnique);
       if (student) {
-        // eslint-disable-next-line prefer-destructuring
         await this.db
           .update(Student)
           .set({ userId: user.id, name })
           .where(eq(Student.id, student.id))
           .execute();
       } else {
-        // eslint-disable-next-line prefer-destructuring
         await this.db
           .insert(Student)
           .values({
@@ -213,7 +208,6 @@ export class AuthRepository {
         .then(takeUnique);
 
       if (studentT) {
-        // eslint-disable-next-line prefer-destructuring
         await this.db
           .update(StudentT)
           .set({ department: parseInt(department) })
@@ -224,7 +218,6 @@ export class AuthRepository {
             ),
           );
       } else {
-        // eslint-disable-next-line prefer-destructuring
         await this.db
           .insert(StudentT)
           .values({
@@ -353,7 +346,6 @@ export class AuthRepository {
 
     // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/no-shadow
     for (const student of await students) {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       let studentEnum = 3;
       if (student.number % 10000 < 2000) studentEnum = 1;
       else if (student.number % 10000 < 6000) studentEnum = 2;

--- a/packages/api/src/feature/auth/service/auth.service.ts
+++ b/packages/api/src/feature/auth/service/auth.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from "@nestjs/common";
 
 import { JwtService } from "@nestjs/jwt";
 
+import { ApiAut002ResponseOk } from "@sparcs-clubs/interface/api/auth/endpoint/apiAut002";
+import { ApiAut003ResponseOk } from "@sparcs-clubs/interface/api/auth/endpoint/apiAut003";
+
 import { AuthRepository } from "../repository/auth.repository";
 
 @Injectable()
@@ -29,8 +32,8 @@ export class AuthService {
       department,
     );
 
-    const accessToken = this.getAccessToken({ user });
-    const refreshToken = this.getRefreshToken({ user });
+    const accessToken = this.getAccessToken(user);
+    const refreshToken = this.getRefreshToken(user);
 
     return {
       accessToken,
@@ -38,8 +41,66 @@ export class AuthService {
     };
   }
 
-  getAccessToken({ user }): { [key: string]: string } {
-    const accessToken: { [key: string]: string } = {};
+  async postAuthRefresh(_user: {
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+  }): Promise<ApiAut002ResponseOk> {
+    const user = await this.authRepository.findUserById(_user.id);
+    const accessToken = this.getAccessToken(user);
+
+    return {
+      accessToken,
+    };
+  }
+
+  // TODO: 로직 수정 필요
+  async postAuthSignout(_user: {
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+  }): Promise<ApiAut003ResponseOk> {
+    return null;
+  }
+
+  getAccessToken(user: {
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+    undergraduate?: {
+      id: number;
+      number: number;
+    };
+    master?: {
+      id: number;
+      number: number;
+    };
+    doctor?: {
+      id: number;
+      number: number;
+    };
+    executive?: {
+      id: number;
+      studentId: number;
+    };
+    professor?: {
+      id: number;
+    };
+    employee?: {
+      id: number;
+    };
+  }) {
+    const accessToken: {
+      undergraduate?: string;
+      master?: string;
+      doctor?: string;
+      executive?: string;
+      professor?: string;
+      employee?: string;
+    } = {};
 
     if (user.undergraduate) {
       accessToken.undergraduate = this.jwtService.sign(
@@ -150,7 +211,12 @@ export class AuthService {
     return accessToken;
   }
 
-  getRefreshToken({ user }) {
+  getRefreshToken(user: {
+    id: number;
+    sid: string;
+    name: string;
+    email: string;
+  }) {
     const refreshToken = this.jwtService.sign(
       {
         email: user.email,

--- a/packages/interface/src/api/auth/endpoint/apiAut001.ts
+++ b/packages/interface/src/api/auth/endpoint/apiAut001.ts
@@ -16,14 +16,14 @@ const requestQuery = z.object({});
 const requestBody = z.object({});
 
 const responseBodyMap = {
-  [HttpStatusCode.Ok]: z.object({
+  [HttpStatusCode.Created]: z.object({
     accessToken: z.object({
-      undergraduate: z.string().optional(),
-      master: z.string().optional(),
-      doctor: z.string().optional(),
-      executive: z.string().optional(),
-      professor: z.string().optional(),
-      employee: z.string().optional(),
+      undergraduate: z.coerce.string().optional(),
+      master: z.coerce.string().optional(),
+      doctor: z.coerce.string().optional(),
+      executive: z.coerce.string().optional(),
+      professor: z.coerce.string().optional(),
+      employee: z.coerce.string().optional(),
     }),
   }),
 };
@@ -43,7 +43,7 @@ const apiAut001 = {
 type ApiAut001RequestParam = z.infer<typeof apiAut001.requestParam>;
 type ApiAut001RequestQuery = z.infer<typeof apiAut001.requestQuery>;
 type ApiAut001RequestBody = z.infer<typeof apiAut001.requestBody>;
-type ApiAut001ResponseOk = z.infer<(typeof apiAut001.responseBodyMap)[200]>;
+type ApiAut001ResponseOk = z.infer<(typeof apiAut001.responseBodyMap)[201]>;
 
 export default apiAut001;
 

--- a/packages/interface/src/api/auth/endpoint/apiAut001.ts
+++ b/packages/interface/src/api/auth/endpoint/apiAut001.ts
@@ -1,0 +1,55 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+/**
+ * @version v0.1
+ * @description 로그인을 시도합니다
+ */
+
+const url = () => `/auth/sign-in`;
+const method = "POST";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({
+    accessToken: z.object({
+      undergraduate: z.string().optional(),
+      master: z.string().optional(),
+      doctor: z.string().optional(),
+      executive: z.string().optional(),
+      professor: z.string().optional(),
+      employee: z.string().optional(),
+    }),
+  }),
+};
+
+const responseErrorMap = {};
+
+const apiAut001 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiAut001RequestParam = z.infer<typeof apiAut001.requestParam>;
+type ApiAut001RequestQuery = z.infer<typeof apiAut001.requestQuery>;
+type ApiAut001RequestBody = z.infer<typeof apiAut001.requestBody>;
+type ApiAut001ResponseOk = z.infer<(typeof apiAut001.responseBodyMap)[200]>;
+
+export default apiAut001;
+
+export type {
+  ApiAut001RequestParam,
+  ApiAut001RequestQuery,
+  ApiAut001RequestBody,
+  ApiAut001ResponseOk,
+};

--- a/packages/interface/src/api/auth/endpoint/apiAut002.ts
+++ b/packages/interface/src/api/auth/endpoint/apiAut002.ts
@@ -18,12 +18,12 @@ const requestBody = z.object({});
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
     accessToken: z.object({
-      undergraduate: z.string().optional(),
-      master: z.string().optional(),
-      doctor: z.string().optional(),
-      executive: z.string().optional(),
-      professor: z.string().optional(),
-      employee: z.string().optional(),
+      undergraduate: z.coerce.string().optional(),
+      master: z.coerce.string().optional(),
+      doctor: z.coerce.string().optional(),
+      executive: z.coerce.string().optional(),
+      professor: z.coerce.string().optional(),
+      employee: z.coerce.string().optional(),
     }),
   }),
 };

--- a/packages/interface/src/api/auth/endpoint/apiAut002.ts
+++ b/packages/interface/src/api/auth/endpoint/apiAut002.ts
@@ -1,0 +1,55 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+/**
+ * @version v0.1
+ * @description 만료된 access token을 재발급 합니다
+ */
+
+const url = () => `/auth/refresh`;
+const method = "POST";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({
+    accessToken: z.object({
+      undergraduate: z.string().optional(),
+      master: z.string().optional(),
+      doctor: z.string().optional(),
+      executive: z.string().optional(),
+      professor: z.string().optional(),
+      employee: z.string().optional(),
+    }),
+  }),
+};
+
+const responseErrorMap = {};
+
+const apiAut002 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiAut002RequestParam = z.infer<typeof apiAut002.requestParam>;
+type ApiAut002RequestQuery = z.infer<typeof apiAut002.requestQuery>;
+type ApiAut002RequestBody = z.infer<typeof apiAut002.requestBody>;
+type ApiAut002ResponseOk = z.infer<(typeof apiAut002.responseBodyMap)[200]>;
+
+export default apiAut002;
+
+export type {
+  ApiAut002RequestParam,
+  ApiAut002RequestQuery,
+  ApiAut002RequestBody,
+  ApiAut002ResponseOk,
+};

--- a/packages/interface/src/api/auth/endpoint/apiAut003.ts
+++ b/packages/interface/src/api/auth/endpoint/apiAut003.ts
@@ -1,0 +1,46 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+/**
+ * @version v0.1
+ * @description
+ */
+
+const url = () => `/auth/sign-out`;
+const method = "POST";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({}),
+};
+
+const responseErrorMap = {};
+
+const apiAut003 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiAut003RequestParam = z.infer<typeof apiAut003.requestParam>;
+type ApiAut003RequestQuery = z.infer<typeof apiAut003.requestQuery>;
+type ApiAut003RequestBody = z.infer<typeof apiAut003.requestBody>;
+type ApiAut003ResponseOk = z.infer<(typeof apiAut003.responseBodyMap)[200]>;
+
+export default apiAut003;
+
+export type {
+  ApiAut003RequestParam,
+  ApiAut003RequestQuery,
+  ApiAut003RequestBody,
+  ApiAut003ResponseOk,
+};


### PR DESCRIPTION
# 요약 \*
- aut-001, aut-002, aut-003 구현
- postRefresh method 작동하도록 수정 구현

# 스크린샷
- POST /auth/sign-in으로 요청을 보내 로그인한다
- POST /auth/refresh로 요청을 보내 access token을 재발급한다
- "Authorization":"Bearer [accessToken]"을 헤더에 포함시킨 후 GET /auth/test에 요청을 보내 인증에 문제 없는지 확인한다

# 이후 Task \*
@Jiuuung 
- [ ]  expire 디비 조회, 추가 로직 필요
- [ ]  refesh token을 http only cookie로 발급되도록 수정
- [ ]  데코레이터 만들기 @getProfileStudent
- [ ]  집행부원 토큰 발급시 executive_t 테이블을 조회하여 현재 기간에 해당하는 집행부원만 토큰이 발급되도록 해야함
- [ ]  professor, employee에 대해서는 accesstoken 발급 로직이 없음
@wjeongchoi 
- [ ] 프론트에서 로그인 버튼 클릭시 aut-001 호출해 access token을 로컬 스토리지에 저장
- [ ] 로컬 스토리지에 저장한 토큰 중 프로필 전환에 따라 토큰 하나를 모든 요청 시 header에 Bearer 로 포함시켜 보내기
- [ ] 만약 백에서 보낸 요청이 401 에러를 반환할 경우 aut-002 호출
- [ ] 로그아웃 버튼을 누르면 aut-003을 호출하고, 쿠키의 refresh token, 로컬 스토리지의 모든 access token 삭제
