### PR TITLE
revise member registration policy REG-007, 008

### DIFF
--- a/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
@@ -155,11 +155,8 @@ export default class ClubStudentTRepository {
     clubId: number,
     semesterId: number,
   ): Promise<void> {
-    const cur = getKSTDate();
-
     await this.db
-      .update(ClubStudentT)
-      .set({ deletedAt: cur })
+      .delete(ClubStudentT)
       .where(
         and(
           eq(ClubStudentT.studentId, studentId),

--- a/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from "@nestjs/common";
 import { and, count, desc, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 
-import { takeUnique } from "@sparcs-clubs/api/common/util/util";
+import { getKSTDate, takeUnique } from "@sparcs-clubs/api/common/util/util";
 import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 
 import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
@@ -131,5 +131,43 @@ export default class ClubStudentTRepository {
         ),
       );
     return clubs;
+  }
+
+  async addStudentToClub(
+    studentId: number,
+    clubId: number,
+    semesterId: number,
+  ): Promise<void> {
+    const cur = getKSTDate();
+    await this.db
+      .insert(ClubStudentT)
+      .values({
+        studentId,
+        clubId,
+        semesterId,
+        startTerm: cur,
+      })
+      .execute();
+  }
+
+  async removeStudentFromClub(
+    studentId: number,
+    clubId: number,
+    semesterId: number,
+  ): Promise<void> {
+    const cur = getKSTDate();
+
+    await this.db
+      .update(ClubStudentT)
+      .set({ deletedAt: cur })
+      .where(
+        and(
+          eq(ClubStudentT.studentId, studentId),
+          eq(ClubStudentT.clubId, clubId),
+          eq(ClubStudentT.semesterId, semesterId),
+          isNull(ClubStudentT.deletedAt),
+        ),
+      )
+      .execute();
   }
 }

--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -145,4 +145,67 @@ export default class ClubPublicService {
       );
     return isPresident;
   }
