### PR TITLE
add activity report section in register club

### DIFF
--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -30,9 +30,7 @@ const ModalContainer = styled.div`
   justify-content: center;
   align-items: center;
 
-  height: max-content;
-  max-width: 600px;
-  max-height: 300px;
+  max-height: 90%;
 
   background-color: ${({ theme }) => theme.colors.WHITE};
   border-radius: ${({ theme }) => theme.round.md};

--- a/packages/web/src/features/register-club/components/ActivityReportFrame.tsx
+++ b/packages/web/src/features/register-club/components/ActivityReportFrame.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import { overlay } from "overlay-kit";
+import styled from "styled-components";
+
+import Button from "@sparcs-clubs/web/common/components/Button";
+import Card from "@sparcs-clubs/web/common/components/Card";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { mockPastActivityData } from "@sparcs-clubs/web/features/manage-club/activity-report/_mock/mock";
+import PastActivityReportList from "@sparcs-clubs/web/features/manage-club/activity-report/components/PastActivityReportList";
+
+import CreateActivityReportModal from "./_atomic/CreateActivityReportModal";
+
+const OptionOuter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  align-self: stretch;
+`;
+
+const ActivityReportFrame: React.FC = () => {
+  const openCreateActivityReportModal = () => {
+    overlay.open(({ isOpen, close }) => (
+      <CreateActivityReportModal isOpen={isOpen} close={close} />
+    ));
+  };
+
+  return (
+    <FlexWrapper direction="column" gap={40}>
+      <SectionTitle>가등록 / 등록 취소 기간 활동 보고서</SectionTitle>
+      <Card outline gap={32} style={{ marginLeft: 20 }}>
+        <OptionOuter>
+          <Typography
+            fs={14}
+            fw="REGULAR"
+            lh={20}
+            color="GRAY.300"
+            ff="PRETENDARD"
+          >
+            활동 보고서는 최대 20개까지 작성 가능합니다
+          </Typography>
+          <Button type="default" onClick={openCreateActivityReportModal}>
+            + 활동 보고서 작성
+          </Button>
+        </OptionOuter>
+        <PastActivityReportList data={mockPastActivityData} />
+      </Card>
+    </FlexWrapper>
+  );
+};
+
+export default ActivityReportFrame;

--- a/packages/web/src/features/register-club/components/_atomic/CreateActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/_atomic/CreateActivityReportModal.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+
+import styled from "styled-components";
+
+import Button from "@sparcs-clubs/web/common/components/Button";
+import FileUpload from "@sparcs-clubs/web/common/components/FileUpload";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import Select from "@sparcs-clubs/web/common/components/Select";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { mockParticipantData } from "@sparcs-clubs/web/features/manage-club/activity-report/_mock/mock";
+import SelectParticipant from "@sparcs-clubs/web/features/manage-club/activity-report/components/SelectParticipant";
+
+interface CreateActivityReportModalProps {
+  isOpen: boolean;
+  close: VoidFunction;
+}
+
+const HorizontalPlacer = styled.div`
+  display: flex;
+  gap: 32px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
+  isOpen,
+  close,
+}) => (
+  <Modal isOpen={isOpen}>
+    <FlexWrapper direction="column" gap={32}>
+      <TextInput label="활동명" placeholder="활동명을 입력해주세요" />
+      <HorizontalPlacer>
+        <Select
+          label="활동 분류"
+          items={[
+            {
+              value: "internal",
+              label: "동아리 성격에 합치하는 내부 활동",
+              selectable: true,
+            },
+            {
+              value: "external",
+              label: "동아리 성격에 합치하는 외부 활동",
+              selectable: true,
+            },
+            {
+              value: "none",
+              label: "동아리 성격에 합치하지 않는 활동",
+              selectable: true,
+            },
+          ]}
+        />
+        {/* <DateRangeInput label="활동 기간" /> */}
+      </HorizontalPlacer>
+      <TextInput label="활동 장소" placeholder="활동 장소를 입력해주세요" />
+      <TextInput label="활동 목적" placeholder="활동 목적을 입력해주세요" />
+      <TextInput
+        area
+        label="활동 내용"
+        placeholder="활동 내용을 입력해주세요"
+      />
+      <FlexWrapper direction="column" gap={4}>
+        <Typography fs={16} lh={20} fw="MEDIUM" color="BLACK">
+          활동 인원
+        </Typography>
+        <SelectParticipant data={mockParticipantData} />
+      </FlexWrapper>
+      <FlexWrapper direction="column" gap={4}>
+        <Typography fs={16} lh={20} fw="MEDIUM" color="BLACK">
+          활동 증빙
+        </Typography>
+        <TextInput
+          area
+          placeholder="(선택) 활동 증빙에 대해서 작성하고 싶은 것이 있다면 입력해주세요"
+        />
+        <FileUpload />
+      </FlexWrapper>
+      <ButtonWrapper>
+        <Button type="outlined" onClick={close}>
+          취소
+        </Button>
+        <Button
+          onClick={() => {
+            // TODO. 저장 로직 추가
+            close();
+          }}
+        >
+          저장
+        </Button>
+      </ButtonWrapper>
+    </FlexWrapper>
+  </Modal>
+);
+
+export default CreateActivityReportModal;

--- a/packages/web/src/features/register-club/frame/RegisterClubMainFrame.tsx
+++ b/packages/web/src/features/register-club/frame/RegisterClubMainFrame.tsx
@@ -11,6 +11,7 @@ import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
+import ActivityReportFrame from "../components/ActivityReportFrame";
 import AdvancedInformFrame from "../components/AdvancedInformFrame";
 import BasicInformFrame from "../components/BasicInformFrame";
 import ClubRulesFrame from "../components/ClubRulesFrame";
@@ -61,6 +62,7 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
       <Info text="현재는 2024년 봄학기 동아리 등록 기간입니다 (신청 마감 : 2024년 3월 10일 23:59)" />
       <BasicInformFrame type={type} />
       <AdvancedInformFrame type={type} />
+      {type !== RegisterClubType.renewal && <ActivityReportFrame />}
       <ClubRulesFrame isProvisional={type === RegisterClubType.provisional} />
       <ButtonWrapper>
         <Button


### PR DESCRIPTION
# 요약 \*

It closes #416 

# 논의사항
1. Modal max-height , max-width가 원래 각각 600, 300 이었는데 이번에 디자인 보니까 더 늘려야 할 것 같아서 일단 width 는 아예 풀고 height는 90% 로 수정했습니다. 구체적으로 정해진 수치가 있다면 알려주세요!
2. Table 컴포넌트에 onSelectRow(?) 요런 행 클릭 했을 때 실행할 수 있는 함수를 prop으로 받아야 할 것 같은데 어떻게 생각하시나요? 일단 테이블 클릭 시 나와야 하는 모달은 아직 구현 안 하고 있습니다. 
3. 상세모달에서 수정 버튼 클릭하면 생성모달이 다시 띄워지는걸까요?


# 스크린샷
<img width="1245" alt="image" src="https://github.com/user-attachments/assets/95dbfaec-69e9-40dc-9e67-73ec5c923b45">
<img width="693" alt="image" src="https://github.com/user-attachments/assets/cc5c22b8-fdf5-4f8c-8242-cb3c8861ac28">
<img width="697" alt="image" src="https://github.com/user-attachments/assets/0071b251-8775-4de5-9242-de9032d1da44">


# 이후 Task \*

- 없음
