### PR TITLE
Impl registration frame in my

### DIFF
--- a/packages/web/src/app/my/page.tsx
+++ b/packages/web/src/app/my/page.tsx
@@ -15,6 +15,7 @@ import MyChangeDivisionPresident, {
 import MyChangeRepresentative from "@sparcs-clubs/web/features/my/components/MyChangeRepresentative";
 import MyClubFrame from "@sparcs-clubs/web/features/my/frames/MyClubFrame";
 import MyInfoFrame from "@sparcs-clubs/web/features/my/frames/MyInfoFrame";
+import MyRegisterFrame from "@sparcs-clubs/web/features/my/frames/MyRegisterFrame";
 import MyServiceFrame from "@sparcs-clubs/web/features/my/frames/MyServiceFrame";
 import { useGetMyDelegateRequest } from "@sparcs-clubs/web/features/my/services/getMyDelegateRequest";
 
@@ -88,6 +89,7 @@ const My: React.FC = () => {
             onRejected={onDivisionPresidentChangeRequestRejected}
           />
         )}
+        <MyRegisterFrame />
         <MyInfoFrame />
         <MyClubFrame />
         <MyServiceFrame />

--- a/packages/web/src/app/my/page.tsx
+++ b/packages/web/src/app/my/page.tsx
@@ -89,9 +89,9 @@ const My: React.FC = () => {
             onRejected={onDivisionPresidentChangeRequestRejected}
           />
         )}
-        <MyRegisterFrame />
         <MyInfoFrame />
         <MyClubFrame />
+        <MyRegisterFrame />
         <MyServiceFrame />
       </FlexWrapper>
     </AsyncBoundary>

