### PR TITLE
Fix unintentional horizontal scroll

### DIFF
--- a/packages/web/src/common/components/FoldableSectionTitle.tsx
+++ b/packages/web/src/common/components/FoldableSectionTitle.tsx
@@ -10,6 +10,7 @@ import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 
 const FoldableSectionOuter = styled.div`
   width: 100%;
+  max-width: calc(100vw + (100% - 100vw));
 `;
 
 const FoldableSectionTitleInner = styled.div`

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -38,6 +38,11 @@ a {
   color: inherit;
 }
 
+main {
+  overflow-x: hidden;
+  min-width: 320px;
+}
+
 .viewer-download {
   color: #fff;
   font-family: FontAwesome, serif;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #728 

Table Component는, 부모 안에 딱 맞는 width와 가로 위치를 가지는 것이 아니라, 100vw 너비와 (100vw - 100%)의 절반씩에 해당하는 대칭인 padding을 가지고 있습니다. (튀어나가서 스크롤할 영역까지 보이게 하기 위해서인 것으로 추정합니다)
그런데 FoldableSectionTitle 안에 있는 경우, 들여쓰기가 들어가면서 표가 배치되는 위치가 좌우대칭 위치가 아니게 됩니다. 이로 인해서 100vw의 너비지만 왼쪽 끝에 붙어있지 않은, 그래서 오른쪽으로 튀어나가는 거대한 Table이 전체 화면의 스크롤을 유발하게 됩니다.

1. width를 100%로 하는 수정 방안들 -> 튀어나간 영역이 보이지 않습니다
2. width를 100vw보다는 작게 한다 -> (좌우대칭이 아닌) 왼쪽, 오른쪽 끝의 특정 선 밖의 표가 잘려서 보입니다

@babycroc 님의 도움으로, main의 overflow-x를 hidden으로 처리하는 방법을 사용하게 되었습니다. globals.css를 수정하는 김에, min-width를 320px로 설정하는 것도 함께 했습니다. 다만 320px보다 좁은 화면에서 여전히 의도하지 않은 것으로 보이는 화면이 나타나는데, 장기적으로 100vw로 된 값들을 max(100vw, 320px)로 설정하는 등의 해결 방안이 필요해 보입니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- main의 min-width 320px 설정에 대응하는 수정 사항들
