### PR TITLE
fix: check isStudentDelegate while removing Student from Club

### DIFF
--- a/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
@@ -155,6 +155,8 @@ export default class ClubStudentTRepository {
       .execute();
   }
 
+  // ** 주의: delegate 또는 일반 부원을 제거합니다.
+  // ** 제거 시 hard deletion이 이루어집니다.
   async removeStudentFromClub(
     studentId: number,
     clubId: number,

--- a/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
@@ -6,7 +6,12 @@ import { getKSTDate, takeUnique } from "@sparcs-clubs/api/common/util/util";
 import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 
 import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
-import { Club, ClubStudentT, SemesterD } from "src/drizzle/schema/club.schema";
+import {
+  Club,
+  ClubDelegateD,
+  ClubStudentT,
+  SemesterD,
+} from "src/drizzle/schema/club.schema";
 
 @Injectable()
 export default class ClubStudentTRepository {
@@ -154,7 +159,19 @@ export default class ClubStudentTRepository {
     studentId: number,
     clubId: number,
     semesterId: number,
+    isTargetStudentDelegate: boolean,
   ): Promise<void> {
+    if (isTargetStudentDelegate)
+      await this.db
+        .delete(ClubDelegateD)
+        .where(
+          and(
+            eq(ClubDelegateD.studentId, studentId),
+            eq(ClubDelegateD.clubId, clubId),
+            isNull(ClubDelegateD.deletedAt),
+          ),
+        )
+        .execute();
     await this.db
       .delete(ClubStudentT)
       .where(

--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -208,11 +208,16 @@ export default class ClubPublicService {
       );
     }
 
+    const isTargetStudentDelegate = await this.isStudentDelegate(
+      studentId,
+      clubId,
+    );
     // 신입 부원 제거
     await this.clubStudentTRepository.removeStudentFromClub(
       studentId,
       clubId,
       semesterId,
+      isTargetStudentDelegate,
     );
   }
 }


### PR DESCRIPTION
# 요약 \*
club public service에 존재하는 removeStudentFromClub을 시행할 때 클럽 스튜던트 테이블에서는 사라지지만
해당 student가 동아리의 대표자 / 대의원일 경우 DB에서 대표자/대의원로 계속해서 남아있는 문제가 있었습니다

해당 문제를 고치기 위해, remove의 대상이 되는 학생의 ID를 통해 해당 학생이 대표자 / 대의원인지 확인하고, 만약 이것이 true이면
대표자/대의원인지 검사하는 로직을 추가합니다.


<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #782 

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
