### PR TITLE
Fix representative change success component

### DIFF
--- a/packages/web/src/app/my/page.tsx
+++ b/packages/web/src/app/my/page.tsx
@@ -21,7 +21,7 @@ import { useGetMyDelegateRequest } from "@sparcs-clubs/web/features/my/services/
 
 const My: React.FC = () => {
   // TODO: clb014 api 구현되면 refetch 테스트
-  const isStudent = false; // 학생 <--> 지도교수 TODO: 로그인 정보로 대체
+  const isStudent = true; // 학생 <--> 지도교수 TODO: 로그인 정보로 대체
   const { data, isLoading, isError, refetch } = useGetMyDelegateRequest();
   const fetchDivisionPresident = () => {}; // TODO
 

--- a/packages/web/src/constants/changeRepresentative.ts
+++ b/packages/web/src/constants/changeRepresentative.ts
@@ -22,8 +22,12 @@ const myChangeRepresentativeRequestText = (
 ) =>
   `'${clubName}'의 동아리 대표자 변경이 다음과 같이 요청되었습니다 \n${prevRepresentative} -> ${newRepresentative} (승인 전)`;
 
-const myChangeRepresentativeFinishText = (clubName: string) =>
-  `'${clubName}'의 동아리 대표자 변경이 완료되었습니다`;
+const myChangeRepresentativeFinishText = (
+  clubName: string,
+  prevRepresentative: string,
+  newRepresentative: string,
+) =>
+  `'${clubName}'의 동아리 대표자 변경이 다음과 같이 완료되었습니다 \n${prevRepresentative} -> ${newRepresentative}`;
 
 const ChangeRepresentativeModalText = (
   clubName: string,

--- a/packages/web/src/features/my/components/MyChangeRepresentative.tsx
+++ b/packages/web/src/features/my/components/MyChangeRepresentative.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import isPropValid from "@emotion/is-prop-valid";
+import { useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
 import styled from "styled-components";
 
@@ -49,6 +50,7 @@ const MyChangeRepresentative: React.FC<MyChangeRepresentativeProps> = ({
   newRepresentative,
   refetch,
 }) => {
+  const router = useRouter();
   const Title =
     type === "Requested"
       ? "동아리 대표자 변경 요청"
@@ -60,8 +62,12 @@ const MyChangeRepresentative: React.FC<MyChangeRepresentativeProps> = ({
           prevRepresentative,
           newRepresentative,
         )
-      : myChangeRepresentativeFinishText(clubName);
-
+      : myChangeRepresentativeFinishText(
+          clubName,
+          prevRepresentative,
+          newRepresentative,
+        );
+  const isNewRepresentative = true; // TODO: 본인이 새로운 대표자인지 확인하는 로직 필요
   const openConfirmModal = () => {
     overlay.open(({ isOpen, close }) => (
       <Modal isOpen={isOpen}>
@@ -94,9 +100,19 @@ const MyChangeRepresentative: React.FC<MyChangeRepresentativeProps> = ({
         {type === "Requested" && (
           <TextButton
             color="GRAY"
-            text="클릭해서 더보기"
+            text="클릭하여 더보기"
             fw="REGULAR"
             onClick={openConfirmModal}
+          />
+        )}
+        {type === "Finished" && isNewRepresentative && (
+          <TextButton
+            color="GRAY"
+            text="대표 동아리 관리 페이지 바로가기"
+            fw="REGULAR"
+            onClick={() => {
+              router.push(`/manage-club/`);
+            }}
           />
         )}
       </FlexWrapper>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #529 

MyChangeRepresentative.tsx에 임시로 isNewRepresentative라는 boolean 변수를 달아서 두 경우 다 테스트할 수 있도록 해놨습니다

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/2a2bbcbe-7d54-4a4e-bf9b-f08d79182173)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
