### PR TITLE
refactor: adjust gap and margin in mobile credits page

### DIFF
--- a/packages/web/src/app/credits/page.tsx
+++ b/packages/web/src/app/credits/page.tsx
@@ -2,6 +2,8 @@
 
 import React from "react";
 
+import styled from "styled-components";
+
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
@@ -10,6 +12,22 @@ import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import MemberCardSection from "@sparcs-clubs/web/features/credits/components/MemberCardSection";
 import credits from "@sparcs-clubs/web/features/credits/credits";
 
+const CreditCardsFlexWrapper = styled(FlexWrapper)`
+  gap: 40px;
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
+    gap: 20px;
+  }
+`;
+
+const ResponsiveMemberCardSectionWrapper = styled.div`
+  margin-left: 24px;
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
+    margin-left: 16px;
+  }
+`;
+
 const Credits: React.FC = () => (
   <FlexWrapper direction="column" gap={60}>
     <PageHead
@@ -17,18 +35,22 @@ const Credits: React.FC = () => (
       title="만든 사람들"
     />
     {credits.map((credit, index) => (
-      <FlexWrapper direction="column" gap={40} key={credit.semester}>
+      <CreditCardsFlexWrapper direction="column" gap={40} key={credit.semester}>
         {index === 0 ? (
           <>
             <SectionTitle size="lg">{credit.semester}</SectionTitle>
-            <MemberCardSection semesterCredit={credit} leftMargin={24} />
+            <ResponsiveMemberCardSectionWrapper>
+              <MemberCardSection semesterCredit={credit} leftMargin={0} />
+            </ResponsiveMemberCardSectionWrapper>
           </>
         ) : (
           <FoldableSectionTitle title={credit.semester}>
-            <MemberCardSection semesterCredit={credit} />
+            <ResponsiveMemberCardSectionWrapper>
+              <MemberCardSection semesterCredit={credit} />
+            </ResponsiveMemberCardSectionWrapper>
           </FoldableSectionTitle>
         )}
-      </FlexWrapper>
+      </CreditCardsFlexWrapper>
     ))}
   </FlexWrapper>
 );


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #766

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/3673684f-f055-47b5-9f32-f6ac74aa2f56)

## Figma에서 맞춰야 할 사항
![image](https://github.com/user-attachments/assets/86018177-ef2d-462d-a98a-4e5bafc4501c)
20 -> 12로 변경해야 합니다

![image](https://github.com/user-attachments/assets/8d2428ed-7c5b-4d4b-82de-89f7f650c0c8)
40 -> 20으로 변경해야 합니다

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
