### PR TITLE
Add activity report edit page

### DIFF
--- a/packages/web/src/app/manage-club/activity-report/[id]/edit/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/edit/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from "react";
+
+import ActivityReportEditFrame from "@sparcs-clubs/web/features/manage-club/activity-report/frames/ActivityReportEditFrame";
+
+const ActivityReport = ({ params }: { params: { id: string } }) => (
+  <ActivityReportEditFrame id={params.id} />
+);
+
+export default ActivityReport;

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+import apiAct003 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct003";
+import { format, isValid, parse } from "date-fns";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+
+import { z } from "zod";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import Button from "@sparcs-clubs/web/common/components/Button";
+import Card from "@sparcs-clubs/web/common/components/Card";
+import FileUpload from "@sparcs-clubs/web/common/components/FileUpload";
+import DateRangeInput from "@sparcs-clubs/web/common/components/Forms/DateRangeInput";
+import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
+import Select from "@sparcs-clubs/web/common/components/Select";
+import { ActivityTypeEnum } from "@sparcs-clubs/web/features/manage-club/service/_mock/mockManageClub";
+
+import { mockParticipantData } from "../_mock/mock";
+import SelectParticipant from "../components/SelectParticipant";
+import { useGetActivityReport } from "../services/useGetActivityReport";
+import { usePutActivityReport } from "../services/usePutActivityReport";
+
+const ActivityReportMainFrameInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 60px;
+`;
+
+const SectionInner = styled.div`
+  padding-left: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+  align-self: stretch;
+`;
+
+const HorizontalPlacer = styled.div`
+  display: flex;
+  gap: 32px;
+`;
+
+const ButtonPlaceRight = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  align-self: stretch;
+`;
+
+type PutActivityReportBody = z.infer<typeof apiAct003.requestBody>;
+const ActivityReportEditFrame: React.FC<{ id: string }> = ({ id }) => {
+  const { data, isLoading, isError } = useGetActivityReport(Number(id));
+  const { mutate } = usePutActivityReport();
+  const [formData, setFormData] = useState<PutActivityReportBody>();
+  const [duration, setDuration] = useState<[string, string]>(["", ""]);
+  const router = useRouter();
+
+  const handleFormChange = useCallback(
+    <K extends keyof PutActivityReportBody>(
+      key: K,
+      value: PutActivityReportBody[K],
+    ) => {
+      if (!formData) return;
+      setFormData({ ...formData, [key]: value });
+    },
+    [formData],
+  );
+
+  useEffect(() => {
+    const parsedStartDate = parse(duration[0], "yyyy.MM.dd", new Date());
+    const parsedEndDate = parse(duration[1], "yyyy.MM.dd", new Date());
+
+    if (isValid(parsedStartDate) && isValid(parsedEndDate)) {
+      handleFormChange("durations", [
+        { startTerm: parsedStartDate, endTerm: parsedEndDate },
+      ]);
+    }
+  }, [duration, handleFormChange]);
+
+  useEffect(() => {
+    if (data) {
+      setFormData(data);
+      if (data.durations.length) {
+        const { startTerm, endTerm } = data.durations[0];
+        const formattedStart = format(startTerm, "yyyy.MM.dd");
+        const formattedEnd = format(endTerm, "yyyy.MM.dd");
+        setDuration([formattedStart, formattedEnd]);
+      }
+    }
+  }, [data]);
+
+  const handleSubmit = useCallback(() => {
+    if (!formData) return;
+    mutate(
+      { activityId: Number(id), body: formData },
+      {
+        onSuccess: () => {
+          router.push("/manage-club/activity-report");
+        },
+      },
+    );
+  }, [formData, id, mutate, router]);
+
+  return (
+    <ActivityReportMainFrameInner>
+      <PageHead
+        items={[
+          { name: "대표 동아리 관리", path: "/manage-club" },
+          { name: "활동 보고서", path: "/manage-club/activity-report" },
+        ]}
+        title="활동 보고서 작성"
+        enableLast
+      />
+      <AsyncBoundary isLoading={isLoading} isError={isError}>
+        <SectionTitle>활동 정보</SectionTitle>
+        <SectionInner>
+          <Card outline padding="32px" gap={32}>
+            <TextInput
+              label="활동명"
+              placeholder="활동명을 입력해주세요"
+              name="name"
+              value={formData?.name}
+              handleChange={value => handleFormChange("name", value)}
+            />
+            <HorizontalPlacer>
+              <Select
+                label="활동 분류"
+                items={[
+                  {
+                    value: ActivityTypeEnum.FitInside.toString(),
+                    label: "동아리 성격에 합치하는 내부 활동",
+                    selectable: true,
+                  },
+                  {
+                    value: ActivityTypeEnum.FitOutside.toString(),
+                    label: "동아리 성격에 합치하는 외부 활동",
+                    selectable: true,
+                  },
+                  {
+                    value: ActivityTypeEnum.NotFit.toString(),
+                    label: "동아리 성격에 합치하지 않는 활동",
+                    selectable: true,
+                  },
+                ]}
+                selectedValue={formData?.activityTypeEnumId.toString()}
+                onSelect={value =>
+                  handleFormChange("activityTypeEnumId", Number(value))
+                }
+              />
+              <DateRangeInput
+                label={["활동 기간", "\u200B"]}
+                startValue={duration[0]}
+                endValue={duration[1]}
+                limitStartValue="2000.01.01"
+                limitEndValue="3000.01.01"
+                placeholder="날짜를 입력해주세요"
+                onChange={value => {
+                  const [start, end] = value.split("|");
+                  setDuration([start, end]);
+                }}
+                useDays
+              />
+            </HorizontalPlacer>
+            <TextInput
+              label="활동 장소"
+              placeholder="활동 장소를 입력해주세요"
+              name="location"
+              value={formData?.location}
+              handleChange={value => handleFormChange("location", value)}
+            />
+            <TextInput
+              label="활동 목적"
+              placeholder="활동 목적을 입력해주세요"
+              name="purpose"
+              value={formData?.purpose}
+              handleChange={value => handleFormChange("purpose", value)}
+            />
+            <TextInput
+              area
+              label="활동 내용"
+              placeholder="활동 내용을 입력해주세요"
+              name="detail"
+              value={formData?.detail}
+              handleChange={value => handleFormChange("detail", value)}
+            />
+          </Card>
+        </SectionInner>
+        <SectionTitle>활동 인원</SectionTitle>
+        <SectionInner>
+          <SelectParticipant data={mockParticipantData} />
+        </SectionInner>
+        <SectionTitle>활동 증빙</SectionTitle>
+        <SectionInner>
+          <Card outline padding="32px" gap={32}>
+            <FileUpload />
+            <TextInput
+              area
+              placeholder="(선택) 활동 증빙에 대해서 작성하고 싶은 것이 있다면 입력해주세요"
+              name="evidence"
+              value={formData?.evidence}
+              handleChange={value => handleFormChange("evidence", value)}
+            />
+          </Card>
+        </SectionInner>
+        <ButtonPlaceRight>
+          <Button type="default" onClick={handleSubmit}>
+            저장
+          </Button>
+        </ButtonPlaceRight>
+      </AsyncBoundary>
+    </ActivityReportMainFrameInner>
+  );
+};
+
+export default ActivityReportEditFrame;

