### PR TITLE
Add advisory professor approval column

### DIFF
--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -4,6 +4,7 @@ import { PromotionalPrintingOrderStatusEnum } from "@sparcs-clubs/interface/comm
 import { RentalOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/rental.enum";
 
 import {
+  ActivityProfessorApprovalEnum,
   ActivityStatusEnum,
   ActivityTypeEnum,
   MemberStatusEnum,
@@ -89,6 +90,14 @@ const ApplyTagList: {
   [ActivityStatusEnum.Rejected]: { text: "신청 반려", color: "RED" },
 };
 
+const ProfessorApprovalTagList: {
+  [key in ActivityProfessorApprovalEnum]: StatusDetail;
+} = {
+  [ActivityProfessorApprovalEnum.Requested]: { text: "대기", color: "GRAY" },
+  [ActivityProfessorApprovalEnum.Approved]: { text: "승인", color: "GREEN" },
+  [ActivityProfessorApprovalEnum.Denied]: { text: "반려", color: "RED" },
+};
+
 const ActTypeTagList: {
   [key in ActivityTypeEnum]: StatusDetail;
 } = {
@@ -112,5 +121,6 @@ export {
   RntTagList,
   MemTagList,
   ApplyTagList,
+  ProfessorApprovalTagList,
   ActTypeTagList,
 };

--- a/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
@@ -23,7 +23,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
+    professorApproval: "완료",
   },
   {
     status: "신청 반려",
@@ -31,7 +31,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
+    professorApproval: "반려",
   },
   {
     status: "승인 완료",
@@ -39,7 +39,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
+    professorApproval: "완료",
   },
   {
     status: "승인 완료",
@@ -47,7 +47,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하지 않는 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
+    professorApproval: "완료",
   },
 ];
 

--- a/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
@@ -7,6 +7,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     status: "신청 완료",
@@ -14,6 +15,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     status: "신청 완료",
@@ -21,6 +23,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     status: "신청 반려",
@@ -28,6 +31,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     status: "승인 완료",
@@ -35,6 +39,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     status: "승인 완료",
@@ -42,6 +47,7 @@ export const mockNewActivityData = [
     category: "동아리 성격에 합치하지 않는 활동",
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
 ];
 

--- a/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
@@ -35,6 +35,15 @@ const getStatusTagColor = (status: string): TagColor => {
   }
 };
 
