### PR TITLE
feat: impl executive/register-club with mock data

### DIFF
--- a/packages/web/src/app/executive/register-club/page.tsx
+++ b/packages/web/src/app/executive/register-club/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useState } from "react";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import ExecutiveRegistrationTable from "@sparcs-clubs/web/common/components/ExecutiveRegistrationTable";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import Pagination from "@sparcs-clubs/web/common/components/Pagination";
+import { mockRegisterClub } from "@sparcs-clubs/web/features/register-club/service/_mock/mockRegisterClub";
+
+const RegisterClub = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const limit = 10;
+
+  /* TODO : API로 데이터 받아오기 */
+  const data = mockRegisterClub;
+  const paginatedData = {
+    total: data.total,
+    items: data.items.slice((currentPage - 1) * limit, currentPage * limit),
+    offset: (currentPage - 1) * limit,
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <FlexWrapper direction="column" gap={20}>
+      <PageHead
+        items={[
+          { name: "집행부원 대시보드", path: "/executive" },
+          { name: "동아리 등록 신청 내역", path: `/executive/register-club` },
+        ]}
+        title="동아리 등록 신청 내역"
+      />
+      <AsyncBoundary isLoading={false} isError={false}>
+        <ExecutiveRegistrationTable registerList={paginatedData} />
+        <FlexWrapper direction="row" gap={16} justify="center">
+          <Pagination
+            totalPage={Math.ceil(data.total / limit)}
+            currentPage={currentPage}
+            limit={limit}
+            setPage={handlePageChange}
+          />
+        </FlexWrapper>
+      </AsyncBoundary>
+    </FlexWrapper>
+  );
+};
+
+export default RegisterClub;

--- a/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
+++ b/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
@@ -31,7 +31,11 @@ const columns = [
         info.getValue(),
         RegistrationStatusTagList,
       );
-      return <Tag color={color}>{text}</Tag>;
+      return (
+        <Tag color={color} width="50px">
+          {text}
+        </Tag>
+      );
     },
     size: 90,
   }),

--- a/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
+++ b/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
@@ -43,7 +43,11 @@ const columns = [
         info.getValue(),
         RegistrationTypeTagList,
       );
-      return <Tag color={color}>{text}</Tag>;
+      return (
+        <Tag color={color} width="80px">
+          {text}
+        </Tag>
+      );
     },
     size: 120,
   }),
@@ -55,7 +59,11 @@ const columns = [
         info.getValue(),
         DivisionTypeTagList,
       );
-      return <Tag color={color}>{text}</Tag>;
+      return (
+        <Tag color={color} width="80px">
+          {text}
+        </Tag>
+      );
     },
     size: 120,
   }),

