### PR TITLE
impl mock data on manage-club/activity-report detail page

### DIFF
--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -2,6 +2,8 @@
 
 import React, { ReactNode } from "react";
 
+import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
+
 import { useParams, useRouter } from "next/navigation";
 import styled from "styled-components";
 
@@ -16,7 +18,9 @@ import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import { ProfessorApprovalTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import { mockActivityDetailData } from "@sparcs-clubs/web/features/manage-club/activity-report/_mock/mock";
 import { ActivityProfessorApprovalEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface ActivitySectionProps extends React.PropsWithChildren {
@@ -103,6 +107,28 @@ const ActivityReportDetail: React.FC = () => {
     ProfessorApprovalTagList,
   );
 
+  const editButtonOnClick = () => {
+    router.push(`/manage-club/activity-report/${id}/edit`);
+  };
+
+  const data = mockActivityDetailData;
+
+  const activityType: (type: ActivityTypeEnum) => string = type => {
+    switch (type) {
+      case ActivityTypeEnum.matchedInternalActivity:
+        return "동아리 성격에 합치하는 내부 활동";
+        break;
+      case ActivityTypeEnum.matchedExternalActivity:
+        return "동아리 성격에 합치하는 외부 활동";
+        break;
+      case ActivityTypeEnum.notMatchedActivity:
+        return "동아리 성격에 합치하지 않는 활동";
+        break;
+      default:
+        return "";
+    }
+  };
+
   return (
     <FlexWrapper direction="column" gap={60}>
       <PageHead
@@ -123,38 +149,34 @@ const ActivityReportDetail: React.FC = () => {
             ]}
           />
           <ActivitySection label="활동 정보">
-            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
+            <ActivityDetail>{`활동명: ${data.name}`}</ActivityDetail>
             <ActivityDetail>
-              활동 분류: 동아리 성격에 합치하는 내부 활동
+              {`활동 분류: ${activityType(data.activityTypeEnumId)}`}
             </ActivityDetail>
             <ActivityDetail>
-              활동 기간: 2024년 5월 24일 (금) ~ 2024년 5월 25일 (토)
+              {`활동 기간: ${formatDate(
+                data.durations[0].startTerm,
+              )} ~ ${formatDate(data.durations[0].endTerm)}`}
             </ActivityDetail>
-            <ActivityDetail>활동 장소: 동아리방</ActivityDetail>
-            <ActivityDetail>
-              활동 목적: 동아리 회원 개발 실력 향상
-            </ActivityDetail>
-            <ActivityDetail>활동 내용: 밤을 새서 개발을 했다.</ActivityDetail>
+            <ActivityDetail>{`활동 장소: ${data.location}`}</ActivityDetail>
+            <ActivityDetail>{`활동 목적: ${data.purpose}`}</ActivityDetail>
+            <ActivityDetail>{`활동 내용: ${data.detail}`}</ActivityDetail>
           </ActivitySection>
-          <ActivitySection label="활동 인원(4명)">
-            <ActivityDetail>20200510 이지윤</ActivityDetail>
-            <ActivityDetail>20200511 박병찬</ActivityDetail>
-            <ActivityDetail>20230510 이도라</ActivityDetail>
-            <ActivityDetail>20240510 스팍스</ActivityDetail>
+          <ActivitySection label={`활동 인원(${data.participants.length}명)`}>
+            {data.participants.map((participant: { studentId: number }) => (
+              <ActivityDetail key="1">{`${participant.studentId}`}</ActivityDetail>
+            ))}
           </ActivitySection>
           <ActivitySection label="활동 증빙">
-            <ActivityDetail>활동명: 스팍스 봄학기 해커톤</ActivityDetail>
             <ActivityDetail>첨부 파일</ActivityDetail>
             <ActivityDetail>
               <FilePreviewContainer>
-                <FilePreview fileName="bamsaem.pdf" />
-                <FilePreview fileName="coffee.pdf" />
-                <FilePreview fileName="gaebal.pdf" />
+                {data.evidenceFiles.map((evidenceFile: { uuid: string }) => (
+                  <FilePreview key="1" fileName={evidenceFile.uuid} />
+                ))}
               </FilePreviewContainer>
             </ActivityDetail>
-            <ActivityDetail>
-              부가 설명: 커피를 마시며 개발을 했고 밤을 샜어요
-            </ActivityDetail>
+            <ActivityDetail>{`부가 설명: ${data.evidence}`}</ActivityDetail>
           </ActivitySection>
           <FlexWrapper
             direction="row"
@@ -176,7 +198,9 @@ const ActivityReportDetail: React.FC = () => {
           </Button>
           <DeleteAndEditButtonContainer>
             <Button type="default">삭제</Button>
-            <Button type="default">수정</Button>
+            <Button type="default" onClick={editButtonOnClick}>
+              수정
+            </Button>
           </DeleteAndEditButtonContainer>
         </ButtonContainer>
       </FlexWrapper>

--- a/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
+++ b/packages/web/src/app/manage-club/activity-report/[id]/page.tsx
@@ -2,7 +2,10 @@
 
 import React, { ReactNode } from "react";
 
-import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
+import {
+  ActivityStatusEnum,
+  ActivityTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/activity.enum";
 
 import { useParams, useRouter } from "next/navigation";
 import styled from "styled-components";
@@ -129,6 +132,37 @@ const ActivityReportDetail: React.FC = () => {
     }
   };
 
+  const activityStatus: (type: ActivityStatusEnum) => string = type => {
+    switch (type) {
+      case ActivityStatusEnum.Applied:
+        return "신청 완료";
+        break;
+      case ActivityStatusEnum.Approved:
+        return "동아리 연합회 승인 완료";
+        break;
+      case ActivityStatusEnum.Rejected:
+        return "동아리 연합회 승인 반려";
+        break;
+      default:
+        return "";
+    }
+  };
+
+  const activityStatusToProgressStatus: (
+    type: ActivityStatusEnum,
+  ) => Status = type => {
+    switch (type) {
+      case ActivityStatusEnum.Applied:
+        return Status.Pending;
+        break;
+      case ActivityStatusEnum.Approved:
+        return Status.Approved;
+        break;
+      default: // ActivityStatusEnum.Rejected:
+        return Status.Canceled;
+    }
+  };
+
   return (
     <FlexWrapper direction="column" gap={60}>
       <PageHead
@@ -136,16 +170,21 @@ const ActivityReportDetail: React.FC = () => {
           { name: "대표 동아리 관리", path: "/manage-club" },
           { name: "활동 보고서", path: "/manage-club/activity-report" },
         ]}
-        title={`활동 보고서 : ${id}(id 가져오기 테스트용)`}
+        title="활동 보고서"
         enableLast
       />
       <FlexWrapper direction="column" gap={40} style={{ alignSelf: "stretch" }}>
         <Card outline={false} padding="32px" gap={20}>
           <ProgressStatus
-            labels={["신청 완료", "동아리 연합회 신청 반려"]}
+            labels={["신청 완료", activityStatus(data.activityStatusEnumId)]}
             progress={[
-              { status: Status.Approved, date: new Date("2024-03-11 21:00") },
-              { status: Status.Canceled, date: new Date("2024-03-11 21:00") },
+              { status: Status.Approved, date: data.writtenTime },
+              {
+                status: activityStatusToProgressStatus(
+                  data.activityStatusEnumId,
+                ),
+                date: data.checkedTime,
+              },
             ]}
           />
           <ActivitySection label="활동 정보">
@@ -163,17 +202,30 @@ const ActivityReportDetail: React.FC = () => {
             <ActivityDetail>{`활동 내용: ${data.detail}`}</ActivityDetail>
           </ActivitySection>
           <ActivitySection label={`활동 인원(${data.participants.length}명)`}>
-            {data.participants.map((participant: { studentId: number }) => (
-              <ActivityDetail key="1">{`${participant.studentId}`}</ActivityDetail>
-            ))}
+            {data.participants.map(
+              (participant: {
+                studentId: number;
+                studentNumber: number;
+                name: string;
+              }) => (
+                <ActivityDetail
+                  key={participant.studentId}
+                >{`${participant.studentNumber} ${participant.name}`}</ActivityDetail>
+              ),
+            )}
           </ActivitySection>
           <ActivitySection label="활동 증빙">
             <ActivityDetail>첨부 파일</ActivityDetail>
             <ActivityDetail>
               <FilePreviewContainer>
-                {data.evidenceFiles.map((evidenceFile: { uuid: string }) => (
-                  <FilePreview key="1" fileName={evidenceFile.uuid} />
-                ))}
+                {data.evidenceFiles.map(
+                  (evidenceFile: { uuid: string }, index: number) => (
+                    <FilePreview
+                      key={`${evidenceFile.uuid}_${index.toString()}`}
+                      fileName={evidenceFile.uuid}
+                    />
+                  ),
+                )}
               </FilePreviewContainer>
             </ActivityDetail>
             <ActivityDetail>{`부가 설명: ${data.evidence}`}</ActivityDetail>

--- a/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
@@ -1,13 +1,27 @@
 import { ApiAct002ResponseOk } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct002";
 
-import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
+import {
+  ActivityStatusEnum,
+  ActivityTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/activity.enum";
 
 import { ActivityProfessorApprovalEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
 
 import { Participant } from "../types/activityReport";
 
-export interface ApiAct002ResponseOkTemp extends ApiAct002ResponseOk {
-  advisorProfessorApproval: ActivityProfessorApprovalEnum;
+export interface ParticipantTemp {
+  studentId: number; // 고유 ID
+  studentNumber: number; // 학번
+  name: string; // 이름
+}
+
+export interface ApiAct002ResponseOkTemp
+  extends Omit<ApiAct002ResponseOk, "participants"> {
+  advisorProfessorApproval: ActivityProfessorApprovalEnum; // 지도교수 승인 상태
+  activityStatusEnumId: ActivityStatusEnum; // 신청 상태 (동연 승인 등)
+  participants: ParticipantTemp[];
+  writtenTime: Date; // 작성 시간
+  checkedTime?: Date; // 승인 또는 반려한 시간
 }
 
 export const mockNewActivityData = [
@@ -143,7 +157,10 @@ export const mockActivityDetailData: ApiAct002ResponseOkTemp = {
   clubId: 1,
   originalName: "술박스",
   name: "스팍스 봄학기 해커톤",
+  activityStatusEnumId: ActivityStatusEnum.Rejected,
   activityTypeEnumId: ActivityTypeEnum.matchedInternalActivity,
+  writtenTime: new Date("2024-07-01 13:00"),
+  checkedTime: new Date("2024-07-02 13:00"),
   durations: [
     {
       startTerm: new Date("2024-07-01"),
@@ -164,16 +181,24 @@ export const mockActivityDetailData: ApiAct002ResponseOkTemp = {
   ],
   participants: [
     {
-      studentId: 20200510,
+      studentId: 1,
+      studentNumber: 20200510,
+      name: "이지윤",
     },
     {
-      studentId: 20200511,
+      studentId: 2,
+      studentNumber: 20200511,
+      name: "박병찬",
     },
     {
-      studentId: 20230510,
+      studentId: 3,
+      studentNumber: 20230510,
+      name: "이도라",
     },
     {
-      studentId: 20240510,
+      studentId: 4,
+      studentNumber: 20240510,
+      name: "스팍스",
     },
   ],
   advisorProfessorApproval: ActivityProfessorApprovalEnum.Requested,

--- a/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
@@ -1,4 +1,14 @@
+import { ApiAct002ResponseOk } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct002";
+
+import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
+
+import { ActivityProfessorApprovalEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+
 import { Participant } from "../types/activityReport";
+
+export interface ApiAct002ResponseOkTemp extends ApiAct002ResponseOk {
+  advisorProfessorApproval: ActivityProfessorApprovalEnum;
+}
 
 export const mockNewActivityData = [
   {
@@ -128,3 +138,43 @@ export const mockParticipantData: Participant[] = [
     email: "nicolelee2001@kaist.ac.kr",
   },
 ];
+
+export const mockActivityDetailData: ApiAct002ResponseOkTemp = {
+  clubId: 1,
+  originalName: "술박스",
+  name: "스팍스 봄학기 해커톤",
+  activityTypeEnumId: ActivityTypeEnum.matchedInternalActivity,
+  durations: [
+    {
+      startTerm: new Date("2024-07-01"),
+      endTerm: new Date("2024-08-15"),
+    },
+  ],
+  location: "동아리방",
+  purpose: "동아리 회원 개발 실력 향상",
+  detail: "밤을 새서 개발을 했다.",
+  evidence: "증거",
+  evidenceFiles: [
+    {
+      uuid: "file-uuid",
+    },
+    {
+      uuid: "file-uuid2",
+    },
+  ],
+  participants: [
+    {
+      studentId: 20200510,
+    },
+    {
+      studentId: 20200511,
+    },
+    {
+      studentId: 20230510,
+    },
+    {
+      studentId: 20240510,
+    },
+  ],
+  advisorProfessorApproval: ActivityProfessorApprovalEnum.Requested,
+};


### PR DESCRIPTION
# 요약

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #608 

## 현재까지 진행한 내용
1. `packages/web/src/features/manage-club/activity-report/_mock/mock.ts` 에 mock data 선언
2. 해당 mock data로 내용 채우기 (신청 상태 및 지도교수 승인 부분 제외)

## 앞으로 진행할 내용 (다음 PR에서)
1. 활동 명단의 이름과 승인 관련 사항에 대해 백엔드와 협의
2. API 연결

## 리뷰 받고 싶은 부분
1. '앞으로 진행할 내용'에 대하여 어떻게 생각하시나요?
2. mock data의 선언 및 사용 방법 등이 적절한가요?

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/b268ed67-b9b5-43b9-af12-042241b89974)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