+
+  /**
+   * @param studentId 학생의 ID
+   * @param clubId 동아리의 ID
+   * @returns void
+   *
+   * 학생을 특정 동아리에 추가합니다.
+   * 이 메소드는 현재 학기(`semesterId`)에 해당하는 동아리에 학생을 추가합니다.
+   * 현재 학기를 기준으로 `semesterId`를 조회하고, 조회된 학기가 없는 경우 예외를 발생시킵니다.
+   * 조회된 `semesterId`를 사용하여 해당 동아리(`clubId`)에 학생(`studentId`)을 추가합니다.
+   */
+
+  async addStudentToClub(studentId: number, clubId: number): Promise<void> {
+    const cur = getKSTDate(); // 현재 KST 시간을 가져옴
+
+    const semesterId = await this.dateToSemesterId(cur);
+    if (!semesterId) {
+      throw new HttpException(
+        "No current semester found.",
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // 신입 부원 추가
+    await this.clubStudentTRepository.addStudentToClub(
+      studentId,
+      clubId,
+      semesterId,
+    );
+  }
+
+  /**
+   * 학생을 특정 동아리에서 제거합니다.
+   *
+   * @param studentId 학생의 ID
+   * @param clubId 동아리의 ID
+   * @returns void
+   *
+   * 이 메소드는 현재 학기(`semesterId`)에 해당하는 동아리에서 학생을 제거합니다.
+   * 현재 학기를 기준으로 `semesterId`를 조회하고, 조회된 학기가 없는 경우 예외를 발생시킵니다.
+   * 조회된 `semesterId`를 사용하여 해당 동아리(`clubId`)에서 학생(`studentId`)을 제거합니다.
+   */
+  async removeStudentFromClub(
+    studentId: number,
+    clubId: number,
+  ): Promise<void> {
+    const cur = getKSTDate(); // 현재 KST 시간을 가져옴
+
+    const semesterId = await this.dateToSemesterId(cur);
+    if (!semesterId) {
+      throw new HttpException(
+        "No current semester found.",
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // 신입 부원 제거
+    await this.clubStudentTRepository.removeStudentFromClub(
+      studentId,
+      clubId,
+      semesterId,
+    );
+  }
 }

--- a/packages/api/src/feature/registration/member-registration/repository/member-registration.repository.ts
+++ b/packages/api/src/feature/registration/member-registration/repository/member-registration.repository.ts
@@ -229,7 +229,12 @@ export class MemberRegistrationRepository {
     const result = await this.db
       .select()
       .from(RegistrationApplicationStudent)
-      .where(eq(RegistrationApplicationStudent.id, applyId))
+      .where(
+        and(
+          eq(RegistrationApplicationStudent.id, applyId),
+          isNull(RegistrationApplicationStudent.deletedAt),
+        ),
+      )
       .execute();
 
     return result.length > 0 ? result[0] : null;

--- a/packages/api/src/feature/registration/member-registration/repository/member-registration.repository.ts
+++ b/packages/api/src/feature/registration/member-registration/repository/member-registration.repository.ts
@@ -19,6 +19,15 @@ import {
   RegistrationDeadlineD,
 } from "@sparcs-clubs/api/drizzle/schema/registration.schema";
 
+interface IRegistrationApplicationStudent {
+  id: number;
+  studentId: number;
+  clubId: number;
+  registrationApplicationStudentEnumId: number;
+  createdAt: Date;
+  deletedAt?: Date; // nullable
+}
+
 @Injectable()
 export class MemberRegistrationRepository {
   constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
@@ -180,22 +189,18 @@ export class MemberRegistrationRepository {
           and(
             eq(RegistrationApplicationStudent.id, applyId),
             eq(RegistrationApplicationStudent.clubId, clubId),
-            eq(
-              RegistrationApplicationStudent.registrationApplicationStudentEnumId,
-              RegistrationApplicationStudentStatusEnum.Pending,
-            ),
             isNull(RegistrationApplicationStudent.deletedAt),
           ),
         );
       if (result.affectedRows > 2) {
-        await tx.rollback();
         throw new HttpException("Registration update failed", 500);
-      } else if (result.affectedRows === 0) {
         await tx.rollback();
+      } else if (result.affectedRows === 0) {
         throw new HttpException(
           "Not available application",
           HttpStatus.FORBIDDEN,
         );
+        await tx.rollback();
       }
     });
     return {};
@@ -216,5 +221,17 @@ export class MemberRegistrationRepository {
         ),
       );
     return { applies: result };
+  }
+
+  async findMemberRegistrationById(
+    applyId: number,
+  ): Promise<IRegistrationApplicationStudent | null> {
+    const result = await this.db
+      .select()
+      .from(RegistrationApplicationStudent)
+      .where(eq(RegistrationApplicationStudent.id, applyId))
+      .execute();
+
+    return result.length > 0 ? result[0] : null;
   }
 }

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -131,9 +131,22 @@ export class MemberRegistrationService {
         HttpStatus.BAD_REQUEST,
       );
 