--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -1,6 +1,10 @@
 import { ActivityCertificateOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/activityCertificate.enum";
 import { CommonSpaceUsageOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/commonSpace.enum";
 import { PromotionalPrintingOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/promotionalPrinting.enum";
+import {
+  RegistrationStatusEnum,
+  RegistrationTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/registration.enum";
 import { RentalOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/rental.enum";
 
 import {
@@ -124,6 +128,22 @@ const ActTypeTagList: {
     color: "PURPLE",
   },
 };
+const RegistrationStatusTagList: {
+  [key in RegistrationStatusEnum]: StatusDetail;
+} = {
+  [RegistrationStatusEnum.Approved]: { text: "승인", color: "GREEN" },
+  [RegistrationStatusEnum.Pending]: { text: "신청", color: "BLUE" },
+  [RegistrationStatusEnum.Rejected]: { text: "반려", color: "RED" },
+};
+
+const RegistrationTypeTagList: { [key in RegistrationTypeEnum]: StatusDetail } =
+  {
+    [RegistrationTypeEnum.Renewal]: { text: "재등록", color: "PURPLE" },
+    [RegistrationTypeEnum.Promotional]: { text: "신규 등록", color: "YELLOW" },
+    [RegistrationTypeEnum.NewProvisional]: { text: "가등록", color: "BLUE" },
+    [RegistrationTypeEnum.ReProvisional]: { text: "가등록", color: "BLUE" },
+  };
+
 export {
   AcfTagList,
   CmsTagList,
@@ -134,4 +154,6 @@ export {
   ProfessorApprovalTagList,
   ActTypeTagList,
   FundingTagList,
+  RegistrationTypeTagList,
+  RegistrationStatusTagList,
 };

--- a/packages/web/src/features/executive/activity-certificate/components/ExecutiveAcfTable.tsx
+++ b/packages/web/src/features/executive/activity-certificate/components/ExecutiveAcfTable.tsx
@@ -13,7 +13,7 @@ import { mockExecutiveAcf } from "@sparcs-clubs/web/features/executive/_mock/moc
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-interface ExecutivePrintingTableProps {
+interface ExecutiveAcfTableProps {
   acfList: typeof mockExecutiveAcf;
 }
 
@@ -68,9 +68,7 @@ const columns = [
   }),
 ];
 
-const ExecutiveAcfTable: React.FC<ExecutivePrintingTableProps> = ({
-  acfList,
-}) => {
+const ExecutiveAcfTable: React.FC<ExecutiveAcfTableProps> = ({ acfList }) => {
   const table = useReactTable({
     columns,
     data: acfList.items,

--- a/packages/web/src/features/my/components/MyClubTable.tsx
+++ b/packages/web/src/features/my/components/MyClubTable.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import Table from "@sparcs-clubs/web/common/components/Table";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import {
+  RegistrationStatusTagList,
+  RegistrationTypeTagList,
+} from "@sparcs-clubs/web/constants/tableTagList";
+import { mockClubRegister } from "@sparcs-clubs/web/features/my/services/_mock/mockMyRegister";
+import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+interface MyClubTableProps {
+  clubRegisterList: typeof mockClubRegister;
+}
+
+const columnHelper =
+  createColumnHelper<(typeof mockClubRegister)["items"][number]>();
+
+const columns = [
+  columnHelper.accessor("registrationStatusEnum", {
+    id: "registrationStatusEnum",
+    header: "상태",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        RegistrationStatusTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 10,
+  }),
+  columnHelper.accessor("registrationTypeEnum", {
+    id: "registrationTypeEnum",
+    header: "구분",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        RegistrationTypeTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 10,
+  }),
+  columnHelper.accessor("clubDivision", {
+    id: "clubDivision",
+    header: "분과",
+    cell: info => (
+      <Tag color={getTagColorFromDivision(info.getValue())}>
+        {info.getValue()}
+      </Tag>
+    ),
+    size: 10,
+  }),
+
+  columnHelper.accessor("clubNameKr", {
+    id: "clubNameKr",
+    header: "동아리",
+    cell: info => info.getValue(),
+    size: 128,
+  }),
+  columnHelper.accessor("activityFieldKr", {
+    id: "activityFieldKr",
+    header: "활동 분야",
+    cell: info => info.getValue(),
+    size: 255,
+  }),
+  columnHelper.accessor("professorName", {
+    id: "professorName",
+    header: "지도교수",
+    cell: info => info.getValue(),
+    size: 128,
+  }),
+];
+
+const MyClubTable: React.FC<MyClubTableProps> = ({ clubRegisterList }) => {
+  const table = useReactTable({
+    columns,
+    data: clubRegisterList.items,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return <Table table={table} />;
+};
+
+export default MyClubTable;

--- a/packages/web/src/features/my/components/MyMemberTable.tsx
+++ b/packages/web/src/features/my/components/MyMemberTable.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import Table from "@sparcs-clubs/web/common/components/Table";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import { RegistrationStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import { mockMemberRegister } from "@sparcs-clubs/web/features/my/services/_mock/mockMyRegister";
+import {
+  getTagColorFromClubType,
+  getTagColorFromDivision,
+  getTagContentFromClubType,
+} from "@sparcs-clubs/web/types/clubdetail.types";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+interface MyMemberTableProps {
+  memberRegisterList: typeof mockMemberRegister;
+}
+
+const columnHelper =
+  createColumnHelper<(typeof mockMemberRegister)["items"][number]>();
+
+const columns = [
+  columnHelper.accessor("applyStatusEnum", {
+    id: "applyStatusEnum",
+    header: "상태",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        RegistrationStatusTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 10,
+  }),
+  columnHelper.accessor("clubType", {
+    id: "clubType",
+    header: "구분",
+    cell: info => (
+      <Tag
+        color={getTagColorFromClubType(
+          info.getValue().type,
+          info.getValue().isPermanent,
+        )}
+      >
+        {getTagContentFromClubType(
+          info.getValue().type,
+          info.getValue().isPermanent,
+        )}
+      </Tag>
+    ),
+    size: 10,
+  }),
+  columnHelper.accessor("clubDivision", {
+    id: "clubDivision",
+    header: "분과",
+    cell: info => (
+      <Tag color={getTagColorFromDivision(info.getValue())}>
+        {info.getValue()}
+      </Tag>
+    ),
+    size: 10,
+  }),
+
+  columnHelper.accessor("clubNameKr", {
+    id: "clubNameKr",
+    header: "동아리",
+    cell: info => info.getValue(),
+    size: 128,
+  }),
+];
+
+const MyMemberTable: React.FC<MyMemberTableProps> = ({
+  memberRegisterList,
+}) => {
+  const table = useReactTable({
+    columns,
+    data: memberRegisterList.items,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return <Table table={table} />;
+};
+
+export default MyMemberTable;

--- a/packages/web/src/features/my/frames/MyRegisterFrame.tsx
+++ b/packages/web/src/features/my/frames/MyRegisterFrame.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+import { RegistrationEventEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
+import MyClubTable from "@sparcs-clubs/web/features/my/components/MyClubTable";
+import MyMemberTable from "@sparcs-clubs/web/features/my/components/MyMemberTable";
+import {
+  mockClubRegister,
+  mockMemberRegister,
+  mockRegisterPeriod,
+} from "@sparcs-clubs/web/features/my/services/_mock/mockMyRegister";
+
+const MyRegisterFrame: React.FC = () =>
+  (mockRegisterPeriod.includes(
+    RegistrationEventEnum.ClubRegistrationApplication,
+  ) ||
+    mockRegisterPeriod.includes(
+      RegistrationEventEnum.StudentRegistrationApplication,
+    )) && (
+    <FoldableSectionTitle title="동아리 신청 내역">
+      <AsyncBoundary isLoading={false} isError={false}>
+        <FlexWrapper direction="column" gap={40}>
+          {mockRegisterPeriod.includes(
+            RegistrationEventEnum.ClubRegistrationApplication,
+          ) && (
+            <FlexWrapper direction="column" gap={20}>
+              <MoreDetailTitle
+                title="동아리 등록"
+                moreDetail=""
+                moreDetailPath=""
+              />
+              <AsyncBoundary isLoading={false} isError={false}>
+                <MyClubTable
+                  clubRegisterList={
+                    mockClubRegister ?? { total: 0, items: [], offset: 0 }
+                  }
+                />
+              </AsyncBoundary>
+            </FlexWrapper>
+          )}
+          {mockRegisterPeriod.includes(
+            RegistrationEventEnum.StudentRegistrationApplication,
+          ) && (
+            <FlexWrapper direction="column" gap={20}>
+              <MoreDetailTitle
+                title="회원 등록"
+                moreDetail=""
+                moreDetailPath=""
+              />
+              <AsyncBoundary isLoading={false} isError={false}>
+                <MyMemberTable
+                  memberRegisterList={
+                    mockMemberRegister ?? { total: 0, items: [], offset: 0 }
+                  }
+                />
+              </AsyncBoundary>
+            </FlexWrapper>
+          )}
+        </FlexWrapper>
+      </AsyncBoundary>
+    </FoldableSectionTitle>
+  );
+
+export default MyRegisterFrame;

--- a/packages/web/src/features/my/services/_mock/mockMyRegister.ts
+++ b/packages/web/src/features/my/services/_mock/mockMyRegister.ts
@@ -1,0 +1,62 @@
+import { ClubTypeEnum } from "@sparcs-clubs/interface/common/enum/club.enum";
+import {
+  RegistrationEventEnum,
+  RegistrationStatusEnum,
+  RegistrationTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+const mockClubRegister = {
+  items: [
+    {
+      registrationStatusEnum: RegistrationStatusEnum.Pending,
+      registrationTypeEnum: RegistrationTypeEnum.NewProvisional,
+      clubDivision: "생활문화",
+      clubNameKr: "술박스",
+      activityFieldKr: "개발개발한 어떤 활동",
+      professorName: "박지호",
+      clubId: 1,
+    },
+  ],
+  total: 1,
+  offset: 1,
+};
+const mockMemberRegister = {
+  items: [
+    {
+      applyStatusEnum: RegistrationStatusEnum.Pending,
+      clubType: { type: ClubTypeEnum.Regular, isPermanent: false },
+      clubDivision: "생활문화",
+      clubNameKr: "술박스",
+      clubId: 1,
+    },
+    {
+      applyStatusEnum: RegistrationStatusEnum.Pending,
+      clubType: { type: ClubTypeEnum.Regular, isPermanent: true },
+      clubDivision: "밴드음악",
+      clubNameKr: "술박스",
+      clubId: 1,
+    },
+    {
+      applyStatusEnum: RegistrationStatusEnum.Pending,
+      clubType: { type: ClubTypeEnum.Provisional, isPermanent: false },
+      clubDivision: "사회",
+      clubNameKr: "술박스",
+      clubId: 1,
+    },
+    {
+      applyStatusEnum: RegistrationStatusEnum.Pending,
+      clubType: { type: ClubTypeEnum.Provisional, isPermanent: false },
+      clubDivision: "보컬음악",
+      clubNameKr: "술박스",
+      clubId: 1,
+    },
+  ],
+  total: 4,
+  offset: 4,
+};
+const mockRegisterPeriod = [
+  RegistrationEventEnum.ClubRegistrationApplication,
+  RegistrationEventEnum.StudentRegistrationApplication,
+];
+
+export { mockClubRegister, mockMemberRegister, mockRegisterPeriod };


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #476 

![image](https://github.com/user-attachments/assets/73a32ea4-3003-405f-a019-61888d375f8a)
행 클릭 시 다른 페이지로 라우팅하는 것 제외하고 모두 구현 완료


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![스크린샷 2024-08-20 165121](https://github.com/user-attachments/assets/03a59314-b8f2-4968-95f8-9953f1a94953)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- Table 컴포넌트에 행 클릭 시 페이지로 이동하는 기능 추가 --> #638 
- Table 컴포넌트에 값이 없을 경우 보여지는 placeholder 텍스트 추가 --> #640 
