### PR TITLE
Fix AxiosClient to AxiosClientWithAuth in services

### DIFF
--- a/packages/web/src/common/services/getUserProfile.ts
+++ b/packages/web/src/common/services/getUserProfile.ts
@@ -2,7 +2,7 @@ import apiUsr001 from "@sparcs-clubs/interface/api/user/endpoint/apiUsr001";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,10 @@ const useGetUserProfile = () =>
   useQuery<ApiUsr001ResponseOK, Error>({
     queryKey: [apiUsr001.url()],
     queryFn: async (): Promise<ApiUsr001ResponseOK> => {
-      const { data, status } = await axiosClient.get(apiUsr001.url(), {});
+      const { data, status } = await axiosClientWithAuth.get(
+        apiUsr001.url(),
+        {},
+      );
 
       // Possible exceptions: UnexpectedAPIResponseError, ZodError, LibAxiosError
       switch (status) {

--- a/packages/web/src/features/activity-certificate/services/getUserClubs.ts
+++ b/packages/web/src/features/activity-certificate/services/getUserClubs.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -16,7 +16,10 @@ export const useGetUserClubs = () =>
   useQuery<ISuccessResponseType, Error>({
     queryKey: [apiAcf002.url()],
     queryFn: async (): Promise<ISuccessResponseType> => {
-      const { data, status } = await axiosClient.get(apiAcf002.url(), {});
+      const { data, status } = await axiosClientWithAuth.get(
+        apiAcf002.url(),
+        {},
+      );
       console.log(data);
 
       // Possible exceptions: UnexpectedAPIResponseError, ZodError, LibAxiosError

--- a/packages/web/src/features/activity-certificate/services/useGetUserInfo.tsx
+++ b/packages/web/src/features/activity-certificate/services/useGetUserInfo.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 import mockUpUserInfo from "@sparcs-clubs/web/features/activity-certificate/services/_mock/mockupUserInfo";
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -22,7 +22,10 @@ export const useGetUserInfo = () =>
   useQuery<ISuccessResponseType, Error>({
     queryKey: [apiAcf001.url()],
     queryFn: async (): Promise<ISuccessResponseType> => {
-      const { data, status } = await axiosClient.get(apiAcf001.url(), {});
+      const { data, status } = await axiosClientWithAuth.get(
+        apiAcf001.url(),
+        {},
+      );
 
       switch (status) {
         case 201:

--- a/packages/web/src/features/clubDetails/services/getClubDetail.ts
+++ b/packages/web/src/features/clubDetails/services/getClubDetail.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import mockupData from "@sparcs-clubs/web/features/clubDetails/services/_mock/mockupClubDetail";
 import {
-  axiosClientWithAuth,
+  axiosClient,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,7 @@ export const useGetClubDetail = (club_id: string) =>
   useQuery<ApiClb002ResponseOK, Error>({
     queryKey: [apiClb002.url(club_id)],
     queryFn: async (): Promise<ApiClb002ResponseOK> => {
-      const { data, status } = await axiosClientWithAuth.get(
+      const { data, status } = await axiosClient.get(
         apiClb002.url(club_id),
         {},
       );

--- a/packages/web/src/features/clubs/services/useGetClubsList.ts
+++ b/packages/web/src/features/clubs/services/useGetClubsList.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import mockupData from "@sparcs-clubs/web/features/clubs/services/_mock/mockupClubData";
 import {
-  axiosClientWithAuth,
+  axiosClient,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -17,10 +17,7 @@ export const useGetClubsList = () =>
   useQuery<ISuccessResponseType, Error>({
     queryKey: [apiClb001.url()],
     queryFn: async (): Promise<ISuccessResponseType> => {
-      const { data, status } = await axiosClientWithAuth.get(
-        apiClb001.url(),
-        {},
-      );
+      const { data, status } = await axiosClient.get(apiClb001.url(), {});
 
       // Possible exceptions: UnexpectedAPIResponseError, ZodError, LibAxiosError
       switch (status) {

--- a/packages/web/src/features/common-space/service/postCommonSpaceUsageOrder.ts
+++ b/packages/web/src/features/common-space/service/postCommonSpaceUsageOrder.ts
@@ -1,7 +1,7 @@
 import apiCms003 from "@sparcs-clubs/interface/api/common-space/endpoint/apiCms003";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
 
@@ -16,7 +16,7 @@ const postCommonSpaceUsageOrder = async (
   requestParam: ApiCms003RequestParam,
   requestBody: ApiCms003RequestBody,
 ): Promise<ApiCms003ResponseCreated | ApiCms003Error423> => {
-  const { data, status } = await axiosClient.post(
+  const { data, status } = await axiosClientWithAuth.post(
     apiCms003.url(requestParam.spaceId),
     requestBody,
   );

--- a/packages/web/src/features/manage-club/activity-report/services/useGetActivityReport.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetActivityReport.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -13,7 +13,7 @@ export const useGetActivityReport = (activityId: number) =>
   useQuery<ISuccessResponseType, Error>({
     queryKey: [apiAct002.url(activityId)],
     queryFn: async (): Promise<ISuccessResponseType> => {
-      const { data, status } = await axiosClient.get(
+      const { data, status } = await axiosClientWithAuth.get(
         apiAct002.url(activityId),
         {},
       );

--- a/packages/web/src/features/manage-club/activity-report/services/usePutActivityReport.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/usePutActivityReport.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { z } from "zod";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
 
@@ -16,7 +16,7 @@ export const usePutActivityReport = () =>
     { activityId: number; body: z.infer<typeof apiAct003.requestBody> }
   >({
     mutationFn: async ({ activityId, body }): Promise<ISuccessResponseType> => {
-      const { data, status } = await axiosClient.put(
+      const { data, status } = await axiosClientWithAuth.put(
         apiAct003.url(activityId),
         body,
       );

--- a/packages/web/src/features/manage-club/services/deleteChangeDelegateRequest.ts
+++ b/packages/web/src/features/manage-club/services/deleteChangeDelegateRequest.ts
@@ -1,7 +1,7 @@
 import apiClb012 from "@sparcs-clubs/interface/api/club/endpoint/apiClb012";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -11,7 +11,7 @@ import type { ApiClb012RequestParam } from "@sparcs-clubs/interface/api/club/end
 export const deleteChangeDelegateRequest = async (
   requestParam: ApiClb012RequestParam,
 ) => {
-  const { data, status } = await axiosClient.delete(
+  const { data, status } = await axiosClientWithAuth.delete(
     apiClb012.url(requestParam.clubId),
   );
   switch (status) {

--- a/packages/web/src/features/manage-club/services/getChangeDelegateRequests.ts
+++ b/packages/web/src/features/manage-club/services/getChangeDelegateRequests.ts
@@ -2,7 +2,7 @@ import apiClb011 from "@sparcs-clubs/interface/api/club/endpoint/apiClb011";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -20,7 +20,7 @@ export const useGetChangeDelegateRequests = (
   useQuery<ApiClb011ResponseOk, Error>({
     queryKey: [apiClb011.url(requestParam.clubId)],
     queryFn: async (): Promise<ApiClb011ResponseOk> => {
-      const { data, status } = await axiosClient.get(
+      const { data, status } = await axiosClientWithAuth.get(
         apiClb011.url(requestParam.clubId),
       );
       switch (status) {

--- a/packages/web/src/features/manage-club/services/getClubDelegate.ts
+++ b/packages/web/src/features/manage-club/services/getClubDelegate.ts
@@ -2,7 +2,7 @@ import apiClb006 from "@sparcs-clubs/interface/api/club/endpoint/apiClb006";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -18,7 +18,7 @@ export const useGetClubDelegate = (requestParam: ApiClb006RequestParam) =>
   useQuery<ApiClb006ResponseOK, Error>({
     queryKey: [apiClb006.url(requestParam.clubId)],
     queryFn: async (): Promise<ApiClb006ResponseOK> => {
-      const { data, status } = await axiosClient.get(
+      const { data, status } = await axiosClientWithAuth.get(
         apiClb006.url(requestParam.clubId),
       );
       switch (status) {

--- a/packages/web/src/features/manage-club/services/getDelegateCandidates.ts
+++ b/packages/web/src/features/manage-club/services/getDelegateCandidates.ts
@@ -2,7 +2,7 @@ import apiClb008 from "@sparcs-clubs/interface/api/club/endpoint/apiClb008";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -18,7 +18,7 @@ export const useGetDelegateCandidates = (requestParam: ApiClb008RequestParam) =>
   useQuery<ApiClb008ResponseOk, Error>({
     queryKey: [apiClb008.url(requestParam.clubId, requestParam.delegateEnumId)],
     queryFn: async (): Promise<ApiClb008ResponseOk> => {
-      const { data, status } = await axiosClient.get(
+      const { data, status } = await axiosClientWithAuth.get(
         apiClb008.url(requestParam.clubId, requestParam.delegateEnumId),
       );
       switch (status) {

--- a/packages/web/src/features/manage-club/services/updateClubDelegate.ts
+++ b/packages/web/src/features/manage-club/services/updateClubDelegate.ts
@@ -1,7 +1,7 @@
 import apiClb007 from "@sparcs-clubs/interface/api/club/endpoint/apiClb007";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,7 @@ export const updateClubDelegates = async (
   requestParam: ApiClb007RequestParam,
   requestBody: ApiClb007RequestBody,
 ) => {
-  const { data, status } = await axiosClient.put(
+  const { data, status } = await axiosClientWithAuth.put(
     apiClb007.url(requestParam.clubId),
     requestBody,
   );

--- a/packages/web/src/features/my/clubs/service/useGetMyClub.ts
+++ b/packages/web/src/features/my/clubs/service/useGetMyClub.ts
@@ -2,7 +2,7 @@ import apiClb003 from "@sparcs-clubs/interface/api/club/endpoint/apiClb003";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,10 @@ const useGetMyClub = () =>
   useQuery<ApiClb003ResponseOK, Error>({
     queryKey: [apiClb003.url()],
     queryFn: async (): Promise<ApiClb003ResponseOK> => {
-      const { data, status } = await axiosClient.get(apiClb003.url(), {});
+      const { data, status } = await axiosClientWithAuth.get(
+        apiClb003.url(),
+        {},
+      );
 
       // Possible exceptions: UnexpectedAPIResponseError, ZodError, LibAxiosError
       switch (status) {

--- a/packages/web/src/features/my/services/getMyActivityCertificate.ts
+++ b/packages/web/src/features/my/services/getMyActivityCertificate.ts
@@ -2,7 +2,7 @@ import apiAcf007 from "@sparcs-clubs/interface/api/activity-certificate/endpoint
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -30,7 +30,7 @@ export const useGetMyActivityCertificate = (
   return useQuery<ApiAcf007ResponseOk, Error>({
     queryKey: [apiAcf007.url(), requestQuery],
     queryFn: async (): Promise<ApiAcf007ResponseOk> => {
-      const { data, status } = await axiosClient.get(apiAcf007.url(), {
+      const { data, status } = await axiosClientWithAuth.get(apiAcf007.url(), {
         params: requestQuery,
       });
 

--- a/packages/web/src/features/my/services/getMyCommonSpace.ts
+++ b/packages/web/src/features/my/services/getMyCommonSpace.ts
@@ -2,7 +2,7 @@ import apiCms007 from "@sparcs-clubs/interface/api/common-space/endpoint/apiCms0
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -30,7 +30,7 @@ export const useGetMyCommonSpace = (
   return useQuery<ApiCms007ResponseOk, Error>({
     queryKey: [apiCms007.url(), requestQuery],
     queryFn: async (): Promise<ApiCms007ResponseOk> => {
-      const { data, status } = await axiosClient.get(apiCms007.url(), {
+      const { data, status } = await axiosClientWithAuth.get(apiCms007.url(), {
         params: requestQuery,
       });
 

--- a/packages/web/src/features/my/services/getMyDelegateRequest.ts
+++ b/packages/web/src/features/my/services/getMyDelegateRequest.ts
@@ -2,7 +2,7 @@ import apiClb013 from "@sparcs-clubs/interface/api/club/endpoint/apiClb013";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,7 @@ export const useGetMyDelegateRequest = () =>
   useQuery<ApiClb013ResponseOk, Error>({
     queryKey: [apiClb013.url()],
     queryFn: async (): Promise<ApiClb013ResponseOk> => {
-      const { data, status } = await axiosClient.get(apiClb013.url());
+      const { data, status } = await axiosClientWithAuth.get(apiClb013.url());
 
       switch (status) {
         case 200:

--- a/packages/web/src/features/my/services/getMyPrinting.ts
+++ b/packages/web/src/features/my/services/getMyPrinting.ts
@@ -2,7 +2,7 @@ import apiPrt005 from "@sparcs-clubs/interface/api/promotional-printing/endpoint
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -30,7 +30,7 @@ export const useGetMyPrinting = (
   return useQuery<ApiPrt005ResponseOk, Error>({
     queryKey: [apiPrt005.url(), requestQuery],
     queryFn: async (): Promise<ApiPrt005ResponseOk> => {
-      const { data, status } = await axiosClient.get(apiPrt005.url(), {
+      const { data, status } = await axiosClientWithAuth.get(apiPrt005.url(), {
         params: requestQuery,
       });
 

--- a/packages/web/src/features/my/services/getMyRentals.ts
+++ b/packages/web/src/features/my/services/getMyRentals.ts
@@ -2,7 +2,7 @@ import apiRnt006 from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt006";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -30,7 +30,7 @@ export const useGetMyRentals = (
   return useQuery<ApiRnt006ResponseOK, Error>({
     queryKey: [apiRnt006.url(), requestQuery],
     queryFn: async (): Promise<ApiRnt006ResponseOK> => {
-      const { data, status } = await axiosClient.get(apiRnt006.url(), {
+      const { data, status } = await axiosClientWithAuth.get(apiRnt006.url(), {
         params: requestQuery,
       });
 

--- a/packages/web/src/features/my/services/patchMyDelegateRequest.ts
+++ b/packages/web/src/features/my/services/patchMyDelegateRequest.ts
@@ -1,7 +1,7 @@
 import apiClb014 from "@sparcs-clubs/interface/api/club/endpoint/apiClb014";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -15,7 +15,7 @@ export const patchMyDelegateRequest = async (
   requestParam: ApiClb014RequestParam,
   requestBody: ApiClb014RequestBody,
 ) => {
-  const { data, status } = await axiosClient.patch(
+  const { data, status } = await axiosClientWithAuth.patch(
     apiClb014.url(requestParam.requestId),
     requestBody,
   );

--- a/packages/web/src/features/printing-business/service/postBusinessPrintingOrder.ts
+++ b/packages/web/src/features/printing-business/service/postBusinessPrintingOrder.ts
@@ -1,7 +1,7 @@
 import apiPrt002 from "@sparcs-clubs/interface/api/promotional-printing/endpoint/apiPrt002";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
 
@@ -15,7 +15,7 @@ const postBusinessPrintingOrder = async (
   requestParam: ApiPrt002RequestParam,
   reuestBody: ApiPrt002RequestBody,
 ): Promise<ApiPrt002ResponseCreated> => {
-  const { data, status } = await axiosClient.post(
+  const { data, status } = await axiosClientWithAuth.post(
     apiPrt002.url(requestParam.clubId.toString()),
     reuestBody,
   );

--- a/packages/web/src/features/rental-business/service/getAvailableRentals.ts
+++ b/packages/web/src/features/rental-business/service/getAvailableRentals.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import mockupAvailableRental from "@sparcs-clubs/web/features/rental-business/service/_mock/mockAvailableRental";
 import {
-  axiosClient,
+  axiosClientWithAuth,
   defineAxiosMock,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
@@ -19,7 +19,7 @@ export const useGetAvailableRentals = (startDate: Date, endDate: Date) => {
   return useQuery<ApiRnt001ResponseOK, Error>({
     queryKey: [apiRnt001.url(), requestQuery],
     queryFn: async (): Promise<ApiRnt001ResponseOK> => {
-      const { data, status } = await axiosClient.get(apiRnt001.url(), {
+      const { data, status } = await axiosClientWithAuth.get(apiRnt001.url(), {
         params: requestQuery,
       });
 

--- a/packages/web/src/features/rental-business/service/postRentalOrder.ts
+++ b/packages/web/src/features/rental-business/service/postRentalOrder.ts
@@ -1,7 +1,7 @@
 import apiRnt002 from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt002";
 
 import {
-  axiosClient,
+  axiosClientWithAuth,
   UnexpectedAPIResponseError,
 } from "@sparcs-clubs/web/lib/axios";
 
@@ -15,7 +15,7 @@ const postRentalOrder = async (
   requestQuery: ApiRnt002RequestQuery,
   requestBody: ApiRnt002RequestBody,
 ): Promise<ApiRnt002ResponseOK> => {
-  const { data, status } = await axiosClient.post(
+  const { data, status } = await axiosClientWithAuth.post(
     apiRnt002.url(),
     requestBody,
     {


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #678 
- 제외 api에 포함된 Clb001, 002는 withauth로 되어있어서 axiosclient로 다시 변경


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