-    if (applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Approved)
-      await this.clubPublicService.addStudentToClub(studentId, clubId);
-    else if (
+    if (
+      applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Approved
+    ) {
+      const isAlreadyMember = await this.clubPublicService.isStudentBelongsTo(
+        studentId,
+        clubId,
+      );
+
+      if (!isAlreadyMember)
+        await this.clubPublicService.addStudentToClub(studentId, clubId);
+      else
+        throw new HttpException(
+          "this registration is already approved, or student is already belongs to this club",
+          HttpStatus.BAD_REQUEST,
+        );
+    } else if (
       applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Rejected
     )
       if (isDelegate)

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -131,11 +131,18 @@ export class MemberRegistrationService {
         HttpStatus.BAD_REQUEST,
       );
 
-    // if (applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Approved) {
+    if (applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Approved)
+      await this.clubPublicService.addStudentToClub(studentId, clubId);
+    else if (
+      applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Rejected
+    )
+      if (isDelegate)
+        throw new HttpException(
+          "club delegate cannot be rejected",
+          HttpStatus.BAD_REQUEST,
+        );
+    await this.clubPublicService.removeStudentFromClub(studentId, clubId);
 
-    // }
-    // TODO: Enum이 Approved 이면 동아리 회원목록에 추가
-    // TODO: Enum이 Rejected 되면 동아리 회원목록에서 제거
     const result =
       await this.memberRegistrationRepository.patchMemberRegistration(
         applyId,

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -117,12 +117,12 @@ export class MemberRegistrationService {
       applyStatusEnumId !== RegistrationApplicationStudentStatusEnum.Rejected
     )
       throw new HttpException("Invalid status enum", HttpStatus.BAD_REQUEST);
-    const isPresident = await this.clubPublicService.isStudentPresident(
+    const isPresident = await this.clubPublicService.isStudentDelegate(
       studentId,
       clubId,
     );
     if (!isPresident)
-      throw new HttpException("Not a club president", HttpStatus.FORBIDDEN);
+      throw new HttpException("Not a club delegate", HttpStatus.FORBIDDEN);
     const ismemberRegistrationEvent =
       await this.memberRegistrationRepository.isMemberRegistrationEvent();
     if (!ismemberRegistrationEvent)

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -130,6 +130,12 @@ export class MemberRegistrationService {
         "Not a member registration event duration",
         HttpStatus.BAD_REQUEST,
       );
+
+    // if (applyStatusEnumId === RegistrationApplicationStudentStatusEnum.Approved) {
+
+    // }
+    // TODO: Enum이 Approved 이면 동아리 회원목록에 추가
+    // TODO: Enum이 Rejected 되면 동아리 회원목록에서 제거
     const result =
       await this.memberRegistrationRepository.patchMemberRegistration(
         applyId,

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -117,11 +117,11 @@ export class MemberRegistrationService {
       applyStatusEnumId !== RegistrationApplicationStudentStatusEnum.Rejected
     )
       throw new HttpException("Invalid status enum", HttpStatus.BAD_REQUEST);
-    const isPresident = await this.clubPublicService.isStudentDelegate(
+    const isDelegate = await this.clubPublicService.isStudentDelegate(
       studentId,
       clubId,
     );
-    if (!isPresident)
+    if (!isDelegate)
       throw new HttpException("Not a club delegate", HttpStatus.FORBIDDEN);
     const ismemberRegistrationEvent =
       await this.memberRegistrationRepository.isMemberRegistrationEvent();
@@ -143,7 +143,7 @@ export class MemberRegistrationService {
     studentId: number,
     clubId: number,
   ): Promise<ApiReg008ResponseOk> {
-    const isPresident = await this.clubPublicService.isStudentPresident(
+    const isPresident = await this.clubPublicService.isStudentDelegate(
       studentId,
       clubId,
     );

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -143,12 +143,12 @@ export class MemberRegistrationService {
     studentId: number,
     clubId: number,
   ): Promise<ApiReg008ResponseOk> {
-    const isPresident = await this.clubPublicService.isStudentDelegate(
+    const isDelegate = await this.clubPublicService.isStudentDelegate(
       studentId,
       clubId,
     );
-    if (!isPresident)
-      throw new HttpException("Not a club president", HttpStatus.FORBIDDEN);
+    if (!isDelegate)
+      throw new HttpException("Not a club delegate", HttpStatus.FORBIDDEN);
     const ismemberRegistrationEvent =
       await this.memberRegistrationRepository.isMemberRegistrationEvent();
     if (!ismemberRegistrationEvent)

--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -141,7 +141,8 @@ export class MemberRegistrationService {
           "club delegate cannot be rejected",
           HttpStatus.BAD_REQUEST,
         );
-    await this.clubPublicService.removeStudentFromClub(studentId, clubId);
+      else
+        await this.clubPublicService.removeStudentFromClub(studentId, clubId);
 
     const result =
       await this.memberRegistrationRepository.patchMemberRegistration(


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->
회원 등록 신청을 생성하는 REG-007 / 008의 정책 변경을 완료했습니다.
본래 동아리 대표자만이 학생의 동아리 가입 신청을 수정 / 목록 열람 할 수 있었으나
대표자와 대의원, 즉 delegate인지 검사하는 로직으로 수정 완료했습니다.

2024.08.22 00:08 추가
REG-007에서 동아리 가입 신청이 "승인" 되면, 가입 신청 내부 신청자 학생을 동아리 멤버 명단에 추가합니다. (아직 미구현)
REG-007에서 동아리 가입 신청이 "반려" 되면, 가입 신청 내부 신청자 학생을 동아리 멤버 명단에서 제거합니다. (아직 미구현)

It closes #687 

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/f0009c3e-9973-4a37-a9ec-51f896375596)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
