### PR TITLE
Impl /register-club responsive design

### DIFF
--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -15,8 +15,10 @@ import ClubButton from "@sparcs-clubs/web/features/register-club/components/Club
 const ClubButtonWrapper = styled.div`
   display: flex;
   align-items: center;
-  gap: 20px;
   align-self: stretch;
+  border: 1px solid black;
+
+  gap: 20px;
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
     flex-direction: column;
   }
@@ -44,7 +46,11 @@ const RegisterClub = () => {
   };
 
   return (
-    <FlexWrapper direction="column" gap={60}>
+    <FlexWrapper
+      direction="column"
+      gap={60}
+      style={{ alignItems: "flex-end", alignSelf: "stretch" }}
+    >
       <PageHead
         items={[{ name: "동아리 등록", path: "/register-club" }]}
         title="동아리 등록"

--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -16,8 +16,7 @@ const ClubButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   align-self: stretch;
-  border: 1px solid black;
-
+  flex: 1 0 0;
   gap: 20px;
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
     flex-direction: column;

--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -14,11 +14,12 @@ import ClubButton from "@sparcs-clubs/web/features/register-club/components/Club
 
 const ClubButtonWrapper = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   gap: 20px;
   align-self: stretch;
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
+    flex-direction: column;
+  }
 `;
 
 const RegisterClub = () => {

--- a/packages/web/src/features/register-club/components/ClubButton.tsx
+++ b/packages/web/src/features/register-club/components/ClubButton.tsx
@@ -35,6 +35,7 @@ const ClubButton: React.FC<ClubButtonProps> = ({
       border: selected
         ? `1px solid ${colors.PRIMARY}`
         : `1px solid ${colors.GRAY[200]}`,
+      flex: "1 0 0",
     }}
   >
     <Typography fw="MEDIUM" fs={20} lh={24}>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #497

- page.tsx 반응형 및 등록 신청 버튼 위치 구현 완료
- ClubButton이 화면 사이즈에 따라 동적으로 움직여서 ClubButton끼리의 gap이 20px이 되도록 유지되어야 하는데, 그러지 못하여 gap이 달라지는 문제가 있었습니다. 이는 ClubButton.tsx의 Card 컴포넌트에 `style={{flex: 1 0 0}} `을 추가하여 해결했습니다.

# 스크린샷

xs
<img width="393" alt="스크린샷 2024-07-30 오전 2 02 13" src="https://github.com/user-attachments/assets/c55b2205-8e55-4e6e-801d-d77262e8486e">
sm
<img width="719" alt="스크린샷 2024-07-30 오전 2 03 04" src="https://github.com/user-attachments/assets/7b4a2ff9-9fbe-407b-9d13-a7030bb2c772">
md
<img width="958" alt="스크린샷 2024-07-30 오전 2 03 38" src="https://github.com/user-attachments/assets/71d31386-3831-4b4e-9293-f3861f00c88f">
lg
<img width="1200" alt="스크린샷 2024-07-30 오전 2 04 04" src="https://github.com/user-attachments/assets/3e58b94c-d293-4296-a370-5f729f3f1221">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
