### PR TITLE
Add search for /clubs

### DIFF
--- a/packages/web/src/app/clubs/page.tsx
+++ b/packages/web/src/app/clubs/page.tsx
@@ -16,11 +16,6 @@ const Clubs: React.FC = () => {
   const { data, isLoading, isError } = useGetClubsList();
   const isRegistrationPeriod = true;
   const [searchText, setSearchText] = useState<string>("");
-  // const searchFilter = item => return (
-  //   item.name.includes(searchText.toLowerCase()) ||
-  //     item.name.includes(searchText.toUpperCase()) ||
-  //     hangulIncludes(item.name, searchText);
-  // );
 
   return (
     <FlexWrapper direction="column" gap={60}>

--- a/packages/web/src/app/clubs/page.tsx
+++ b/packages/web/src/app/clubs/page.tsx
@@ -1,23 +1,30 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import ClubsSectionFrame from "@sparcs-clubs/web/features/clubs/frames/ClubsSectionFrame";
 import { useGetClubsList } from "@sparcs-clubs/web/features/clubs/services/useGetClubsList";
 
 const Clubs: React.FC = () => {
   const { data, isLoading, isError } = useGetClubsList();
   const isRegistrationPeriod = true;
+  const [searchText, setSearchText] = useState<string>("");
 
   return (
     <FlexWrapper direction="column" gap={60}>
       <PageHead
         items={[{ name: "동아리 목록", path: "/clubs" }]}
         title="동아리 목록"
+      />
+      <SearchInput
+        searchText={searchText}
+        handleChange={setSearchText}
+        placeholder="동아리 이름으로 검색하세요"
       />
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         {isRegistrationPeriod && (
@@ -27,11 +34,13 @@ const Clubs: React.FC = () => {
           {(data?.divisions ?? []).map(division => (
             <ClubsSectionFrame
               title={division.name}
-              clubList={division.clubs.sort((a, b) => {
-                if (a.isPermanent && !b.isPermanent) return -1;
-                if (!a.isPermanent && b.isPermanent) return 1;
-                return a.type - b.type || a.name.localeCompare(b.name);
-              })}
+              clubList={division.clubs
+                .filter(item => item.name.startsWith(searchText))
+                .sort((a, b) => {
+                  if (a.isPermanent && !b.isPermanent) return -1;
+                  if (!a.isPermanent && b.isPermanent) return 1;
+                  return a.type - b.type || a.name.localeCompare(b.name);
+                })}
               key={division.name}
               isRegistrationPeriod={isRegistrationPeriod}
             />

--- a/packages/web/src/app/clubs/page.tsx
+++ b/packages/web/src/app/clubs/page.tsx
@@ -16,6 +16,11 @@ const Clubs: React.FC = () => {
   const { data, isLoading, isError } = useGetClubsList();
   const isRegistrationPeriod = true;
   const [searchText, setSearchText] = useState<string>("");
+  // const searchFilter = item => return (
+  //   item.name.includes(searchText.toLowerCase()) ||
+  //     item.name.includes(searchText.toUpperCase()) ||
+  //     hangulIncludes(item.name, searchText);
+  // );
 
   return (
     <FlexWrapper direction="column" gap={60}>
@@ -33,25 +38,33 @@ const Clubs: React.FC = () => {
           <Info text="현재는 2024년 봄학기 동아리 신청 기간입니다 (신청 마감 : 2024년 3월 10일 23:59)" />
         )}
         <FlexWrapper direction="column" gap={40}>
-          {(data?.divisions ?? []).map(division => (
-            <ClubsSectionFrame
-              title={division.name}
-              clubList={division.clubs
-                .filter(
-                  item =>
-                    item.name.includes(searchText.toLowerCase()) ||
-                    item.name.includes(searchText.toUpperCase()) ||
-                    hangulIncludes(item.name, searchText),
-                )
-                .sort((a, b) => {
-                  if (a.isPermanent && !b.isPermanent) return -1;
-                  if (!a.isPermanent && b.isPermanent) return 1;
-                  return a.type - b.type || a.name.localeCompare(b.name);
-                })}
-              key={division.name}
-              isRegistrationPeriod={isRegistrationPeriod}
-            />
-          ))}
+          {(data?.divisions ?? []).map(
+            division =>
+              division.clubs.filter(
+                item =>
+                  item.name.includes(searchText.toLowerCase()) ||
+                  item.name.includes(searchText.toUpperCase()) ||
+                  hangulIncludes(item.name, searchText),
+              ).length !== 0 && (
+                <ClubsSectionFrame
+                  title={division.name}
+                  clubList={division.clubs
+                    .filter(
+                      item =>
+                        item.name.includes(searchText.toLowerCase()) ||
+                        item.name.includes(searchText.toUpperCase()) ||
+                        hangulIncludes(item.name, searchText),
+                    )
+                    .sort((a, b) => {
+                      if (a.isPermanent && !b.isPermanent) return -1;
+                      if (!a.isPermanent && b.isPermanent) return 1;
+                      return a.type - b.type || a.name.localeCompare(b.name);
+                    })}
+                  key={division.name}
+                  isRegistrationPeriod={isRegistrationPeriod}
+                />
+              ),
+          )}
         </FlexWrapper>
       </AsyncBoundary>
     </FlexWrapper>

--- a/packages/web/src/app/clubs/page.tsx
+++ b/packages/web/src/app/clubs/page.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from "react";
 
+import { hangulIncludes } from "es-hangul";
+
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Info from "@sparcs-clubs/web/common/components/Info";
@@ -35,7 +37,12 @@ const Clubs: React.FC = () => {
             <ClubsSectionFrame
               title={division.name}
               clubList={division.clubs
-                .filter(item => item.name.startsWith(searchText))
+                .filter(
+                  item =>
+                    item.name.includes(searchText.toLowerCase()) ||
+                    item.name.includes(searchText.toUpperCase()) ||
+                    hangulIncludes(item.name, searchText),
+                )
                 .sort((a, b) => {
                   if (a.isPermanent && !b.isPermanent) return -1;
                   if (!a.isPermanent && b.isPermanent) return 1;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #634

동아리 목록에서 동아리 이름으로 검색 가능하도록 합니다.
- 영문은 대문자 소문자 관계 없게
- 한글은 검색어가 포함만 되면 다 뜨게

추가
- 검색 결과 나타나는 동아리가 없는 division은 아예 안 뜨게

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="966" alt="스크린샷 2024-08-20 오후 7 52 08" src="https://github.com/user-attachments/assets/f9bfa6c4-11f3-4c21-9f32-dd80a665a1df">
<img width="1918" alt="스크린샷 2024-08-20 오후 7 52 24" src="https://github.com/user-attachments/assets/a4ee292f-92a3-4bc0-be88-2b8f092b4ee7">
<img width="1918" alt="스크린샷 2024-08-20 오후 7 53 43" src="https://github.com/user-attachments/assets/361e6d9b-1ec6-468a-8bfb-a707090131ee">
<img width="1918" alt="스크린샷 2024-08-20 오후 7 54 16" src="https://github.com/user-attachments/assets/8fb97a04-8003-43d1-9912-d265df44638d">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
