### PR TITLE
Remove right padding at /clubs

### DIFF
--- a/packages/web/src/features/clubs/components/ClubListGrid.tsx
+++ b/packages/web/src/features/clubs/components/ClubListGrid.tsx
@@ -18,7 +18,7 @@ interface ClubListGridItemProps {
 }
 
 const ClubListGridInner = styled.div`
-  width: calc(100% - 48px);
+  width: 100%;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #722 

foldablesectiontitle에 있는 접기랑 정렬 맞도록 수정

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/3192ec84-b756-46d4-9f6a-ac0e437e7540)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
