### PR TITLE
feat: add committe tag

### DIFF
--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -94,10 +94,10 @@ const FundingTagList: {
 const ApplyTagList: {
   [key in ActivityStatusEnum]: StatusDetail;
 } = {
-  [ActivityStatusEnum.Writing]: { text: "작성 중", color: "BLUE" },
-  [ActivityStatusEnum.Applied]: { text: "신청 완료", color: "PURPLE" },
-  [ActivityStatusEnum.Approved]: { text: "승인 완료", color: "GREEN" },
-  [ActivityStatusEnum.Rejected]: { text: "신청 반려", color: "RED" },
+  [ActivityStatusEnum.Committe]: { text: "운위", color: "ORANGE" },
+  [ActivityStatusEnum.Applied]: { text: "신청", color: "BLUE" },
+  [ActivityStatusEnum.Approved]: { text: "승인", color: "GREEN" },
+  [ActivityStatusEnum.Rejected]: { text: "반려", color: "RED" },
 };
 
 const ProfessorApprovalTagList: {

--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -86,7 +86,7 @@ const FundingTagList: {
   [key in FundingStatusEnum]: StatusDetail;
 } = {
   [FundingStatusEnum.Applied]: { text: "신청", color: "BLUE" },
-  [FundingStatusEnum.Committe]: { text: "운위", color: "YELLOW" },
+  [FundingStatusEnum.Committee]: { text: "운위", color: "YELLOW" },
   [FundingStatusEnum.Approved]: { text: "승인", color: "GREEN" },
   [FundingStatusEnum.Rejected]: { text: "반려", color: "RED" },
 };
@@ -94,7 +94,7 @@ const FundingTagList: {
 const ApplyTagList: {
   [key in ActivityStatusEnum]: StatusDetail;
 } = {
-  [ActivityStatusEnum.Committe]: { text: "운위", color: "ORANGE" },
+  [ActivityStatusEnum.Committee]: { text: "운위", color: "ORANGE" },
   [ActivityStatusEnum.Applied]: { text: "신청", color: "BLUE" },
   [ActivityStatusEnum.Approved]: { text: "승인", color: "GREEN" },
   [ActivityStatusEnum.Rejected]: { text: "반려", color: "RED" },

--- a/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/manage-club/activity-report/_mock/mock.ts
@@ -10,7 +10,7 @@ export const mockNewActivityData = [
     professorApproval: "대기",
   },
   {
-    status: "신청 완료",
+    status: "신청",
     activity: "개발개발한 어떠한 활동",
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
@@ -18,7 +18,7 @@ export const mockNewActivityData = [
     professorApproval: "대기",
   },
   {
-    status: "신청 완료",
+    status: "운위",
     activity: "개발개발한 어떠한 활동",
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
@@ -26,7 +26,7 @@ export const mockNewActivityData = [
     professorApproval: "완료",
   },
   {
-    status: "신청 반려",
+    status: "반려",
     activity: "개발개발한 어떠한 활동",
     category: "동아리 성격에 합치하는 외부 활동",
     startDate: new Date("2024-03-11"),
@@ -34,7 +34,7 @@ export const mockNewActivityData = [
     professorApproval: "반려",
   },
   {
-    status: "승인 완료",
+    status: "승인",
     activity: "개발개발한 어떠한 활동",
     category: "동아리 성격에 합치하는 내부 활동",
     startDate: new Date("2024-03-11"),
@@ -42,7 +42,7 @@ export const mockNewActivityData = [
     professorApproval: "완료",
   },
   {
-    status: "승인 완료",
+    status: "승인",
     activity: "2024년도 봄의기 MT",
     category: "동아리 성격에 합치하지 않는 활동",
     startDate: new Date("2024-03-11"),

--- a/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
@@ -22,13 +22,13 @@ const columnHelper = createColumnHelper<NewActivityReport>();
 
 const getStatusTagColor = (status: string): TagColor => {
   switch (status) {
-    case "작성중":
+    case "운위":
+      return "ORANGE";
+    case "신청":
       return "BLUE";
-    case "신청 완료":
-      return "PURPLE";
-    case "신청 반려":
+    case "반려":
       return "RED";
-    case "승인 완료":
+    case "승인":
       return "GREEN";
     default:
       return "GRAY";

--- a/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
@@ -45,7 +45,7 @@ export interface Members {
 
 export enum ActivityStatusEnum {
   Applied = 1, // 신청
-  Committe, // 운위
+  Committee, // 운위
   Approved, // 승인
   Rejected, // 반려
 }
@@ -64,7 +64,7 @@ export enum ActivityTypeEnum {
 
 export enum FundingStatusEnum {
   Applied = 1, // 신청
-  Committe, // 운위
+  Committee, // 운위
   Approved, // 승인
   Rejected, // 반려
 }

--- a/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
@@ -44,8 +44,8 @@ export interface Members {
 }
 
 export enum ActivityStatusEnum {
-  Writing = 1, // 작성 중
-  Applied, // 신청
+  Applied = 1, // 신청
+  Committe, // 운위
   Approved, // 승인
   Rejected, // 반려
 }


### PR DESCRIPTION
# 요약 \*

manage-club 페이지와 manage-club/activity-report 페이지에 운위 태그 추가.

It closes #418 

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

manage-club페이지의 활동 보고서 테이블과 manage-club/activity-report의 신규활동보고서 테이블이 전체 개수 표시만을 제외하면 동일한것 같아서 추후 신규활동보고서 테이블을 manage-club페이지의 활동보고서 테이블과 동일하도록 코드 수정이 필요할듯합니다.
- 이유: 신규활동보고서 테이블에서 사용하는 NewActivity interface에서는 enum대신 string으로 상태와 타입등을 받아오고있어서 수정이 필요함.
