### PR TITLE
627 impl responsive mainslogan fix bug on font weight

### DIFF
--- a/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
+++ b/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
@@ -55,17 +55,13 @@ const MainPageMainFrame: React.FC = () => (
   <FlexWrapper direction="column" gap={60}>
     <PageTitleWrapper>
       <ResponsiveSloganTypography
-        ff="PRETENDARD"
         fw="SEMIBOLD"
-        color="BLACK"
         style={{ width: "fit-content" }}
       >
         <StyledSpan>동아리</StyledSpan>의 모든 것을 한번에
       </ResponsiveSloganTypography>
       <ResponsiveSloganTypography
-        ff="PRETENDARD"
         fw="SEMIBOLD"
-        color="BLACK"
         style={{ width: "fit-content" }}
       >
         동아리연합회 통합 플랫폼, <BreakBeforeStyledSpan />

--- a/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
+++ b/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
@@ -31,29 +31,46 @@ const StyledSpan = styled.span`
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.SEMIBOLD};
 `;
 
+const BreakBeforeStyledSpan = styled.span`
+  display: none;
+  @media (max-width: 360px) {
+    display: block;
+  }
+`;
+
+const ResponsiveSloganTypography = styled(Typography)`
+  font-size: 32px;
+  line-height: 48px;
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
+    font-size: 28px;
+    line-height: 40px;
+  }
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
+    font-size: 20px;
+    line-height: 32px;
+  }
+`;
+
 const MainPageMainFrame: React.FC = () => (
   <FlexWrapper direction="column" gap={60}>
     <PageTitleWrapper>
-      <Typography
+      <ResponsiveSloganTypography
         ff="PRETENDARD"
-        fs={32}
-        lh={48}
         fw="SEMIBOLD"
         color="BLACK"
         style={{ width: "fit-content" }}
       >
         <StyledSpan>동아리</StyledSpan>의 모든 것을 한번에
-      </Typography>
-      <Typography
+      </ResponsiveSloganTypography>
+      <ResponsiveSloganTypography
         ff="PRETENDARD"
-        fs={32}
-        lh={48}
         fw="SEMIBOLD"
         color="BLACK"
         style={{ width: "fit-content" }}
       >
-        동아리연합회 통합 플랫폼, <StyledSpan>Clubs</StyledSpan>입니다
-      </Typography>
+        동아리연합회 통합 플랫폼, <BreakBeforeStyledSpan />
+        <StyledSpan>Clubs</StyledSpan>입니다
+      </ResponsiveSloganTypography>
     </PageTitleWrapper>
     <NoticeAndServiceWrapper>
       <NoticeSectionFrame />

--- a/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
+++ b/packages/web/src/features/landing/frames/MainPageMainFrame.tsx
@@ -26,6 +26,11 @@ const NoticeAndServiceWrapper = styled.div`
   }
 `;
 
+const StyledSpan = styled.span`
+  color: ${colors.PRIMARY};
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.SEMIBOLD};
+`;
+
 const MainPageMainFrame: React.FC = () => (
   <FlexWrapper direction="column" gap={60}>
     <PageTitleWrapper>
@@ -37,7 +42,7 @@ const MainPageMainFrame: React.FC = () => (
         color="BLACK"
         style={{ width: "fit-content" }}
       >
-        <span style={{ color: colors.PRIMARY }}>동아리</span>의 모든 것을 한번에
+        <StyledSpan>동아리</StyledSpan>의 모든 것을 한번에
       </Typography>
       <Typography
         ff="PRETENDARD"
@@ -47,8 +52,7 @@ const MainPageMainFrame: React.FC = () => (
         color="BLACK"
         style={{ width: "fit-content" }}
       >
-        동아리연합회 통합 플랫폼,{" "}
-        <span style={{ color: colors.PRIMARY }}>Clubs</span>입니다
+        동아리연합회 통합 플랫폼, <StyledSpan>Clubs</StyledSpan>입니다
       </Typography>
     </PageTitleWrapper>
     <NoticeAndServiceWrapper>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #627 

강조된 글씨의 font weight을 figma 기준으로 맞추고,
figma 기준으로 반응형 구현했습니다.

-360px : 'Clubs입니다' 줄바꿈 & sm 사이즈
361-720px : 줄바꿈 안 함 & sm 사이즈
721-960px : md 사이즈
961px- : lg 사이즈

# 스크린샷

![image](https://github.com/user-attachments/assets/35b35be9-fdbc-48de-ae2f-3c1c83cb2a17)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