+const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
+  switch (professorApproval) {
+    case "대기":
+      return "GRAY";
+    default:
+      return "GRAY";
+  }
+};
+
 const getCategoryTagColor = (category: string): TagColor => {
   switch (category) {
     case "동아리 성격에 합치하는 내부 활동":
@@ -55,7 +64,17 @@ const columns = [
     cell: info => (
       <Tag color={getStatusTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
-    size: 15,
+    size: 8,
+  }),
+  columnHelper.accessor("professorApproval", {
+    id: "professorApproval",
+    header: "지도교수",
+    cell: info => (
+      <Tag color={getProfessorApprovalTagColor(info.getValue())}>
+        {info.getValue()}
+      </Tag>
+    ),
+    size: 8,
   }),
   columnHelper.accessor("activity", {
     id: "activity",

--- a/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
@@ -39,6 +39,10 @@ const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
   switch (professorApproval) {
     case "대기":
       return "GRAY";
+    case "완료":
+      return "GREEN";
+    case "반려":
+      return "RED";
     default:
       return "GRAY";
   }

--- a/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
+++ b/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
@@ -7,6 +7,7 @@ export interface PastActivityReport {
 
 export interface NewActivityReport extends PastActivityReport {
   status: string;
+  professorApproval: string;
 }
 
 export interface Participant {

--- a/packages/web/src/features/manage-club/component/ActivityReportTable.tsx
+++ b/packages/web/src/features/manage-club/component/ActivityReportTable.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-table";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
-import Tag from "@sparcs-clubs/web/common/components/Tag";
+import Tag, { type TagColor } from "@sparcs-clubs/web/common/components/Tag";
 import {
   ActTypeTagList,
   ApplyTagList,
@@ -21,6 +21,15 @@ interface ActivityTableProps {
   activityList: Activity[];
 }
 
+const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
+  switch (professorApproval) {
+    case "대기":
+      return "GRAY";
+    default:
+      return "GRAY";
+  }
+};
+
 const columnHelper = createColumnHelper<Activity>();
 
 const columns = [
@@ -30,7 +39,16 @@ const columns = [
       const { color, text } = getTagDetail(info.getValue(), ApplyTagList);
       return <Tag color={color}>{text}</Tag>;
     },
-    size: 10,
+    size: 8,
+  }),
+  columnHelper.accessor("professorApproval", {
+    header: "지도교수",
+    cell: info => (
+      <Tag color={getProfessorApprovalTagColor(info.getValue())}>
+        {info.getValue()}
+      </Tag>
+    ),
+    size: 8,
   }),
   columnHelper.accessor("name", {
     header: "활동명",

--- a/packages/web/src/features/manage-club/component/ActivityReportTable.tsx
+++ b/packages/web/src/features/manage-club/component/ActivityReportTable.tsx
@@ -7,10 +7,11 @@ import {
 } from "@tanstack/react-table";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
-import Tag, { type TagColor } from "@sparcs-clubs/web/common/components/Tag";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
 import {
   ActTypeTagList,
   ApplyTagList,
+  ProfessorApprovalTagList,
 } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formateDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
@@ -20,15 +21,6 @@ import { type Activity } from "../service/_mock/mockManageClub";
 interface ActivityTableProps {
   activityList: Activity[];
 }
-
-const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
-  switch (professorApproval) {
-    case "대기":
-      return "GRAY";
-    default:
-      return "GRAY";
-  }
-};
 
 const columnHelper = createColumnHelper<Activity>();
 
@@ -43,12 +35,14 @@ const columns = [
   }),
   columnHelper.accessor("professorApproval", {
     header: "지도교수",
-    cell: info => (
-      <Tag color={getProfessorApprovalTagColor(info.getValue())}>
-        {info.getValue()}
-      </Tag>
-    ),
-    size: 8,
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        ProfessorApprovalTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 10,
   }),
   columnHelper.accessor("name", {
     header: "활동명",

--- a/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
@@ -253,7 +253,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 1,
     status: 1,
-    professorApproval: 1,
+    professorApproval: ActivityProfessorApprovalEnum.Requested,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
@@ -262,7 +262,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 2,
     status: 2,
-    professorApproval: 1,
+    professorApproval: ActivityProfessorApprovalEnum.Requested,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
@@ -271,7 +271,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 3,
     status: 2,
-    professorApproval: 2,
+    professorApproval: ActivityProfessorApprovalEnum.Approved,
     name: "개발개발한 어떠한 활동",
     type: 2,
     startDate: new Date("2024-03-11"),
@@ -280,7 +280,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 4,
     status: 4,
-    professorApproval: 3,
+    professorApproval: ActivityProfessorApprovalEnum.Denied,
     name: "개발개발한 어떠한 활동",
     type: 2,
     startDate: new Date("2024-03-11"),
@@ -289,7 +289,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 5,
     status: 3,
-    professorApproval: 2,
+    professorApproval: ActivityProfessorApprovalEnum.Approved,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
@@ -298,7 +298,7 @@ const mockupManageReport: Activity[] = [
   {
     id: 6,
     status: 3,
-    professorApproval: 2,
+    professorApproval: ActivityProfessorApprovalEnum.Approved,
     name: "2024년도 봄학기 MT",
     type: 3,
     startDate: new Date("2024-03-11"),

--- a/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
@@ -17,6 +17,7 @@ import type { ApiRnt003ResponseOK } from "@sparcs-clubs/interface/api/rental/end
 export interface Activity {
   id: number;
   status: number;
+  professorApproval: string;
   name: string;
   type: number;
   startDate: Date;
@@ -250,6 +251,7 @@ const mockupManageReport: Activity[] = [
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     id: 2,
@@ -258,6 +260,7 @@ const mockupManageReport: Activity[] = [
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     id: 3,
@@ -266,6 +269,7 @@ const mockupManageReport: Activity[] = [
     type: 2,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     id: 4,
@@ -274,6 +278,7 @@ const mockupManageReport: Activity[] = [
     type: 2,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     id: 5,
@@ -282,6 +287,7 @@ const mockupManageReport: Activity[] = [
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
   {
     id: 6,
@@ -290,6 +296,7 @@ const mockupManageReport: Activity[] = [
     type: 3,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
+    professorApproval: "대기",
   },
 ];
 

--- a/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/service/_mock/mockManageClub.ts
@@ -17,7 +17,7 @@ import type { ApiRnt003ResponseOK } from "@sparcs-clubs/interface/api/rental/end
 export interface Activity {
   id: number;
   status: number;
-  professorApproval: string;
+  professorApproval: number;
   name: string;
   type: number;
   startDate: Date;
@@ -49,6 +49,12 @@ export enum ActivityStatusEnum {
   Applied, // 신청
   Approved, // 승인
   Rejected, // 반려
+}
+
+export enum ActivityProfessorApprovalEnum {
+  Requested = 1, // 대기
+  Approved, // 완료
+  Denied, // 반려
 }
 
 export enum ActivityTypeEnum {
@@ -247,56 +253,56 @@ const mockupManageReport: Activity[] = [
   {
     id: 1,
     status: 1,
+    professorApproval: 1,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
   {
     id: 2,
     status: 2,
+    professorApproval: 1,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
   {
     id: 3,
     status: 2,
+    professorApproval: 2,
     name: "개발개발한 어떠한 활동",
     type: 2,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
   {
     id: 4,
     status: 4,
+    professorApproval: 3,
     name: "개발개발한 어떠한 활동",
     type: 2,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
   {
     id: 5,
     status: 3,
+    professorApproval: 2,
     name: "개발개발한 어떠한 활동",
     type: 1,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
   {
     id: 6,
     status: 3,
+    professorApproval: 2,
     name: "2024년도 봄학기 MT",
     type: 3,
     startDate: new Date("2024-03-11"),
     endDate: new Date("2024-03-18"),
-    professorApproval: "대기",
   },
 ];
 


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #322 

# 스크린샷

![image](https://github.com/user-attachments/assets/351393b3-d93d-4a43-8a6f-4c7101f4c77c)

![image](https://github.com/user-attachments/assets/a1cf95e9-b48e-4cd5-88d0-56a2a1441641)



# 이후 Task \*

- /manage-club 페이지도 /manage-club/activity-report와 똑같이 고치면 되겠다 생각했는데 통일이 안되어 있네요.. 같은 내용은 통일하면 좋을 것 같아요!

세부 설명: /manage-club 페이지에는 status가 숫자와 enum으로 구현되어 있고 /manage-club/activity-report 페이지에는 문자열로 구현되어 있음. 일단은 각자 방식에 맞춰서 professor approval 구현해 넣었습니당