--- a/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
+++ b/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import Table from "@sparcs-clubs/web/common/components/Table";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import {
+  DivisionTypeTagList,
+  RegistrationStatusTagList,
+  RegistrationTypeTagList,
+} from "@sparcs-clubs/web/constants/tableTagList";
+import { RegisterClubList } from "@sparcs-clubs/web/features/register-club/service/_mock/mockRegisterClub";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+interface ExecutiveRegistrationTableProps {
+  registerList: RegisterClubList;
+}
+
+const columnHelper = createColumnHelper<RegisterClubList["items"][number]>();
+
+const columns = [
+  columnHelper.accessor("status", {
+    id: "status",
+    header: "상태",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        RegistrationStatusTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 90,
+  }),
+  columnHelper.accessor("type", {
+    id: "type",
+    header: "구분",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        RegistrationTypeTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 120,
+  }),
+  columnHelper.accessor("division", {
+    id: "division",
+    header: "분과",
+    cell: info => {
+      const { color, text } = getTagDetail(
+        info.getValue(),
+        DivisionTypeTagList,
+      );
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 120,
+  }),
+  columnHelper.accessor("clubName", {
+    id: "clubName",
+    header: "동아리",
+    cell: info => info.getValue(),
+  }),
+  columnHelper.accessor("president", {
+    id: "president",
+    header: "대표자",
+    cell: info => info.getValue(),
+  }),
+  columnHelper.accessor("activityField", {
+    id: "activityField",
+    header: "활동 분야",
+    cell: info => info.getValue(),
+    size: 240,
+  }),
+  columnHelper.accessor("advisorProfessor", {
+    id: "advisorProfessor",
+    header: "지도교수",
+    cell: info => info.getValue(),
+  }),
+];
+
+const ExecutiveRegistrationTable: React.FC<ExecutiveRegistrationTableProps> = ({
+  registerList,
+}) => {
+  const table = useReactTable({
+    columns,
+    data: registerList.items,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return <Table table={table} count={registerList.total} />;
+};
+
+export default ExecutiveRegistrationTable;

--- a/packages/web/src/common/components/RegisterMemberTable.tsx
+++ b/packages/web/src/common/components/RegisterMemberTable.tsx
@@ -10,12 +10,13 @@ import Link from "next/link";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
+import { DivisionTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import mockupRegistrationMember from "@sparcs-clubs/web/features/executive/_mock/mockMemberRegistration";
 import {
   getTagColorFromClubType,
-  getTagColorFromDivision,
   getTagContentFromClubType,
 } from "@sparcs-clubs/web/types/clubdetail.types";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface RegisterMemberTableProps {
   registerMemberList: typeof mockupRegistrationMember;
@@ -46,7 +47,7 @@ const columns = [
     id: "division",
     header: "분과",
     cell: info => {
-      const tagColor = getTagColorFromDivision(info.getValue());
+      const tagColor = getTagDetail(info.getValue(), DivisionTypeTagList).color;
 
       return <Tag color={tagColor}>{info.getValue()}</Tag>;
     },

--- a/packages/web/src/common/components/Tag.tsx
+++ b/packages/web/src/common/components/Tag.tsx
@@ -14,10 +14,10 @@ type TagColor =
   | "RED"
   | "GRAY";
 
-const TagInner = styled.div<{ color: TagColor }>`
+const TagInner = styled.div<{ color: TagColor; width: string }>`
   position: relative;
-  width: fit-content;
-  padding: 4px 12px;
+  width: ${({ width }) => width};
+  padding: ${({ width }) => (width === "fit-content" ? "4px 12px" : "4px 0px")};
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
   font-size: 14px;
   line-height: 16px;
@@ -27,14 +27,22 @@ const TagInner = styled.div<{ color: TagColor }>`
   background-color: ${({ theme, color }) =>
     color === "RED" ? theme.colors.RED[600] : theme.colors[color][200]};
   border-radius: ${({ theme }) => theme.round.sm};
+  text-align: center;
 `;
 
 interface TagProps extends React.PropsWithChildren {
   color?: TagColor;
+  width?: string;
 }
 
-const Tag: React.FC<TagProps> = ({ children = <div />, color = "BLUE" }) => (
-  <TagInner color={color}>{children}</TagInner>
+const Tag: React.FC<TagProps> = ({
+  children = <div />,
+  color = "BLUE",
+  width = "fit-content",
+}) => (
+  <TagInner color={color} width={width}>
+    {children}
+  </TagInner>
 );
 
 export type { TagColor };

--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -7,6 +7,8 @@ import {
 } from "@sparcs-clubs/interface/common/enum/registration.enum";
 import { RentalOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/rental.enum";
 
+import { DivisionType } from "@sparcs-clubs/web/types/divisions.types";
+
 import {
   ActivityProfessorApprovalEnum,
   ActivityStatusEnum,
@@ -144,6 +146,24 @@ const RegistrationTypeTagList: { [key in RegistrationTypeEnum]: StatusDetail } =
     [RegistrationTypeEnum.ReProvisional]: { text: "가등록", color: "BLUE" },
   };
 
+const DivisionTypeTagList: { [key in DivisionType]: StatusDetail } = {
+  [DivisionType.InstrumentalMusic]: { text: "연주음악", color: "ORANGE" },
+  [DivisionType.VocalMusic]: { text: "보컬음악", color: "ORANGE" },
+  [DivisionType.BandMusic]: { text: "밴드음악", color: "ORANGE" },
+  [DivisionType.LifeSports]: { text: "생활체육", color: "PINK" },
+  [DivisionType.BallSports]: { text: "구기체육", color: "PINK" },
+  [DivisionType.HumanitiesAcademics]: { text: "인문학술", color: "YELLOW" },
+  [DivisionType.ScienceEngineeringAcademics]: {
+    text: "이공학술",
+    color: "YELLOW",
+  },
+  [DivisionType.PerformingArts]: { text: "연행예술", color: "BLUE" },
+  [DivisionType.ExhibitionCreation]: { text: "전시창작", color: "BLUE" },
+  [DivisionType.LifeCulture]: { text: "생활문화", color: "GREEN" },
+  [DivisionType.Society]: { text: "사회", color: "PURPLE" },
+  [DivisionType.Religion]: { text: "종교", color: "PURPLE" },
+};
+
 export {
   AcfTagList,
   CmsTagList,
@@ -156,4 +176,5 @@ export {
   FundingTagList,
   RegistrationTypeTagList,
   RegistrationStatusTagList,
+  DivisionTypeTagList,
 };

--- a/packages/web/src/features/register-club/service/_mock/mockRegisterClub.ts
+++ b/packages/web/src/features/register-club/service/_mock/mockRegisterClub.ts
@@ -1,0 +1,211 @@
+import {
+  RegistrationStatusEnum,
+  RegistrationTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+import { DivisionType } from "@sparcs-clubs/web/types/divisions.types";
+
+export interface RegisterClubList {
+  total: number;
+  items: RegisterClub[];
+  offset: number;
+}
+
+export interface RegisterClub {
+  status: RegistrationStatusEnum;
+  type: RegistrationTypeEnum;
+  division: DivisionType;
+  clubName: string;
+  president: string;
+  activityField: string;
+  advisorProfessor: string;
+}
+
+const items: Array<RegisterClub> = [
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.InstrumentalMusic,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.HumanitiesAcademics,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.PerformingArts,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.NewProvisional,
+    division: DivisionType.LifeCulture,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.VocalMusic,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.BandMusic,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.ReProvisional,
+    division: DivisionType.Society,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.Religion,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.BallSports,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.ExhibitionCreation,
+    clubName: "술박스",
+    president: "이지윤",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.ScienceEngineeringAcademics,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.LifeSports,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.PerformingArts,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Pending,
+    type: RegistrationTypeEnum.NewProvisional,
+    division: DivisionType.LifeCulture,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.VocalMusic,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.BandMusic,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Approved,
+    type: RegistrationTypeEnum.ReProvisional,
+    division: DivisionType.Society,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Renewal,
+    division: DivisionType.Religion,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.BallSports,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+  {
+    status: RegistrationStatusEnum.Rejected,
+    type: RegistrationTypeEnum.Promotional,
+    division: DivisionType.ExhibitionCreation,
+    clubName: "클럽스",
+    president: "권진현",
+    activityField: "개발개발한 어떤 활동~sjfslkjfksldjklf",
+    advisorProfessor: "박지호",
+  },
+];
+
+export const mockRegisterClub: RegisterClubList = {
+  total: items.length,
+  items,
+  offset: 0,
+};

--- a/packages/web/src/types/clubdetail.types.ts
+++ b/packages/web/src/types/clubdetail.types.ts
@@ -87,6 +87,7 @@ const getTagContentFromClubType = (
 };
 
 const getTagColorFromDivision = (divisionName: string): TagColor => {
+  // TODO : getTagDetail 사용
   switch (divisionName) {
     case "생활문화":
     case "사회":

--- a/packages/web/src/types/divisions.types.ts
+++ b/packages/web/src/types/divisions.types.ts
@@ -1,16 +1,16 @@
 enum DivisionType /** TODO - 20240320 기준으로 번역 단어장에 각 division 이름에 대한 번역이 존재하지 않아 임시로 제작한 번역이기 때문에 추후 올바르게 수정 요망 */ {
-  LifeCulture = "생활문화",
-  PerformingArts = "연행예술",
-  ExhibitionCreation = "전시창작",
-  BandMusic = "밴드음악",
-  VocalMusic = "보컬음악",
-  InstrumentalMusic = "연주음악",
-  Society = "사회",
-  Religion = "종교",
-  BallSports = "구기체육",
-  LifeSports = "생활체육",
-  ScienceEngineeringAcademics = "이공학술",
-  HumanitiesAcademics = "인문학술",
+  LifeCulture = 1, // 생활문화
+  PerformingArts,
+  ExhibitionCreation,
+  BandMusic,
+  VocalMusic,
+  InstrumentalMusic,
+  Society,
+  Religion,
+  BallSports,
+  LifeSports,
+  ScienceEngineeringAcademics,
+  HumanitiesAcademics,
 }
 
 export { DivisionType };

--- a/packages/web/src/types/divisions.types.ts
+++ b/packages/web/src/types/divisions.types.ts
@@ -1,16 +1,16 @@
 enum DivisionType /** TODO - 20240320 기준으로 번역 단어장에 각 division 이름에 대한 번역이 존재하지 않아 임시로 제작한 번역이기 때문에 추후 올바르게 수정 요망 */ {
   LifeCulture = 1, // 생활문화
-  PerformingArts,
-  ExhibitionCreation,
-  BandMusic,
-  VocalMusic,
-  InstrumentalMusic,
-  Society,
-  Religion,
-  BallSports,
-  LifeSports,
-  ScienceEngineeringAcademics,
-  HumanitiesAcademics,
+  PerformingArts, // 연행예술
+  ExhibitionCreation, // 전시창작
+  BandMusic, // 밴드음악
+  VocalMusic, // 보컬음악
+  InstrumentalMusic, // 연주음악
+  Society, // 사회
+  Religion, // 종교
+  BallSports, // 구기체육
+  LifeSports, // 생활체육
+  ScienceEngineeringAcademics, // 이공학술
+  HumanitiesAcademics, // 인문학술
 }
 
 export { DivisionType };


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #629 

집행부원이 동아리 등록 신청을 조회하는 페이지 UI를 mock data를 사용해서 만들었습니다.

## 피드백 받고 싶은 사항
1. Tag의 폭이 Figma 상으로 80px 고정인데, Tag 컴포넌트 정의 상 width가 fit-content로 되어 있습니다. 이 부분을 어떻게 구현하는 게 좋을지 궁금합니다.
2. 새로 만든 것들이 많은데, 경로나 이름 같은 것들을 적절하게 설정한 것일지 궁금합니다.
3. 집행부원만 접근 가능해야 하는데 이건 나중에 어떻게 작업해야 할지 궁금합니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/f81753b7-9ab2-459b-ac74-79160bd30eb8)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
