### PR TITLE
handle existing club registration case (Mock Data)

### DIFF
--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -14,6 +14,7 @@ import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import ClubButton from "@sparcs-clubs/web/features/register-club/components/ClubButton";
 
+import { mockMyRegistration } from "@sparcs-clubs/web/features/register-club/service/_mock/mockMyRegistration";
 import colors from "@sparcs-clubs/web/styles/themes/colors";
 
 const ClubButtonWrapper = styled.div`
@@ -58,12 +59,11 @@ const WarningTextsWrapper = styled.div`
   opacity: 1;
 `;
 
-const WarningLink = () => {
+const WarningLink: React.FC<{ id: number }> = ({ id }) => {
   const router = useRouter();
-  const link = "/"; // ToDo : 실제 데이터 연결
 
   const onClick = () => {
-    router.push(link);
+    router.push(`my/register-club/${id}`);
   };
 
   const AnchorTypography = styled(Typography)`
@@ -78,7 +78,7 @@ const WarningLink = () => {
   );
 };
 
-const WarningArea = () => (
+const WarningArea: React.FC<{ id: number }> = ({ id }) => (
   <WarningWrapper>
     <WarningIconWrapper>
       <Icon type="error" color={colors.RED["600"]} size={20} />
@@ -87,7 +87,7 @@ const WarningArea = () => (
       <Typography fs={16} fw="REGULAR" lh={24}>
         동아리 등록 신청 내역이 이미 존재하여 추가로 신청할 수 없습니다
       </Typography>
-      <WarningLink />
+      <WarningLink id={id} />
     </WarningTextsWrapper>
   </WarningWrapper>
 );
@@ -102,6 +102,8 @@ const RegisterClub = () => {
   const [selectedType, setSelectedType] = useState<RegistrationType | null>(
     null,
   );
+
+  const myRegistration = mockMyRegistration; // ToDo: 실제 데이터 연결
 
   const router = useRouter();
   const onClick = () => {
@@ -123,7 +125,9 @@ const RegisterClub = () => {
         items={[{ name: "동아리 등록", path: "/register-club" }]}
         title="동아리 등록"
       />
-      <WarningArea />
+      {myRegistration.registrations.length > 0 && (
+        <WarningArea id={myRegistration.registrations[0].id} />
+      )}
       <Info text="현재는 2024년 봄학기 동아리 등록 기간입니다 (신청 마감 : 2024년 3월 10일 23:59)" />
       <ClubButtonWrapper>
         <ClubButton

--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -8,9 +8,13 @@ import styled from "styled-components";
 
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Icon from "@sparcs-clubs/web/common/components/Icon";
 import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 import ClubButton from "@sparcs-clubs/web/features/register-club/components/ClubButton";
+
+import colors from "@sparcs-clubs/web/styles/themes/colors";
 
 const ClubButtonWrapper = styled.div`
   display: flex;
@@ -22,6 +26,71 @@ const ClubButtonWrapper = styled.div`
     flex-direction: column;
   }
 `;
+
+const WarningWrapper = styled.div`
+  display: flex;
+  max-height: 300px;
+  padding: 12px 16px;
+  align-items: flex-start;
+  gap: 8px;
+  align-self: stretch;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.RED[600]};
+  opacity: 1;
+  background: ${({ theme }) => theme.colors.RED[100]};
+`;
+
+const WarningIconWrapper = styled.div`
+  display: flex;
+  height: 24px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  opacity: 1;
+`;
+
+const WarningTextsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1 0 0;
+  opacity: 1;
+`;
+
+const WarningLink = () => {
+  const router = useRouter();
+  const link = "register-club/renewal"; // ToDo : 실제 데이터 연결
+
+  const onClick = () => {
+    router.push(link);
+  };
+
+  const AnchorTypography = styled(Typography)`
+    cursor: pointer;
+    text-decoration: underline;
+  `;
+
+  return (
+    <AnchorTypography fs={16} fw="REGULAR" lh={24} onClick={onClick}>
+      동아리 등록 신청 내역 바로가기
+    </AnchorTypography>
+  );
+};
+
+const WarningArea = () => (
+  <WarningWrapper>
+    <WarningIconWrapper>
+      <Icon type="error" color={colors.RED["600"]} size={20} />
+    </WarningIconWrapper>
+    <WarningTextsWrapper>
+      <Typography fs={16} fw="REGULAR" lh={24}>
+        동아리 등록 신청 내역이 이미 존재하여 추가로 신청할 수 없습니다
+      </Typography>
+      <WarningLink />
+    </WarningTextsWrapper>
+  </WarningWrapper>
+);
 
 const RegisterClub = () => {
   enum RegistrationType {
@@ -54,6 +123,7 @@ const RegisterClub = () => {
         items={[{ name: "동아리 등록", path: "/register-club" }]}
         title="동아리 등록"
       />
+      <WarningArea />
       <Info text="현재는 2024년 봄학기 동아리 등록 기간입니다 (신청 마감 : 2024년 3월 10일 23:59)" />
       <ClubButtonWrapper>
         <ClubButton

--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -156,7 +156,11 @@ const RegisterClub = () => {
         />
       </ClubButtonWrapper>
       <Button
-        type={selectedType === null ? "disabled" : "default"}
+        type={
+          selectedType === null || myRegistration.registrations.length > 0
+            ? "disabled"
+            : "default"
+        }
         onClick={() => onClick()}
       >
         등록 신청

--- a/packages/web/src/app/register-club/page.tsx
+++ b/packages/web/src/app/register-club/page.tsx
@@ -60,7 +60,7 @@ const WarningTextsWrapper = styled.div`
 
 const WarningLink = () => {
   const router = useRouter();
-  const link = "register-club/renewal"; // ToDo : 실제 데이터 연결
+  const link = "/"; // ToDo : 실제 데이터 연결
 
   const onClick = () => {
     router.push(link);

--- a/packages/web/src/features/register-club/service/_mock/mockMyRegistration.ts
+++ b/packages/web/src/features/register-club/service/_mock/mockMyRegistration.ts
@@ -1,0 +1,18 @@
+import { ApiReg012ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg012";
+
+import {
+  RegistrationStatusEnum,
+  RegistrationTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+export const mockMyRegistration: ApiReg012ResponseOk = {
+  registrations: [
+    {
+      id: 1,
+      registrationTypeEnumId: RegistrationTypeEnum.NewProvisional,
+      registrationStatusEnumId: RegistrationStatusEnum.Pending,
+      krName: "술박스",
+      enName: "Soolbox",
+    },
+  ],
+};


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #716 

동아리 등록 신청 내역이 존재하는 경우, 동아리 등록 신청 창에서
1) 신청할 수 없음을 알리는 경고가 뜹니다. 신청 내역으로 연결되는 링크가 있습니다.
2) 신청 버튼이 비활성화 됩니다.

REG-012 API가 구현되지 않아, 우선 interface를 따르는 mock data로 UI 구현하였습니다.

## 리뷰 받고 싶은 부분
1. 등록 정보를 가져와서 쓸 때, useEffect를 써야 하나 고민하다가 쓰지 않았는데 맞는 선택일까요?
2. 신청 내역으로 이동하는 링크를 누르면 `my/register-club/[id]`로 이동하는데, 이 자리에 REG-012에서 넘어오는 id를 그대로 사용하는 게 맞나요?

# 스크린샷

![image](https://github.com/user-attachments/assets/7ba5fdc1-daeb-4343-afeb-85cd8205098a)

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- API 연결
