### PR TITLE
Add placeholder to register table in /my

### DIFF
--- a/packages/web/src/common/components/Table.tsx
+++ b/packages/web/src/common/components/Table.tsx
@@ -63,6 +63,7 @@ const EmptyCenterPlacer = styled.div`
   height: 100%;
   display: flex;
   flex: 1;
+  padding: 12px 8px 12px 8px;
   justify-content: center;
   align-items: center;
 `;

--- a/packages/web/src/features/my/components/MyClubTable.tsx
+++ b/packages/web/src/features/my/components/MyClubTable.tsx
@@ -87,7 +87,7 @@ const MyClubTable: React.FC<MyClubTableProps> = ({ clubRegisterList }) => {
     enableSorting: false,
   });
 
-  return <Table table={table} />;
+  return <Table table={table} emptyMessage="동아리 등록 내역이 없습니다." />;
 };
 
 export default MyClubTable;

--- a/packages/web/src/features/my/components/MyMemberTable.tsx
+++ b/packages/web/src/features/my/components/MyMemberTable.tsx
@@ -84,7 +84,7 @@ const MyMemberTable: React.FC<MyMemberTableProps> = ({
     enableSorting: false,
   });
 
-  return <Table table={table} />;
+  return <Table table={table} emptyMessage="회원 등록 내역이 없습니다." />;
 };
 
 export default MyMemberTable;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #640 

이미 placeholder 기능이 Table 컴포넌트에 존재(emptyMessage 옵션)해서 해당 부분을 표에 추가했습니다.
추가적으로 피그마와 스타일이 안 맞는 부분 수정했습니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![스크린샷 2024-08-20 235943](https://github.com/user-attachments/assets/3a83e693-443d-4e60-b30f-588690d8c681)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