--- a/packages/web/src/features/manage-club/activity-report/services/useGetActivityReport.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetActivityReport.tsx
@@ -1,0 +1,66 @@
+import apiAct002 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct002";
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+
+import {
+  axiosClient,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+type ISuccessResponseType = z.infer<(typeof apiAct002.responseBodyMap)[200]>;
+export const useGetActivityReport = (activityId: number) =>
+  useQuery<ISuccessResponseType, Error>({
+    queryKey: [apiAct002.url(activityId)],
+    queryFn: async (): Promise<ISuccessResponseType> => {
+      const { data, status } = await axiosClient.get(
+        apiAct002.url(activityId),
+        {},
+      );
+
+      switch (status) {
+        case 200:
+          return apiAct002.responseBodyMap[200].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+defineAxiosMock(mock => {
+  mock.onGet(apiAct002.url(1)).reply(() => {
+    const dummy: z.infer<(typeof apiAct002.responseBodyMap)[200]> = {
+      clubId: 1,
+      originalName: "Original Activity Name",
+      name: "Activity Name",
+      activityTypeEnumId: 1,
+      durations: [
+        {
+          startTerm: new Date(),
+          endTerm: new Date(),
+        },
+      ],
+      location: "Activity Location",
+      purpose: "Activity Purpose",
+      detail: "Activity Detail",
+      evidence: "Activity Evidence",
+      evidenceFiles: [
+        {
+          uuid: "file-uuid",
+        },
+      ],
+      participants: [
+        {
+          studentId: 20200515,
+        },
+        {
+          studentId: 20200513,
+        },
+        {
+          studentId: 20230512,
+        },
+      ],
+    };
+    return [200, dummy];
+  });
+});

--- a/packages/web/src/features/manage-club/activity-report/services/usePutActivityReport.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/usePutActivityReport.tsx
@@ -1,0 +1,31 @@
+import apiAct003 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct003";
+import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
+
+import {
+  axiosClient,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+type ISuccessResponseType = z.infer<(typeof apiAct003.responseBodyMap)[200]>;
+
+export const usePutActivityReport = () =>
+  useMutation<
+    ISuccessResponseType,
+    Error,
+    { activityId: number; body: z.infer<typeof apiAct003.requestBody> }
+  >({
+    mutationFn: async ({ activityId, body }): Promise<ISuccessResponseType> => {
+      const { data, status } = await axiosClient.put(
+        apiAct003.url(activityId),
+        body,
+      );
+
+      switch (status) {
+        case 200:
+          return apiAct003.responseBodyMap[200].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #247 

# 스크린샷
<img width="695" alt="Screenshot 2024-07-30 at 22 41 48" src="https://github.com/user-attachments/assets/33a1ad50-d773-4148-a0da-35dc2a492b44">

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

- [ ] #484 완료되면 participant list 추가
- [ ] duration이 리스트로 돌아옴 -> 백엔드 아니면 프런트엔드 디자인 둘중에 하나 수정 필요 @babycroc @Engineer-JJHaMa 

# 할말

```
  const handleFormChange = useCallback(
    <K extends keyof PutActivityReportBody>(
      key: K,
      value: PutActivityReportBody[K],
    ) => {
      if (!formData) return;
      setFormData({ ...formData, [key]: value });
    },
    [formData],
  );
```
만들어 봤는데 되게 편하더라구요 다른 분들도 혹시 이부분에서 문제 있었으면 참고하면 좋을 것 같습니다.
