### PR TITLE
impl meet 001 005 api

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -27,6 +27,7 @@ import UserModule from "./feature/user/user.module";
     DivisionModule,
     DrizzleModule,
     FileModule,
+    MeetingModule,
     NoticeModule,
     PromotionalPrintingModule,
     RegistrationModule,

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -56,6 +56,7 @@ export const Meeting = mysqlTable(
     meetingEnumId: int("meeting_enum_id"),
     isRegular: boolean("is_regular").notNull(),
     location: varchar("location", { length: 255 }),
+    locationEn: varchar("location_en", { length: 255 }),
     startDate: datetime("start_date").notNull(),
     endDate: datetime("end_date"),
     createdAt: timestamp("created_at").defaultNow(),

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -53,7 +53,7 @@ export const Meeting = mysqlTable(
     announcementId: int("announcement_id")
       .references(() => MeetingAnnouncement.id)
       .notNull(),
-    meetingEnum: int("meeting_enum"),
+    meetingEnumId: int("meeting_enum_id"),
     memo: text("memo"),
     isRegular: boolean("is_regular").notNull(),
     location: varchar("location", { length: 255 }),
@@ -66,7 +66,7 @@ export const Meeting = mysqlTable(
   table => ({
     meetingEnumForeignKey: foreignKey({
       name: "meeting_enum_foreign_key",
-      columns: [table.meetingEnum],
+      columns: [table.meetingEnumId],
       foreignColumns: [MeetingEnum.id],
     }),
   }),

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -54,7 +54,6 @@ export const Meeting = mysqlTable(
       .references(() => MeetingAnnouncement.id)
       .notNull(),
     meetingEnumId: int("meeting_enum_id"),
-    memo: text("memo"),
     isRegular: boolean("is_regular").notNull(),
     location: varchar("location", { length: 255 }),
     startDate: datetime("start_date").notNull(),

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -37,22 +37,21 @@ import { MeetingService } from "./meeting.service";
 export default class MeetingController {
   constructor(private meetingService: MeetingService) {}
 
-  @Executive()
+  // @Executive()
   @Post("/executive/meetings/announcements/announcement")
   @UsePipes(new ZodPipe(apiMeet001))
   async createExecutiveMeetingAnnouncement(
     @GetExecutive() user: GetExecutive,
     @Body() body: ApiMeet001RequestBody,
   ): Promise<ApiMeet001ResponseCreated> {
-    const result = await this.meetingService.postExecutiveMeetingAnnouncement(
+    await this.meetingService.postExecutiveMeetingAnnouncement(
       body,
       user.executiveId,
     );
-    return result;
+    return {};
   }
 
-  @Executive()
-  @Get("/executive/meetings/announcements/announcement/:announcementId")
+  @Get("/meetings/announcements/announcement/:announcementId")
   @UsePipes(new ZodPipe(apiMeet002))
   async getExecutiveMeetingAnnouncement(
     @GetExecutive() user: GetExecutive,

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -1,0 +1,97 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UsePipes,
+} from "@nestjs/common";
+
+import apiMeet001, {
+  ApiMeet001RequestBody,
+  ApiMeet001ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet001";
+import apiMeet002, {
+  ApiMeet002RequestParam,
+  // ApiMeet002ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet002";
+import apiMeet003, {
+  ApiMeet003RequestBody,
+  ApiMeet003RequestParam,
+  ApiMeet003ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet003";
+import apiMeet004, {
+  ApiMeet004RequestParam,
+  ApiMeet004ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet004";
+
+import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
+import { Executive } from "@sparcs-clubs/api/common/util/decorators/method-decorator";
+import { GetExecutive } from "@sparcs-clubs/api/common/util/decorators/param-decorator";
+
+import { MeetingService } from "./meeting.service";
+
+@Controller()
+export default class MeetingController {
+  constructor(private meetingService: MeetingService) {}
+
+  @Executive()
+  @Post("/executive/meetings/announcements/announcement")
+  @UsePipes(new ZodPipe(apiMeet001))
+  async createExecutiveMeetingAnnouncement(
+    @GetExecutive() user: GetExecutive,
+    @Body() body: ApiMeet001RequestBody,
+  ): Promise<ApiMeet001ResponseCreated> {
+    const result = await this.meetingService.postExecutiveMeetingAnnouncement(
+      body,
+      user.executiveId,
+    );
+    return result;
+  }
+
+  @Executive()
+  @Get("/executive/meetings/announcements/announcement/:announcementId")
+  @UsePipes(new ZodPipe(apiMeet002))
+  async getExecutiveMeetingAnnouncement(
+    @GetExecutive() user: GetExecutive,
+    @Param() param: ApiMeet002RequestParam,
+  ) {
+    const result = await this.meetingService.getExecutiveMeetingAnnouncement(
+      param,
+      user.executiveId,
+    );
+    return result;
+  }
+
+  @Executive()
+  @Patch("/executive/meetings/announcements/announcement/:announcementId")
+  @UsePipes(new ZodPipe(apiMeet003))
+  async updateExecutiveMeetingAnnouncement(
+    @GetExecutive() user: GetExecutive,
+    @Param() param: ApiMeet003RequestParam,
+    @Body() body: ApiMeet003RequestBody,
+  ): Promise<ApiMeet003ResponseCreated> {
+    const result = await this.meetingService.updateExecutiveMeetingAnnouncement(
+      param,
+      body,
+      user.executiveId,
+    );
+    return result;
+  }
+
+  @Executive()
+  @Delete("/executive/meetings/announcements/announcement/:announcementId")
+  @UsePipes(new ZodPipe(apiMeet004))
+  async deleteExecutiveMeetingAnnouncement(
+    @GetExecutive() user: GetExecutive,
+    @Param() param: ApiMeet004RequestParam,
+  ): Promise<ApiMeet004ResponseOk> {
+    const result = await this.meetingService.deleteExecutiveMeetingAnnouncement(
+      param,
+      user.executiveId,
+    );
+    return result;
+  }
+}

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -10,28 +10,27 @@ import {
   UsePipes,
 } from "@nestjs/common";
 
-import apiMeet001, {
-  ApiMeet001RequestBody,
-  ApiMeet001ResponseCreated,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet001";
-import apiMeet002, {
-  ApiMeet002RequestParam,
-  ApiMeet002ResponseOk,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet002";
-import apiMeet003, {
-  ApiMeet003RequestBody,
-  ApiMeet003RequestParam,
-  ApiMeet003ResponseCreated,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet003";
-import apiMeet004, {
-  ApiMeet004RequestParam,
-  ApiMeet004ResponseOk,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet004";
-import apiMeet005, {
-  ApiMeet005RequestQuery,
-  ApiMeet005ResponseOk,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet005";
-import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
+import apiMee001, {
+  ApiMee001RequestBody,
+  ApiMee001ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee001";
+import apiMee002, {
+  ApiMee002RequestParam,
+  ApiMee002ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee002";
+import apiMee003, {
+  ApiMee003RequestBody,
+  ApiMee003RequestParam,
+  ApiMee003ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee003";
+import apiMee004, {
+  ApiMee004RequestParam,
+  ApiMee004ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee004";
+import apiMee005, {
+  ApiMee005RequestQuery,
+  ApiMee005ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee005";
 
 import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
 import { Executive } from "@sparcs-clubs/api/common/util/decorators/method-decorator";
@@ -45,11 +44,11 @@ export default class MeetingController {
 
   @Executive()
   @Post("/executive/meetings/announcements/announcement")
-  @UsePipes(new ZodPipe(apiMeet001))
+  @UsePipes(new ZodPipe(apiMee001))
   async createExecutiveMeetingAnnouncement(
     @GetExecutive() user: GetExecutive,
-    @Body() body: ApiMeet001RequestBody,
-  ): Promise<ApiMeet001ResponseCreated> {
+    @Body() body: ApiMee001RequestBody,
+  ): Promise<ApiMee001ResponseCreated> {
     await this.meetingService.postExecutiveMeetingAnnouncement(
       body,
       user.executiveId,
@@ -58,22 +57,22 @@ export default class MeetingController {
   }
 
   @Get("/meetings/announcements/announcement/:announcementId")
-  @UsePipes(new ZodPipe(apiMeet002))
+  @UsePipes(new ZodPipe(apiMee002))
   async getMeetingAnnouncement(
-    @Param() param: ApiMeet002RequestParam,
-  ): Promise<ApiMeet002ResponseOk> {
+    @Param() param: ApiMee002RequestParam,
+  ): Promise<ApiMee002ResponseOk> {
     const result = await this.meetingService.getMeetingAnnouncement(param);
     return result;
   }
 
   @Executive()
   @Patch("/executive/meetings/announcements/announcement/:announcementId")
-  @UsePipes(new ZodPipe(apiMeet003))
+  @UsePipes(new ZodPipe(apiMee003))
   async updateExecutiveMeetingAnnouncement(
     @GetExecutive() user: GetExecutive,
-    @Param() param: ApiMeet003RequestParam,
-    @Body() body: ApiMeet003RequestBody,
-  ): Promise<ApiMeet003ResponseCreated> {
+    @Param() param: ApiMee003RequestParam,
+    @Body() body: ApiMee003RequestBody,
+  ): Promise<ApiMee003ResponseCreated> {
     await this.meetingService.updateExecutiveMeetingAnnouncement(
       param,
       body,
@@ -84,11 +83,11 @@ export default class MeetingController {
 
   @Executive()
   @Delete("/executive/meetings/announcements/announcement/:announcementId")
-  @UsePipes(new ZodPipe(apiMeet004))
+  @UsePipes(new ZodPipe(apiMee004))
   async deleteExecutiveMeetingAnnouncement(
     @GetExecutive() user: GetExecutive,
-    @Param() param: ApiMeet004RequestParam,
-  ): Promise<ApiMeet004ResponseOk> {
+    @Param() param: ApiMee004RequestParam,
+  ): Promise<ApiMee004ResponseOk> {
     await this.meetingService.deleteExecutiveMeetingAnnouncement(
       param,
       user.executiveId,
@@ -98,16 +97,13 @@ export default class MeetingController {
 
   @Executive()
   @Get("executive/meetings/meeting/degree")
-  @UsePipes(new ZodPipe(apiMeet005))
+  @UsePipes(new ZodPipe(apiMee005))
   async getMeetingDegree(
     @GetExecutive() user: GetExecutive,
-    @Query() query: ApiMeet005RequestQuery,
-  ): Promise<ApiMeet005ResponseOk> {
-    const inputQuery = {
-      meetingEnumId: query.meetingEnumId as unknown as MeetingEnum,
-    };
+    @Query() query: ApiMee005RequestQuery,
+  ): Promise<ApiMee005ResponseOk> {
     const degree = await this.meetingService.getExecutiveMeetingDegree(
-      inputQuery,
+      query,
       user.executiveId,
     );
 

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -81,10 +81,10 @@ export default class MeetingController {
     @GetExecutive() user: GetExecutive,
     @Param() param: ApiMeet004RequestParam,
   ): Promise<ApiMeet004ResponseOk> {
-    const result = await this.meetingService.deleteExecutiveMeetingAnnouncement(
+    await this.meetingService.deleteExecutiveMeetingAnnouncement(
       param,
       user.executiveId,
     );
-    return result;
+    return {};
   }
 }

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -37,7 +37,7 @@ import { MeetingService } from "./meeting.service";
 export default class MeetingController {
   constructor(private meetingService: MeetingService) {}
 
-  // @Executive()
+  @Executive()
   @Post("/executive/meetings/announcements/announcement")
   @UsePipes(new ZodPipe(apiMeet001))
   async createExecutiveMeetingAnnouncement(
@@ -53,14 +53,8 @@ export default class MeetingController {
 
   @Get("/meetings/announcements/announcement/:announcementId")
   @UsePipes(new ZodPipe(apiMeet002))
-  async getExecutiveMeetingAnnouncement(
-    @GetExecutive() user: GetExecutive,
-    @Param() param: ApiMeet002RequestParam,
-  ) {
-    const result = await this.meetingService.getExecutiveMeetingAnnouncement(
-      param,
-      user.executiveId,
-    );
+  async getMeetingAnnouncement(@Param() param: ApiMeet002RequestParam) {
+    const result = await this.meetingService.getMeetingAnnouncement(param);
     return result;
   }
 

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -66,12 +66,12 @@ export default class MeetingController {
     @Param() param: ApiMeet003RequestParam,
     @Body() body: ApiMeet003RequestBody,
   ): Promise<ApiMeet003ResponseCreated> {
-    const result = await this.meetingService.updateExecutiveMeetingAnnouncement(
+    await this.meetingService.updateExecutiveMeetingAnnouncement(
       param,
       body,
       user.executiveId,
     );
-    return result;
+    return {};
   }
 
   @Executive()

--- a/packages/api/src/feature/meeting/meeting.controller.ts
+++ b/packages/api/src/feature/meeting/meeting.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UsePipes,
 } from "@nestjs/common";
 
@@ -15,7 +16,7 @@ import apiMeet001, {
 } from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet001";
 import apiMeet002, {
   ApiMeet002RequestParam,
-  // ApiMeet002ResponseOk,
+  ApiMeet002ResponseOk,
 } from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet002";
 import apiMeet003, {
   ApiMeet003RequestBody,
@@ -26,6 +27,11 @@ import apiMeet004, {
   ApiMeet004RequestParam,
   ApiMeet004ResponseOk,
 } from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet004";
+import apiMeet005, {
+  ApiMeet005RequestQuery,
+  ApiMeet005ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet005";
+import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
 
 import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
 import { Executive } from "@sparcs-clubs/api/common/util/decorators/method-decorator";
@@ -53,7 +59,9 @@ export default class MeetingController {
 
   @Get("/meetings/announcements/announcement/:announcementId")
   @UsePipes(new ZodPipe(apiMeet002))
-  async getMeetingAnnouncement(@Param() param: ApiMeet002RequestParam) {
+  async getMeetingAnnouncement(
+    @Param() param: ApiMeet002RequestParam,
+  ): Promise<ApiMeet002ResponseOk> {
     const result = await this.meetingService.getMeetingAnnouncement(param);
     return result;
   }
@@ -86,5 +94,23 @@ export default class MeetingController {
       user.executiveId,
     );
     return {};
+  }
+
+  @Executive()
+  @Get("executive/meetings/meeting/degree")
+  @UsePipes(new ZodPipe(apiMeet005))
+  async getMeetingDegree(
+    @GetExecutive() user: GetExecutive,
+    @Query() query: ApiMeet005RequestQuery,
+  ): Promise<ApiMeet005ResponseOk> {
+    const inputQuery = {
+      meetingEnumId: query.meetingEnumId as unknown as MeetingEnum,
+    };
+    const degree = await this.meetingService.getExecutiveMeetingDegree(
+      inputQuery,
+      user.executiveId,
+    );
+
+    return { degree };
   }
 }

--- a/packages/api/src/feature/meeting/meeting.module.ts
+++ b/packages/api/src/feature/meeting/meeting.module.ts
@@ -2,12 +2,24 @@ import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { StudentRepository } from "../user/repository/student.repository";
+import UserPublicService from "../user/service/user.public.service";
+import UserModule from "../user/user.module";
+
+import MeetingController from "./meeting.controller";
 import { MeetingGateway } from "./meeting.gateway";
 import { MeetingRepository } from "./meeting.repository";
 import { MeetingService } from "./meeting.service";
 
 @Module({
-  imports: [DrizzleModule],
-  providers: [MeetingGateway, MeetingService, MeetingRepository],
+  imports: [DrizzleModule, UserModule],
+  controllers: [MeetingController],
+  providers: [
+    MeetingGateway,
+    MeetingService,
+    MeetingRepository,
+    UserPublicService,
+    StudentRepository,
+  ],
 })
 export class MeetingModule {}

--- a/packages/api/src/feature/meeting/meeting.repository.ts
+++ b/packages/api/src/feature/meeting/meeting.repository.ts
@@ -4,6 +4,8 @@ import { and, eq } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 
 import {
+  // Meeting,
+  // MeetingAnnouncement,
   MeetingAttendanceTimeT,
   MeetingVoteResult,
 } from "@sparcs-clubs/api/drizzle/schema/meeting.schema";
@@ -48,5 +50,51 @@ export class MeetingRepository {
     });
 
     return result;
+  }
+
+  async postExecutiveMeetingAnnouncement() //   contents: {
+  //   meetingTypeId: number;
+  //   announcementTitle: string;
+  //   announcementContent: string;
+  //   startDate: Date;
+  //   endDate?: Date;
+  //   isRegular: boolean;
+  //   location: string;
+  // }
+  : Promise<boolean> {
+    // const isInsertionSucceed = await this.db.transaction(async tx => {
+    //   const [announcementInsertResult] = await tx.insert(MeetingAnnouncement).values({
+    //     announcementTitle: contents.announcementTitle,
+    //     announcementContent: contents.announcementContent,
+    //   });
+
+    //   if (announcementInsertResult.affectedRows !== 1) {
+    //     return false;
+    //   }
+
+    //   const [meetingInsertResult] = await tx.insert(Meeting).values({
+    //     announcementId: 1,  // 이거 실제로 받아오기
+    //     meetingEnum: contents.meetingTypeId,
+    //     startDate: contents.startDate,
+    //     endDate: contents.endDate,
+    //     isRegular: contents.isRegular,
+    //     location: contents.location,
+    //   });
+    // }
+
+    // return isInsertionSucceed;
+    return true;
+  }
+
+  async getExecutiveMeetingAnnouncement() {
+    return true;
+  }
+
+  async updateExecutiveMeetingAnnouncement() {
+    return true;
+  }
+
+  async deleteExecutiveMeetingAnnouncement() {
+    return true;
   }
 }

--- a/packages/api/src/feature/meeting/meeting.repository.ts
+++ b/packages/api/src/feature/meeting/meeting.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, gte, lt } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
@@ -272,5 +272,24 @@ export class MeetingRepository {
     });
 
     return isDeleteSucceed;
+  }
+
+  async selectExecutiveMeetingDegree(query: { meetingEnumId: number }) {
+    const thisYear = getKSTDate().getFullYear();
+    const startDate = new Date(thisYear, 0, 1);
+    const endDate = new Date(thisYear + 1, 0, 1);
+
+    const result = await this.db
+      .select()
+      .from(Meeting)
+      .where(
+        and(
+          eq(Meeting.meetingEnumId, query.meetingEnumId),
+          gte(Meeting.startDate, startDate),
+          lt(Meeting.startDate, endDate),
+        ),
+      );
+
+    return result.length;
   }
 }

--- a/packages/api/src/feature/meeting/meeting.repository.ts
+++ b/packages/api/src/feature/meeting/meeting.repository.ts
@@ -63,6 +63,7 @@ export class MeetingRepository {
     location: string;
     locationEn: string;
   }): Promise<boolean> {
+    // TODO: string인 필수 field validation
     const isInsertionSucceed = await this.db.transaction(async tx => {
       const [announcementInsertResult] = await tx
         .insert(MeetingAnnouncement)
@@ -87,6 +88,7 @@ export class MeetingRepository {
         endDate: contents.endDate,
         isRegular: contents.isRegular,
         location: contents.location,
+        locationEn: contents.locationEn,
       });
       if (meetingInsertResult.affectedRows !== 1) {
         logger.debug("[MeetingRepository] Failed to insert meeting");
@@ -101,8 +103,46 @@ export class MeetingRepository {
     return isInsertionSucceed;
   }
 
-  async getExecutiveMeetingAnnouncement() {
-    return true;
+  async selectMeetingAnnouncementById(announcementId: number) {
+    const result = await this.db
+      .select({
+        announcementTitle: MeetingAnnouncement.announcementTitle,
+        announcementContent: MeetingAnnouncement.announcementContent,
+      })
+      .from(MeetingAnnouncement)
+      .where(eq(MeetingAnnouncement.id, announcementId))
+      .execute();
+
+    if (result.length !== 1) {
+      logger.debug(
+        `[MeetingRepository] Failed to select announcement: ${announcementId}`,
+      );
+      return null;
+    }
+    return result[0];
+  }
+
+  async selectMeetingById(announcementId: number) {
+    const result = await this.db
+      .select({
+        meetingEnumId: Meeting.meetingEnumId,
+        startDate: Meeting.startDate,
+        endDate: Meeting.endDate,
+        isRegular: Meeting.isRegular,
+        location: Meeting.location,
+        locationEn: Meeting.locationEn,
+      })
+      .from(Meeting)
+      .where(eq(Meeting.announcementId, announcementId))
+      .execute();
+
+    if (result.length !== 1) {
+      logger.debug(
+        `[MeetingRepository] Failed to select meeting: ${announcementId}`,
+      );
+      return null;
+    }
+    return result[0];
   }
 
   async updateExecutiveMeetingAnnouncement() {

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -73,20 +73,25 @@ export class MeetingService {
     return result;
   }
 
-  async getExecutiveMeetingAnnouncement(
-    param: ApiMeet002RequestParam,
-    executiveId: number,
-  ) {
-    const user = await this.userPublicService.getExecutiveById({
-      id: executiveId,
-    });
+  async getMeetingAnnouncement(param: ApiMeet002RequestParam) {
+    const meeting = await this.meetingRepository.selectMeetingById(
+      param.announcementId,
+    );
+    const meetingAnnouncement =
+      await this.meetingRepository.selectMeetingAnnouncementById(
+        param.announcementId,
+      );
 
-    if (!user) {
-      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
-    }
-    const result =
-      await this.meetingRepository.getExecutiveMeetingAnnouncement();
-    return result;
+    return {
+      meetingEnumId: meeting.meetingEnumId,
+      announcementTitle: meetingAnnouncement.announcementTitle,
+      announcementContent: meetingAnnouncement.announcementContent,
+      startDate: meeting.startDate,
+      endDate: meeting.endDate,
+      isRegular: meeting.isRegular,
+      location: meeting.location,
+      locationEn: meeting.locationEn,
+    };
   }
 
   async updateExecutiveMeetingAnnouncement(

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -131,4 +131,22 @@ export class MeetingService {
       await this.meetingRepository.deleteExecutiveMeetingAnnouncement(param);
     return result;
   }
+
+  async getExecutiveMeetingDegree(
+    query: { meetingEnumId: number },
+    executiveId: number,
+  ) {
+    const user = await this.userPublicService.getExecutiveById({
+      id: executiveId,
+    });
+
+    if (!user) {
+      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
+    }
+
+    const result =
+      await this.meetingRepository.selectExecutiveMeetingDegree(query);
+
+    return result;
+  }
 }

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -68,7 +68,7 @@ export class MeetingService {
     }
 
     const result =
-      await this.meetingRepository.postExecutiveMeetingAnnouncement();
+      await this.meetingRepository.postExecutiveMeetingAnnouncement(body);
 
     return result;
   }
@@ -86,7 +86,6 @@ export class MeetingService {
     }
     const result =
       await this.meetingRepository.getExecutiveMeetingAnnouncement();
-
     return result;
   }
 

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -3,22 +3,19 @@ import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 import { WsException } from "@nestjs/websockets";
 
 import {
-  ApiMeet001RequestBody,
-  ApiMeet001ResponseCreated,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet001";
+  ApiMee001RequestBody,
+  ApiMee001ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee001";
+import { ApiMee002RequestParam } from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee002";
 import {
-  ApiMeet002RequestParam,
-  // ApiMeet002ResponseOk,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet002";
+  ApiMee003RequestBody,
+  ApiMee003RequestParam,
+  ApiMee003ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee003";
 import {
-  ApiMeet003RequestBody,
-  ApiMeet003RequestParam,
-  ApiMeet003ResponseCreated,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet003";
-import {
-  ApiMeet004RequestParam,
-  ApiMeet004ResponseOk,
-} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet004";
+  ApiMee004RequestParam,
+  ApiMee004ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMee004";
 
 import UserPublicService from "../user/service/user.public.service";
 
@@ -56,9 +53,10 @@ export class MeetingService {
   }
 
   async postExecutiveMeetingAnnouncement(
-    body: ApiMeet001RequestBody,
+    body: ApiMee001RequestBody,
     executiveId: number,
-  ): Promise<ApiMeet001ResponseCreated> {
+  ): Promise<ApiMee001ResponseCreated> {
+    // TODO: 국장단 여부 확인
     const user = await this.userPublicService.getExecutiveById({
       id: executiveId,
     });
@@ -73,7 +71,7 @@ export class MeetingService {
     return result;
   }
 
-  async getMeetingAnnouncement(param: ApiMeet002RequestParam) {
+  async getMeetingAnnouncement(param: ApiMee002RequestParam) {
     const meeting = await this.meetingRepository.selectMeetingById(
       param.announcementId,
     );
@@ -95,10 +93,11 @@ export class MeetingService {
   }
 
   async updateExecutiveMeetingAnnouncement(
-    param: ApiMeet003RequestParam,
-    body: ApiMeet003RequestBody,
+    param: ApiMee003RequestParam,
+    body: ApiMee003RequestBody,
     executiveId: number,
-  ): Promise<ApiMeet003ResponseCreated> {
+  ): Promise<ApiMee003ResponseCreated> {
+    // TODO: 국장단 여부 확인
     const user = await this.userPublicService.getExecutiveById({
       id: executiveId,
     });
@@ -116,9 +115,10 @@ export class MeetingService {
   }
 
   async deleteExecutiveMeetingAnnouncement(
-    param: ApiMeet004RequestParam,
+    param: ApiMee004RequestParam,
     executiveId: number,
-  ): Promise<ApiMeet004ResponseOk> {
+  ): Promise<ApiMee004ResponseOk> {
+    // TODO: 국장단 여부 확인
     const user = await this.userPublicService.getExecutiveById({
       id: executiveId,
     });
@@ -136,6 +136,7 @@ export class MeetingService {
     query: { meetingEnumId: number },
     executiveId: number,
   ) {
+    // TODO: 국장단 여부 확인
     const user = await this.userPublicService.getExecutiveById({
       id: executiveId,
     });

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -126,8 +126,9 @@ export class MeetingService {
     if (!user) {
       throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
     }
+
     const result =
-      await this.meetingRepository.deleteExecutiveMeetingAnnouncement();
+      await this.meetingRepository.deleteExecutiveMeetingAnnouncement(param);
     return result;
   }
 }

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -107,7 +107,10 @@ export class MeetingService {
       throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
     }
     const result =
-      await this.meetingRepository.updateExecutiveMeetingAnnouncement();
+      await this.meetingRepository.updateExecutiveMeetingAnnouncement(
+        param,
+        body,
+      );
 
     return result;
   }

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -1,12 +1,35 @@
-import { Injectable } from "@nestjs/common";
+import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 
 import { WsException } from "@nestjs/websockets";
+
+import {
+  ApiMeet001RequestBody,
+  ApiMeet001ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet001";
+import {
+  ApiMeet002RequestParam,
+  // ApiMeet002ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet002";
+import {
+  ApiMeet003RequestBody,
+  ApiMeet003RequestParam,
+  ApiMeet003ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet003";
+import {
+  ApiMeet004RequestParam,
+  ApiMeet004ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/endpoint/apiMeet004";
+
+import UserPublicService from "../user/service/user.public.service";
 
 import { MeetingRepository } from "./meeting.repository";
 
 @Injectable()
 export class MeetingService {
-  constructor(private readonly meetingRepository: MeetingRepository) {}
+  constructor(
+    private readonly meetingRepository: MeetingRepository,
+    private readonly userPublicService: UserPublicService,
+  ) {}
 
   async entryMeeting(meetingId: number, userId: number) {
     const result = await this.meetingRepository.entryMeeting(meetingId, userId);
@@ -29,6 +52,75 @@ export class MeetingService {
     if (!result) {
       throw new WsException("Failed to exit meeting");
     }
+    return result;
+  }
+
+  async postExecutiveMeetingAnnouncement(
+    body: ApiMeet001RequestBody,
+    executiveId: number,
+  ): Promise<ApiMeet001ResponseCreated> {
+    const user = await this.userPublicService.getExecutiveById({
+      id: executiveId,
+    });
+
+    if (!user) {
+      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
+    }
+
+    const result =
+      await this.meetingRepository.postExecutiveMeetingAnnouncement();
+
+    return result;
+  }
+
+  async getExecutiveMeetingAnnouncement(
+    param: ApiMeet002RequestParam,
+    executiveId: number,
+  ) {
+    const user = await this.userPublicService.getExecutiveById({
+      id: executiveId,
+    });
+
+    if (!user) {
+      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
+    }
+    const result =
+      await this.meetingRepository.getExecutiveMeetingAnnouncement();
+
+    return result;
+  }
+
+  async updateExecutiveMeetingAnnouncement(
+    param: ApiMeet003RequestParam,
+    body: ApiMeet003RequestBody,
+    executiveId: number,
+  ): Promise<ApiMeet003ResponseCreated> {
+    const user = await this.userPublicService.getExecutiveById({
+      id: executiveId,
+    });
+
+    if (!user) {
+      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
+    }
+    const result =
+      await this.meetingRepository.updateExecutiveMeetingAnnouncement();
+
+    return result;
+  }
+
+  async deleteExecutiveMeetingAnnouncement(
+    param: ApiMeet004RequestParam,
+    executiveId: number,
+  ): Promise<ApiMeet004ResponseOk> {
+    const user = await this.userPublicService.getExecutiveById({
+      id: executiveId,
+    });
+
+    if (!user) {
+      throw new HttpException("Executive not found", HttpStatus.NOT_FOUND);
+    }
+    const result =
+      await this.meetingRepository.deleteExecutiveMeetingAnnouncement();
     return result;
   }
 }

--- a/packages/api/src/feature/user/repository/executive.repository.ts
+++ b/packages/api/src/feature/user/repository/executive.repository.ts
@@ -26,4 +26,19 @@ export default class ExecutiveRepository {
       );
     return result.length > 0;
   }
+
+  async getExecutiveById(id: number) {
+    const crt = getKSTDate();
+    const result = await this.db
+      .select()
+      .from(ExecutiveT)
+      .where(
+        and(
+          eq(ExecutiveT.executiveId, id),
+          gte(ExecutiveT.endTerm, crt),
+          lte(ExecutiveT.startTerm, crt),
+        ),
+      );
+    return result;
+  }
 }

--- a/packages/api/src/feature/user/repository/executive.repository.ts
+++ b/packages/api/src/feature/user/repository/executive.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, isNull, lte } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 
 import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
@@ -37,6 +37,7 @@ export default class ExecutiveRepository {
           eq(ExecutiveT.executiveId, id),
           gte(ExecutiveT.endTerm, crt),
           lte(ExecutiveT.startTerm, crt),
+          isNull(ExecutiveT.deletedAt),
         ),
       );
     return result;

--- a/packages/api/src/feature/user/service/user.public.service.ts
+++ b/packages/api/src/feature/user/service/user.public.service.ts
@@ -27,6 +27,10 @@ export default class UserPublicService {
     return students[0];
   }
 
+  /**
+   * 집행부원의 id를 통해 집행부원 정보를 가져옵니다.
+   * 만약 매치되는 집행부원이 존재하지 않을 경우 undefined를 리턴합니다.
+   * */
   async getExecutiveById(executive: { id: number }) {
     const executives = await this.executiveRepository.getExecutiveById(
       executive.id,

--- a/packages/api/src/feature/user/service/user.public.service.ts
+++ b/packages/api/src/feature/user/service/user.public.service.ts
@@ -1,10 +1,14 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 
+import ExecutiveRepository from "../repository/executive.repository";
 import { StudentRepository } from "../repository/student.repository";
 
 @Injectable()
 export default class UserPublicService {
-  constructor(private studentRepository: StudentRepository) {}
+  constructor(
+    private studentRepository: StudentRepository,
+    private executiveRepository: ExecutiveRepository,
+  ) {}
 
   /**
    * 학생의 id를 통해 학생 정보를 가져옵니다.
@@ -21,6 +25,21 @@ export default class UserPublicService {
     }
 
     return students[0];
+  }
+
+  async getExecutiveById(executive: { id: number }) {
+    const executives = await this.executiveRepository.getExecutiveById(
+      executive.id,
+    );
+
+    if (executives.length > 1)
+      throw new HttpException("unreachable", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    if (executives.length === 0) {
+      return undefined;
+    }
+
+    return executives[0];
   }
 
   async isNotGraduateStudent(

--- a/packages/interface/src/api/meeting/endpoint/apiMee001.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMee001.ts
@@ -17,13 +17,13 @@ const requestQuery = z.object({});
 
 const requestBody = z.object({
   meetingEnumId: z.nativeEnum(MeetingEnum),
-  announcementTitle: z.coerce.string(),
-  announcementContent: z.coerce.string(),
+  announcementTitle: z.coerce.string().min(1),
+  announcementContent: z.coerce.string().min(1),
   startDate: z.coerce.date(),
   endDate: z.coerce.date().optional(),
   isRegular: z.coerce.boolean(),
-  location: z.coerce.string(),
-  locationEn: z.coerce.string(),
+  location: z.coerce.string().min(1),
+  locationEn: z.coerce.string().min(1),
 });
 
 const responseBodyMap = {
@@ -32,7 +32,7 @@ const responseBodyMap = {
 
 const responseErrorMap = {};
 
-const apiMeet001 = {
+const apiMee001 = {
   url,
   method,
   requestParam,
@@ -42,18 +42,18 @@ const apiMeet001 = {
   responseErrorMap,
 };
 
-type ApiMeet001RequestParam = z.infer<typeof apiMeet001.requestParam>;
-type ApiMeet001RequestQuery = z.infer<typeof apiMeet001.requestQuery>;
-type ApiMeet001RequestBody = z.infer<typeof apiMeet001.requestBody>;
-type ApiMeet001ResponseCreated = z.infer<
-  (typeof apiMeet001.responseBodyMap)[201]
+type ApiMee001RequestParam = z.infer<typeof apiMee001.requestParam>;
+type ApiMee001RequestQuery = z.infer<typeof apiMee001.requestQuery>;
+type ApiMee001RequestBody = z.infer<typeof apiMee001.requestBody>;
+type ApiMee001ResponseCreated = z.infer<
+  (typeof apiMee001.responseBodyMap)[201]
 >;
 
-export default apiMeet001;
+export default apiMee001;
 
 export type {
-  ApiMeet001RequestParam,
-  ApiMeet001RequestQuery,
-  ApiMeet001RequestBody,
-  ApiMeet001ResponseCreated,
+  ApiMee001RequestParam,
+  ApiMee001RequestQuery,
+  ApiMee001RequestBody,
+  ApiMee001ResponseCreated,
 };

--- a/packages/interface/src/api/meeting/endpoint/apiMee002.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMee002.ts
@@ -35,7 +35,7 @@ const responseBodyMap = {
 
 const responseErrorMap = {};
 
-const apiMeet002 = {
+const apiMee002 = {
   url,
   method,
   requestParam,
@@ -45,16 +45,16 @@ const apiMeet002 = {
   responseErrorMap,
 };
 
-type ApiMeet002RequestParam = z.infer<typeof apiMeet002.requestParam>;
-type ApiMeet002RequestQuery = z.infer<typeof apiMeet002.requestQuery>;
-type ApiMeet002RequestBody = z.infer<typeof apiMeet002.requestBody>;
-type ApiMeet002ResponseOk = z.infer<(typeof apiMeet002.responseBodyMap)[200]>;
+type ApiMee002RequestParam = z.infer<typeof apiMee002.requestParam>;
+type ApiMee002RequestQuery = z.infer<typeof apiMee002.requestQuery>;
+type ApiMee002RequestBody = z.infer<typeof apiMee002.requestBody>;
+type ApiMee002ResponseOk = z.infer<(typeof apiMee002.responseBodyMap)[200]>;
 
-export default apiMeet002;
+export default apiMee002;
 
 export type {
-  ApiMeet002RequestParam,
-  ApiMeet002RequestQuery,
-  ApiMeet002RequestBody,
-  ApiMeet002ResponseOk,
+  ApiMee002RequestParam,
+  ApiMee002RequestQuery,
+  ApiMee002RequestBody,
+  ApiMee002ResponseOk,
 };

--- a/packages/interface/src/api/meeting/endpoint/apiMee003.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMee003.ts
@@ -35,7 +35,7 @@ const responseBodyMap = {
 
 const responseErrorMap = {};
 
-const apiMeet003 = {
+const apiMee003 = {
   url,
   method,
   requestParam,
@@ -45,18 +45,18 @@ const apiMeet003 = {
   responseErrorMap,
 };
 
-type ApiMeet003RequestParam = z.infer<typeof apiMeet003.requestParam>;
-type ApiMeet003RequestQuery = z.infer<typeof apiMeet003.requestQuery>;
-type ApiMeet003RequestBody = z.infer<typeof apiMeet003.requestBody>;
-type ApiMeet003ResponseCreated = z.infer<
-  (typeof apiMeet003.responseBodyMap)[201]
+type ApiMee003RequestParam = z.infer<typeof apiMee003.requestParam>;
+type ApiMee003RequestQuery = z.infer<typeof apiMee003.requestQuery>;
+type ApiMee003RequestBody = z.infer<typeof apiMee003.requestBody>;
+type ApiMee003ResponseCreated = z.infer<
+  (typeof apiMee003.responseBodyMap)[201]
 >;
 
-export default apiMeet003;
+export default apiMee003;
 
 export type {
-  ApiMeet003RequestParam,
-  ApiMeet003RequestQuery,
-  ApiMeet003RequestBody,
-  ApiMeet003ResponseCreated,
+  ApiMee003RequestParam,
+  ApiMee003RequestQuery,
+  ApiMee003RequestBody,
+  ApiMee003ResponseCreated,
 };

--- a/packages/interface/src/api/meeting/endpoint/apiMee004.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMee004.ts
@@ -24,7 +24,7 @@ const responseBodyMap = {
 
 const responseErrorMap = {};
 
-const apiMeet004 = {
+const apiMee004 = {
   url,
   method,
   requestParam,
@@ -34,16 +34,16 @@ const apiMeet004 = {
   responseErrorMap,
 };
 
-type ApiMeet004RequestParam = z.infer<typeof apiMeet004.requestParam>;
-type ApiMeet004RequestQuery = z.infer<typeof apiMeet004.requestQuery>;
-type ApiMeet004RequestBody = z.infer<typeof apiMeet004.requestBody>;
-type ApiMeet004ResponseOk = z.infer<(typeof apiMeet004.responseBodyMap)[200]>;
+type ApiMee004RequestParam = z.infer<typeof apiMee004.requestParam>;
+type ApiMee004RequestQuery = z.infer<typeof apiMee004.requestQuery>;
+type ApiMee004RequestBody = z.infer<typeof apiMee004.requestBody>;
+type ApiMee004ResponseOk = z.infer<(typeof apiMee004.responseBodyMap)[200]>;
 
-export default apiMeet004;
+export default apiMee004;
 
 export type {
-  ApiMeet004RequestParam,
-  ApiMeet004RequestQuery,
-  ApiMeet004RequestBody,
-  ApiMeet004ResponseOk,
+  ApiMee004RequestParam,
+  ApiMee004RequestQuery,
+  ApiMee004RequestBody,
+  ApiMee004ResponseOk,
 };

--- a/packages/interface/src/api/meeting/endpoint/apiMee005.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMee005.ts
@@ -12,7 +12,7 @@ const method = "GET";
 const requestParam = z.object({});
 
 const requestQuery = z.object({
-  meetingEnumId: z.coerce.string(),
+  meetingEnumId: z.coerce.number().min(1),
 });
 
 const requestBody = z.object({});
@@ -25,7 +25,7 @@ const responseBodyMap = {
 
 const responseErrorMap = {};
 
-const apiMeet005 = {
+const apiMee005 = {
   url,
   method,
   requestParam,
@@ -35,16 +35,16 @@ const apiMeet005 = {
   responseErrorMap,
 };
 
-type ApiMeet005RequestParam = z.infer<typeof apiMeet005.requestParam>;
-type ApiMeet005RequestQuery = z.infer<typeof apiMeet005.requestQuery>;
-type ApiMeet005RequestBody = z.infer<typeof apiMeet005.requestBody>;
-type ApiMeet005ResponseOk = z.infer<(typeof apiMeet005.responseBodyMap)[200]>;
+type ApiMee005RequestParam = z.infer<typeof apiMee005.requestParam>;
+type ApiMee005RequestQuery = z.infer<typeof apiMee005.requestQuery>;
+type ApiMee005RequestBody = z.infer<typeof apiMee005.requestBody>;
+type ApiMee005ResponseOk = z.infer<(typeof apiMee005.responseBodyMap)[200]>;
 
-export default apiMeet005;
+export default apiMee005;
 
 export type {
-  ApiMeet005RequestParam,
-  ApiMeet005RequestQuery,
-  ApiMeet005RequestBody,
-  ApiMeet005ResponseOk,
+  ApiMee005RequestParam,
+  ApiMee005RequestQuery,
+  ApiMee005RequestBody,
+  ApiMee005ResponseOk,
 };

--- a/packages/interface/src/api/meeting/endpoint/apiMeet005.ts
+++ b/packages/interface/src/api/meeting/endpoint/apiMeet005.ts
@@ -12,7 +12,7 @@ const method = "GET";
 const requestParam = z.object({});
 
 const requestQuery = z.object({
-  meetingTypeId: z.coerce.number().int().min(1).optional(),
+  meetingEnumId: z.coerce.string(),
 });
 
 const requestBody = z.object({});

--- a/packages/interface/src/api/meeting/index.ts
+++ b/packages/interface/src/api/meeting/index.ts
@@ -1,5 +1,5 @@
-import "./endpoint/apiMeet001";
-import "./endpoint/apiMeet002";
-import "./endpoint/apiMeet003";
-import "./endpoint/apiMeet004";
-import "./endpoint/apiMeet005";
+import "./endpoint/apiMee001";
+import "./endpoint/apiMee002";
+import "./endpoint/apiMee003";
+import "./endpoint/apiMee004";
+import "./endpoint/apiMee005";


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #577 

### 확인 필요한 부분
- MEET001에서 request body에 빠진 내용 있을 때 그 field가 string일 경우 validation에서 걸리지 않고 undefined로 들어감
- query param은 string으로만 들어갈 수 있어서 MEET005의 query param의 타입을 string으로 받은 후 controller에서 MeetingEnum으로 바꿔서 사용했는데 이렇게 해도 되는지


# 스크린샷
### 001
<img width="740" alt="스크린샷 2024-08-10 오후 12 02 32" src="https://github.com/user-attachments/assets/ce6a5ead-a29b-478a-86c3-fb050f63f0ed">
<img width="848" alt="스크린샷 2024-08-10 오후 12 03 49" src="https://github.com/user-attachments/assets/93905493-9def-4c61-a276-9f5fe135e063">

### 002
<img width="747" alt="스크린샷 2024-08-10 오후 11 09 23" src="https://github.com/user-attachments/assets/8c90743a-8c73-410b-aa59-3cab5200ae01">

### 003
<img width="754" alt="스크린샷 2024-08-11 오전 4 41 46" src="https://github.com/user-attachments/assets/dd7c60d9-5b19-4de1-a179-1950cddbfb78">
<img width="744" alt="스크린샷 2024-08-11 오전 4 42 10" src="https://github.com/user-attachments/assets/2b3ab255-a417-4a67-a154-8567a88cb5ea">

### 004
<img width="898" alt="스크린샷 2024-08-11 오전 4 47 07" src="https://github.com/user-attachments/assets/645c15e9-4785-477f-932f-4e81e7e78471">
<img width="752" alt="스크린샷 2024-08-11 오전 4 47 23" src="https://github.com/user-attachments/assets/c1fe5a4e-2447-4c51-b3f3-9cfe71f3e145">

### 005
<img width="724" alt="스크린샷 2024-08-11 오전 10 56 45" src="https://github.com/user-attachments/assets/ab5b33e6-48a6-40ac-a2c7-3ddab73d5819">
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 머지 후 스키마 변경사항 전파
