### PR TITLE
Impl Table horizontal scroll

### DIFF
--- a/packages/web/src/common/components/Table.tsx
+++ b/packages/web/src/common/components/Table.tsx
@@ -13,11 +13,17 @@ interface TableProps<T> {
   footer?: React.ReactNode;
 }
 
+const TableInnerWrapper = styled.div`
+  width: calc(100% + (100vw - 100%));
+  padding: 0 calc((100vw - 100%) / 2);
+  overflow-x: auto;
+`;
+
 const TableInner = styled.table<{ height?: number }>`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  width: 100%;
+  min-width: 100%;
   border: 1px solid ${({ theme }) => theme.colors.GRAY[300]};
   border-radius: 8px;
   overflow: hidden;
@@ -63,9 +69,16 @@ const EmptyCenterPlacer = styled.div`
 const TableWithCount = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 8px;
   width: 100%;
+`;
+
+const Count = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  align-self: stretch;
 `;
 
 const Table = <T,>({
@@ -84,25 +97,41 @@ const Table = <T,>({
 
   return (
     <TableWithCount>
-      {count && (
-        <Typography fs={16} lh={20}>
-          총 {count}개
-        </Typography>
-      )}
-      <TableInner height={height}>
-        <Header>
-          {table.getHeaderGroups().map(headerGroup => (
-            <HeaderRow key={headerGroup.id}>
-              {headerGroup.headers.map(header => {
-                if (header.isPlaceholder) {
-                  return null;
-                }
-                if (header.column.getCanSort()) {
+      <Count>
+        {count && (
+          <Typography fs={16} lh={20}>
+            총 {count}개
+          </Typography>
+        )}
+      </Count>
+      <TableInnerWrapper>
+        <TableInner height={height}>
+          <Header>
+            {table.getHeaderGroups().map(headerGroup => (
+              <HeaderRow key={headerGroup.id}>
+                {headerGroup.headers.map(header => {
+                  if (header.isPlaceholder) {
+                    return null;
+                  }
+                  if (header.column.getCanSort()) {
+                    return (
+                      <TableCell
+                        key={header.id}
+                        width={header.getSize()}
+                        type="HeaderSort"
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                      </TableCell>
+                    );
+                  }
                   return (
                     <TableCell
                       key={header.id}
                       width={header.getSize()}
-                      type="HeaderSort"
+                      type="Header"
                     >
                       {flexRender(
                         header.column.columnDef.header,
@@ -110,54 +139,45 @@ const Table = <T,>({
                       )}
                     </TableCell>
                   );
-                }
-                return (
-                  <TableCell
-                    key={header.id}
-                    width={header.getSize()}
-                    type="Header"
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                  </TableCell>
-                );
-              })}
-            </HeaderRow>
-          ))}
-        </Header>
-        <Content>
-          {table.getRowModel().rows.length ? (
-            table.getRowModel().rows.map(row => (
-              <ContentRow key={row.id} selected={row.getIsSelected()}>
-                {row.getVisibleCells().map(cell => (
-                  <TableCell
-                    key={cell.id}
-                    width={cell.column.getSize()}
-                    type="Default"
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </ContentRow>
-            ))
-          ) : (
-            <EmptyCenterPlacer>
-              <Typography
-                fs={16}
-                lh={24}
-                color="GRAY.300"
-                ff="PRETENDARD"
-                fw="REGULAR"
-              >
-                {emptyMessage}
-              </Typography>
-            </EmptyCenterPlacer>
-          )}
-          {footer}
-        </Content>
-      </TableInner>
+                })}
+              </HeaderRow>
+            ))}
+          </Header>
+          <Content>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map(row => (
+                <ContentRow key={row.id} selected={row.getIsSelected()}>
+                  {row.getVisibleCells().map(cell => (
+                    <TableCell
+                      key={cell.id}
+                      width={cell.column.getSize()}
+                      type="Default"
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </ContentRow>
+              ))
+            ) : (
+              <EmptyCenterPlacer>
+                <Typography
+                  fs={16}
+                  lh={24}
+                  color="GRAY.300"
+                  ff="PRETENDARD"
+                  fw="REGULAR"
+                >
+                  {emptyMessage}
+                </Typography>
+              </EmptyCenterPlacer>
+            )}
+            {footer}
+          </Content>
+        </TableInner>
+      </TableInnerWrapper>
     </TableWithCount>
   );
 };

--- a/packages/web/src/common/components/Table.tsx
+++ b/packages/web/src/common/components/Table.tsx
@@ -24,6 +24,7 @@ const TableInner = styled.table<{ height?: number }>`
   flex-direction: column;
   align-items: flex-start;
   min-width: 100%;
+  width: fit-content;
   border: 1px solid ${({ theme }) => theme.colors.GRAY[300]};
   border-radius: 8px;
   overflow: hidden;
@@ -117,7 +118,7 @@ const Table = <T,>({
                     return (
                       <TableCell
                         key={header.id}
-                        width={header.getSize()}
+                        width={header.column.getSize()}
                         type="HeaderSort"
                       >
                         {flexRender(
@@ -130,7 +131,7 @@ const Table = <T,>({
                   return (
                     <TableCell
                       key={header.id}
-                      width={header.getSize()}
+                      width={header.column.getSize()}
                       type="Header"
                     >
                       {flexRender(


### PR DESCRIPTION
# 요약 \*

It closes #603

테이블이 가로로 길어짐에 따라 가로로 scroll 하여 볼 수 있도록 하기 위해 Table.tsx를 수정합니다.

바뀐 부분은 아래와 같습니다.
- TableInnerWrapper 추가: 가로 scroll 시에도 Table이 안 잘리려면 공백을 포함한 커다란 Wrapper가 필요하다고 판단했기 때문 
- TableInner `width -> min-width: 100%`로 수정: 언젠가 min-width에 대해 언급하셨던 적이 있는 것(?) 같아서 
- TableWithCount `align-items: center`로 수정: TableInnerWrapper를 가운데 정렬 해야 하는 상황이기 때문
- Count 추가: TableWithCount `align-items: center`으로 수정함에 따라 Count의 정렬 방식을 추가적으로 설정해줘야 했습니다

### 질문 
우연히 발견한 건데 아래처럼 창 너비를 확 줄이면 Content만 스크롤되고 Header는 스크롤이 안 되더라구요 
Content 부분을 `overflow-x: hidden` 처리하면 둘다 스크롤 안 되긴 하는데 그러면 잘리는 부분은 아예 볼 수조차 없는 문제가 있습니다.
나중에 반응형에서 손 보면 되는 것일까요?

그리고 ContentRow 아래 회색 줄도 잘리는 것 같은데.. 너비는 100%인데 내용이 그보다 넘쳐서 생기는 문제 같아요

<img width="532" alt="스크린샷 2024-08-19 오후 10 51 35" src="https://github.com/user-attachments/assets/0cd4f31a-3f1d-44cf-8e0b-96040e3b395f">


# 스크린샷
### width를 **의도적으로** 키우고 확인한 모습입니다.
<img width="1512" alt="스크린샷 2024-08-19 오후 10 21 50" src="https://github.com/user-attachments/assets/64591024-2b2c-4a5c-a39b-d3af2bbabe97">
<img width="1512" alt="스크린샷 2024-08-19 오후 10 21 43" src="https://github.com/user-attachments/assets/78072afe-ac27-4684-a885-82aadf5a3332">
<img width="1512" alt="스크린샷 2024-08-19 오후 10 32 47" src="https://github.com/user-attachments/assets/96722064-7c83-463a-baed-d9ed47d1ce04">


# 이후 Task \*
