### PR TITLE
[UI] impl: manage-club/activity-report detailed page

### DIFF
--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import React from "react";
+
+import ActivityReportDetailedFrame from "@sparcs-clubs/web/features/manage-club/activity-report/frames/ActivityReportDetailedFrame";
+
+const ActivityReportDetailed = () => <ActivityReportDetailedFrame />;
+export default ActivityReportDetailed;

--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-import ActivityReportDetailedFrame from "@sparcs-clubs/web/features/manage-club/activity-report/frames/ActivityReportDetailedFrame";
+import ActivityReportDetailFrame from "@sparcs-clubs/web/features/manage-club/activity-report/frames/ActivityReportDetailFrame";
 
-const ActivityReportDetailed = () => <ActivityReportDetailedFrame />;
+const ActivityReportDetailed = () => <ActivityReportDetailFrame />;
 export default ActivityReportDetailed;

--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -77,8 +77,17 @@ const FilePreviewContainer: React.FC<React.PropsWithChildren> = ({
   </FilePreviewContainerWrapper>
 );
 
-const BackButton = styled(Button)`
-  padding: 8px 16px;
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
+
+const DeleteAndEditButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
 `;
 
 const ActivityReportDetail: React.FC = () => {
@@ -161,9 +170,15 @@ const ActivityReportDetail: React.FC = () => {
             <Tag color={approvalTagColor}>{approvalTagText}</Tag>
           </FlexWrapper>
         </Card>
-        <BackButton type="default" onClick={onClick}>
-          목록으로 돌아가기
-        </BackButton>
+        <ButtonContainer>
+          <Button type="default" onClick={onClick}>
+            목록으로 돌아가기
+          </Button>
+          <DeleteAndEditButtonContainer>
+            <Button type="default">삭제</Button>
+            <Button type="default">수정</Button>
+          </DeleteAndEditButtonContainer>
+        </ButtonContainer>
       </FlexWrapper>
     </FlexWrapper>
   );

--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -1,8 +1,172 @@
 "use client";
 
-import React from "react";
+import React, { ReactNode } from "react";
 
-import ActivityReportDetailFrame from "@sparcs-clubs/web/features/manage-club/activity-report/frames/ActivityReportDetailFrame";
+import { useParams, useRouter } from "next/navigation";
+import styled from "styled-components";
 
-const ActivityReportDetailed = () => <ActivityReportDetailFrame />;
-export default ActivityReportDetailed;
+import Button from "@sparcs-clubs/web/common/components/Button";
+import Card from "@sparcs-clubs/web/common/components/Card";
+import FilePreview from "@sparcs-clubs/web/common/components/FilePreview";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import { Status } from "@sparcs-clubs/web/common/components/ProgressCheckSection/_atomic/ProgressDot";
+import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+
+import { ProfessorApprovalTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import { ActivityProfessorApprovalEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+interface ActivitySectionProps extends React.PropsWithChildren {
+  label: string;
+}
+
+const ActivitySection: React.FC<ActivitySectionProps> = ({
+  label,
+  children = null,
+}) => (
+  <FlexWrapper direction="column" gap={16} style={{ alignSelf: "stretch" }}>
+    <Typography
+      fw="MEDIUM"
+      fs={16}
+      lh={20}
+      style={{ paddingLeft: "2px", paddingRight: "2px" }}
+    >
+      {label}
+    </Typography>
+    {children}
+  </FlexWrapper>
+);
+// ActivitySection은 활동 보고서에서 구분된 각 영역을 나타냅니다.
+// label prop으로 이름을 넣고, children으로 ActivityDetail들을 넣어 주세요.
+
+const FlexTypography = styled(Typography)`
+display: flex;
+fiex-direction: column;
+gap: 12px;
+align-items: flex-start;
+align-self; stretch;
+`;
+
+const ActivityDetail: React.FC<{ children: string | ReactNode }> = ({
+  children = "",
+}) => {
+  const isString: boolean = typeof children === "string";
+  return (
+    <FlexTypography fw="REGULAR" fs={16} lh={20}>
+      {isString ? `• ${children}` : children}
+    </FlexTypography>
+  );
+};
+// ActivityDetail은 세부 활동 내역을 나타냅니다.
+// string이면 bullet point가 자동으로 포함됩니다.
+// string이 아닌 경우는 FilePreview가 들어가는 경우입니다. padding이 포함됩니다.
+
+const FilePreviewContainerWrapper = styled(FlexWrapper)`
+  padding-left: 24px;
+  align-self: stretch;
+`;
+
+const FilePreviewContainer: React.FC<React.PropsWithChildren> = ({
+  children = null,
+}) => (
+  <FilePreviewContainerWrapper direction="column" gap={12}>
+    {children}
+  </FilePreviewContainerWrapper>
+);
+
+const BackButton = styled(Button)`
+  padding: 8px 16px;
+`;
+
+const ActivityReportDetail: React.FC = () => {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+
+  const onClick = () => {
+    router.push("/manage-club/activity-report");
+  };
+
+  const { color: approvalTagColor, text: approvalTagText } = getTagDetail(
+    ActivityProfessorApprovalEnum.Requested,
+    ProfessorApprovalTagList,
+  );
+
+  return (
+    <FlexWrapper direction="column" gap={60}>
+      <PageHead
+        items={[
+          { name: "대표 동아리 관리", path: "/manage-club" },
+          { name: "활동 보고서", path: "/manage-club/activity-report" },
+        ]}
+        title={`활동 보고서 : ${id}(id 가져오기 테스트용)`}
+        enableLast
+      />
+      <FlexWrapper direction="column" gap={40} style={{ alignSelf: "stretch" }}>
+        <Card outline={false} padding="32px" gap={20}>
+          <ProgressStatus
+            labels={["신청 완료", "동아리 연합회 신청 반려"]}
+            progress={[
+              { status: Status.Approved, date: new Date("2024-03-11 21:00") },
+              { status: Status.Canceled, date: new Date("2024-03-11 21:00") },
+            ]}
+          />
+          <ActivitySection label="활동 정보">
+            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+            <ActivityDetail>
+              활동 분류: 동아리 성격에 합치하는 내부 활동
+            </ActivityDetail>
+            <ActivityDetail>
+              활동 기간: 2024년 5월 24일 (금) ~ 2024년 5월 25일 (토)
+            </ActivityDetail>
+            <ActivityDetail>활동 장소: 동아리방</ActivityDetail>
+            <ActivityDetail>
+              활동 목적: 동아리 회원 개발 실력 향상
+            </ActivityDetail>
+            <ActivityDetail>활동 내용: 밤을 새서 개발을 했다.</ActivityDetail>
+          </ActivitySection>
+          <ActivitySection label="활동 인원(4명)">
+            <ActivityDetail>20200510 이지윤</ActivityDetail>
+            <ActivityDetail>20200511 박병찬</ActivityDetail>
+            <ActivityDetail>20230510 이도라</ActivityDetail>
+            <ActivityDetail>20240510 스팍스</ActivityDetail>
+          </ActivitySection>
+          <ActivitySection label="활동 증빙">
+            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+            <ActivityDetail>첨부 파일</ActivityDetail>
+            <ActivityDetail>
+              <FilePreviewContainer>
+                <FilePreview fileName="bamsaem.pdf" />
+                <FilePreview fileName="coffee.pdf" />
+                <FilePreview fileName="gaebal.pdf" />
+              </FilePreviewContainer>
+            </ActivityDetail>
+            <ActivityDetail>
+              부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
+            </ActivityDetail>
+          </ActivitySection>
+          <FlexWrapper
+            direction="row"
+            gap={16}
+            justify="space-between"
+            style={{
+              alignItems: "center",
+              alignSelf: "stretch",
+              width: "100%",
+            }}
+          >
+            <ActivitySection label="지도교수 승인" />
+            <Tag color={approvalTagColor}>{approvalTagText}</Tag>
+          </FlexWrapper>
+        </Card>
+        <BackButton type="default" onClick={onClick}>
+          목록으로 돌아가기
+        </BackButton>
+      </FlexWrapper>
+    </FlexWrapper>
+  );
+};
+
+export default ActivityReportDetail;

--- a/packages/web/src/features/manage-club/activity-report/components/AdvisorProfessorApprovalTag.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/AdvisorProfessorApprovalTag.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import Tag, { TagColor } from "@sparcs-clubs/web/common/components/Tag";
+
+export enum ProfessorApproval {
+  PENDING = "대기",
+  APPROVED = "승인",
+  REJECTED = "반려",
+}
+
+interface AdvisorProfessorApprovalTagProps {
+  professorApproval: ProfessorApproval;
+}
+
+const getProfessorApprovalTagColor = (
+  professorApproval: ProfessorApproval,
+): TagColor => {
+  switch (professorApproval) {
+    case ProfessorApproval.PENDING:
+      return "GRAY";
+    case ProfessorApproval.APPROVED:
+      return "GREEN";
+    default: // REJECTED
+      return "RED";
+  }
+};
+
+const AdvisorProfessorApprovalTag: React.FC<
+  AdvisorProfessorApprovalTagProps
+> = ({ professorApproval }) => (
+  <Tag color={getProfessorApprovalTagColor(professorApproval)}>
+    {professorApproval}
+  </Tag>
+);
+
+export default AdvisorProfessorApprovalTag;

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -1,69 +1,87 @@
 "use client";
 
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { useParams, useRouter } from "next/navigation";
 import styled from "styled-components";
 
 import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
+import FilePreview from "@sparcs-clubs/web/common/components/FilePreview";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import { Status } from "@sparcs-clubs/web/common/components/ProgressCheckSection/_atomic/ProgressDot";
 import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
-
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
-interface ActivitySectionProps {
+import AdvisorProfessorApprovalTag, {
+  ProfessorApproval,
+} from "../components/AdvisorProfessorApprovalTag";
+
+interface ActivitySectionProps extends React.PropsWithChildren {
   label: string;
-  children?: React.ReactNode;
 }
-
-const ActivityReportDetailedFrameInner = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 60px;
-`;
-
-const ActivitySectionWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 16px;
-  align-self: stretch;
-`;
-
-const CardAndButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 40px;
-  align-self: stretch;
-`;
 
 const ActivitySection: React.FC<ActivitySectionProps> = ({
   label,
   children = null,
 }) => (
-  <ActivitySectionWrapper>
-    <Typography fw="MEDIUM" fs={16} lh={20}>
+  <FlexWrapper
+    direction="column"
+    gap={16}
+    style={{ alignItems: "flex-start", alignSelf: "stretch" }}
+  >
+    <Typography
+      fw="MEDIUM"
+      fs={16}
+      lh={20}
+      style={{ paddingLeft: "2px", paddingRight: "2px" }}
+    >
       {label}
     </Typography>
     {children}
-  </ActivitySectionWrapper>
+  </FlexWrapper>
 );
 // ActivitySection은 활동 보고서에서 구분된 각 영역을 나타냅니다.
 // label prop으로 이름을 넣고, children으로 ActivityDetail들을 넣어 주세요.
 
-const ActivityDetail: React.FC<{ children: string }> = ({ children = "" }) => (
-  <Typography fw="REGULAR" fs={16} lh={20}>
-    {`• ${children}`}
-  </Typography>
-);
-// ActivityDetail은 세부 활동 내역을 나타냅니다.
-// bullet point가 자동으로 포함됩니다.
+const FlexTypography = styled(Typography)`
+display: flex;
+fiex-direction: column;
+gap: 12px;
+align-items: flex-start;
+align-self; stretch;
+`;
 
-const ActivityReportDetailedFrame: React.FC = () => {
+const ActivityDetail: React.FC<{ children: string | ReactNode }> = ({
+  children = "",
+}) => {
+  const isString: boolean = typeof children === "string";
+  return (
+    <FlexTypography fw="REGULAR" fs={16} lh={20}>
+      {isString ? `• ${children}` : children}
+    </FlexTypography>
+  );
+};
+// ActivityDetail은 세부 활동 내역을 나타냅니다.
+// string이면 bullet point가 자동으로 포함됩니다.
+// string이 아닌 경우는 FilePreview가 들어가는 경우입니다. padding이 포함됩니다.
+
+const FilePreviewContainerWrapper = styled(FlexWrapper)`
+  padding-left: 24px;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const FilePreviewContainer: React.FC<React.PropsWithChildren> = ({
+  children = null,
+}) => (
+  <FilePreviewContainerWrapper direction="column" gap={12}>
+    {children}
+  </FilePreviewContainerWrapper>
+);
+
+const ActivityReportDetailFrame: React.FC = () => {
   const router = useRouter();
   const { id } = useParams<{ id: string }>();
 
@@ -72,7 +90,11 @@ const ActivityReportDetailedFrame: React.FC = () => {
   };
 
   return (
-    <ActivityReportDetailedFrameInner>
+    <FlexWrapper
+      direction="column"
+      gap={60}
+      style={{ alignItems: "flex-start" }}
+    >
       <PageHead
         items={[
           { name: "대표 동아리 관리", path: "/manage-club" },
@@ -81,7 +103,11 @@ const ActivityReportDetailedFrame: React.FC = () => {
         title={`활동 보고서 : ${id}(id 가져오기 테스트용)`}
         enableLast
       />
-      <CardAndButtonWrapper>
+      <FlexWrapper
+        direction="column"
+        gap={40}
+        style={{ alignItems: "flex-start", alignSelf: "stretch" }}
+      >
         <Card outline={false} padding="32px" gap={20}>
           <ProgressStatus
             labels={["신청 완료", "동아리 연합회 신청 반려"]}
@@ -114,20 +140,38 @@ const ActivityReportDetailedFrame: React.FC = () => {
             <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
             <ActivityDetail>첨부 파일</ActivityDetail>
             <ActivityDetail>
-              (ActivityDetail 대신 File Thumbnail이 보여야 할 자리)
+              <FilePreviewContainer>
+                <FilePreview fileName="bamsaem.pdf" />
+                <FilePreview fileName="coffee.pdf" />
+                <FilePreview fileName="gaebal.pdf" />
+              </FilePreviewContainer>
             </ActivityDetail>
             <ActivityDetail>
               부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
             </ActivityDetail>
           </ActivitySection>
-          <ActivitySection label="지도교수 승인" />
+          <FlexWrapper
+            direction="row"
+            gap={16}
+            justify="space-between"
+            style={{
+              alignItems: "center",
+              alignSelf: "stretch",
+              width: "100%",
+            }}
+          >
+            <ActivitySection label="지도교수 승인" />
+            <AdvisorProfessorApprovalTag
+              professorApproval={ProfessorApproval.PENDING}
+            />
+          </FlexWrapper>
         </Card>
         <Button type="default" onClick={onClick}>
           목록으로 돌아가기
         </Button>
-      </CardAndButtonWrapper>
-    </ActivityReportDetailedFrameInner>
+      </FlexWrapper>
+    </FlexWrapper>
   );
 };
 
-export default ActivityReportDetailedFrame;
+export default ActivityReportDetailFrame;

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
@@ -1,11 +1,16 @@
+"use client";
+
 import React from "react";
 
+import { useParams, useRouter } from "next/navigation";
 import styled from "styled-components";
 
+import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import { Status } from "@sparcs-clubs/web/common/components/ProgressCheckSection/_atomic/ProgressDot";
 import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
+
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 interface ActivitySectionProps {
@@ -25,6 +30,14 @@ const ActivitySectionWrapper = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 16px;
+  align-self: stretch;
+`;
+
+const CardAndButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 40px;
   align-self: stretch;
 `;
 
@@ -50,54 +63,71 @@ const ActivityDetail: React.FC<{ children: string }> = ({ children = "" }) => (
 // ActivityDetail은 세부 활동 내역을 나타냅니다.
 // bullet point가 자동으로 포함됩니다.
 
-const ActivityReportDetailedFrame: React.FC = () => (
-  <ActivityReportDetailedFrameInner>
-    <PageHead
-      items={[
-        { name: "대표 동아리 관리", path: "/manage-club" },
-        { name: "활동 보고서", path: "/manage-club/activity-report" },
-      ]}
-      title="활동 보고서"
-      enableLast
-    />
-    <Card outline={false} padding="32px" gap={20}>
-      <ProgressStatus
-        labels={["신청 완료", "동아리 연합회 신청 반려"]}
-        progress={[
-          { status: Status.Approved, date: new Date("2024-03-11 21:00") },
-          { status: Status.Canceled, date: new Date("2024-03-11 21:00") },
+const ActivityReportDetailedFrame: React.FC = () => {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+
+  const onClick = () => {
+    router.push("/manage-club/activity-report");
+  };
+
+  return (
+    <ActivityReportDetailedFrameInner>
+      <PageHead
+        items={[
+          { name: "대표 동아리 관리", path: "/manage-club" },
+          { name: "활동 보고서", path: "/manage-club/activity-report" },
         ]}
+        title={`활동 보고서 : ${id}(id 가져오기 테스트용)`}
+        enableLast
       />
-      <ActivitySection label="활동 정보">
-        <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
-        <ActivityDetail>
-          활동 분류: 동아리 성격에 합치하는 내부 활동
-        </ActivityDetail>
-        <ActivityDetail>
-          활동 기간: 2024년 5월 24일 (금) ~ 2024년 5월 25일 (토)
-        </ActivityDetail>
-        <ActivityDetail>활동 장소: 동아리방</ActivityDetail>
-        <ActivityDetail>활동 목적: 동아리 회원 개발 실력 향상</ActivityDetail>
-        <ActivityDetail>활동 내용: 밤을 새서 개발을 했다.</ActivityDetail>
-      </ActivitySection>
-      <ActivitySection label="활동 인원(4명)">
-        <ActivityDetail>20200510 이지윤</ActivityDetail>
-        <ActivityDetail>20200511 박병찬</ActivityDetail>
-        <ActivityDetail>20230510 이도라</ActivityDetail>
-        <ActivityDetail>20240510 스팍스</ActivityDetail>
-      </ActivitySection>
-      <ActivitySection label="활동 증빙">
-        <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
-        <ActivityDetail>첨부 파일</ActivityDetail>
-        <ActivityDetail>
-          (ActivityDetail 대신 File Thumbnail이 보여야 할 자리)
-        </ActivityDetail>
-        <ActivityDetail>
-          부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
-        </ActivityDetail>
-      </ActivitySection>
-    </Card>
-  </ActivityReportDetailedFrameInner>
-);
+      <CardAndButtonWrapper>
+        <Card outline={false} padding="32px" gap={20}>
+          <ProgressStatus
+            labels={["신청 완료", "동아리 연합회 신청 반려"]}
+            progress={[
+              { status: Status.Approved, date: new Date("2024-03-11 21:00") },
+              { status: Status.Canceled, date: new Date("2024-03-11 21:00") },
+            ]}
+          />
+          <ActivitySection label="활동 정보">
+            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+            <ActivityDetail>
+              활동 분류: 동아리 성격에 합치하는 내부 활동
+            </ActivityDetail>
+            <ActivityDetail>
+              활동 기간: 2024년 5월 24일 (금) ~ 2024년 5월 25일 (토)
+            </ActivityDetail>
+            <ActivityDetail>활동 장소: 동아리방</ActivityDetail>
+            <ActivityDetail>
+              활동 목적: 동아리 회원 개발 실력 향상
+            </ActivityDetail>
+            <ActivityDetail>활동 내용: 밤을 새서 개발을 했다.</ActivityDetail>
+          </ActivitySection>
+          <ActivitySection label="활동 인원(4명)">
+            <ActivityDetail>20200510 이지윤</ActivityDetail>
+            <ActivityDetail>20200511 박병찬</ActivityDetail>
+            <ActivityDetail>20230510 이도라</ActivityDetail>
+            <ActivityDetail>20240510 스팍스</ActivityDetail>
+          </ActivitySection>
+          <ActivitySection label="활동 증빙">
+            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+            <ActivityDetail>첨부 파일</ActivityDetail>
+            <ActivityDetail>
+              (ActivityDetail 대신 File Thumbnail이 보여야 할 자리)
+            </ActivityDetail>
+            <ActivityDetail>
+              부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
+            </ActivityDetail>
+          </ActivitySection>
+          <ActivitySection label="지도교수 승인" />
+        </Card>
+        <Button type="default" onClick={onClick}>
+          목록으로 돌아가기
+        </Button>
+      </CardAndButtonWrapper>
+    </ActivityReportDetailedFrameInner>
+  );
+};
 
 export default ActivityReportDetailedFrame;

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
@@ -2,7 +2,16 @@ import React from "react";
 
 import styled from "styled-components";
 
+import Card from "@sparcs-clubs/web/common/components/Card";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import { Status } from "@sparcs-clubs/web/common/components/ProgressCheckSection/_atomic/ProgressDot";
+import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+
+interface ActivitySectionProps {
+  label: string;
+  children?: React.ReactNode;
+}
 
 const ActivityReportDetailedFrameInner = styled.div`
   display: flex;
@@ -10,6 +19,36 @@ const ActivityReportDetailedFrameInner = styled.div`
   align-items: flex-start;
   gap: 60px;
 `;
+
+const ActivitySectionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  align-self: stretch;
+`;
+
+const ActivitySection: React.FC<ActivitySectionProps> = ({
+  label,
+  children = null,
+}) => (
+  <ActivitySectionWrapper>
+    <Typography fw="MEDIUM" fs={16} lh={20}>
+      {label}
+    </Typography>
+    {children}
+  </ActivitySectionWrapper>
+);
+// ActivitySection은 활동 보고서에서 구분된 각 영역을 나타냅니다.
+// label prop으로 이름을 넣고, children으로 ActivityDetail들을 넣어 주세요.
+
+const ActivityDetail: React.FC<{ children: string }> = ({ children = "" }) => (
+  <Typography fw="REGULAR" fs={16} lh={20}>
+    {`• ${children}`}
+  </Typography>
+);
+// ActivityDetail은 세부 활동 내역을 나타냅니다.
+// bullet point가 자동으로 포함됩니다.
 
 const ActivityReportDetailedFrame: React.FC = () => (
   <ActivityReportDetailedFrameInner>
@@ -21,6 +60,43 @@ const ActivityReportDetailedFrame: React.FC = () => (
       title="활동 보고서"
       enableLast
     />
+    <Card outline={false} padding="32px" gap={20}>
+      <ProgressStatus
+        labels={["신청 완료", "동아리 연합회 신청 반려"]}
+        progress={[
+          { status: Status.Approved, date: new Date("2024-03-11 21:00") },
+          { status: Status.Canceled, date: new Date("2024-03-11 21:00") },
+        ]}
+      />
+      <ActivitySection label="활동 정보">
+        <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+        <ActivityDetail>
+          활동 분류: 동아리 성격에 합치하는 내부 활동
+        </ActivityDetail>
+        <ActivityDetail>
+          활동 기간: 2024년 5월 24일 (금) ~ 2024년 5월 25일 (토)
+        </ActivityDetail>
+        <ActivityDetail>활동 장소: 동아리방</ActivityDetail>
+        <ActivityDetail>활동 목적: 동아리 회원 개발 실력 향상</ActivityDetail>
+        <ActivityDetail>활동 내용: 밤을 새서 개발을 했다.</ActivityDetail>
+      </ActivitySection>
+      <ActivitySection label="활동 인원(4명)">
+        <ActivityDetail>20200510 이지윤</ActivityDetail>
+        <ActivityDetail>20200511 박병찬</ActivityDetail>
+        <ActivityDetail>20230510 이도라</ActivityDetail>
+        <ActivityDetail>20240510 스팍스</ActivityDetail>
+      </ActivitySection>
+      <ActivitySection label="활동 증빙">
+        <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+        <ActivityDetail>첨부 파일</ActivityDetail>
+        <ActivityDetail>
+          (ActivityDetail 대신 File Thumbnail이 보여야 할 자리)
+        </ActivityDetail>
+        <ActivityDetail>
+          부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
+        </ActivityDetail>
+      </ActivitySection>
+    </Card>
   </ActivityReportDetailedFrameInner>
 );
 

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailedFrame.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import styled from "styled-components";
+
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+
+const ActivityReportDetailedFrameInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 60px;
+`;
+
+const ActivityReportDetailedFrame: React.FC = () => (
+  <ActivityReportDetailedFrameInner>
+    <PageHead
+      items={[
+        { name: "대표 동아리 관리", path: "/manage-club" },
+        { name: "활동 보고서", path: "/manage-club/activity-report" },
+      ]}
+      title="활동 보고서"
+      enableLast
+    />
+  </ActivityReportDetailedFrameInner>
+);
+
+export default ActivityReportDetailedFrame;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #321 

## 24.08.06. 17:31까지 변경 사항
- 정말 UI만 디자인했습니다 (Mock data도 아닌 raw 값이 return문에 끼어 있는 형태)
- File Thumbnail 부분의 component가 아직 없어서, 해당 부분을 제외하고 Figma와 동일한 화면을 만들었습니다
- `manage-club/activity-report/{아무 값이나}` 경로에서 확인 가능합니다

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/c4e79664-647b-4fb1-b9eb-37f26b104443)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
