### PR TITLE
/executive/register-club connect backend and page redirection

### DIFF
--- a/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
+++ b/packages/web/src/common/components/ExecutiveRegistrationTable.tsx
@@ -109,6 +109,7 @@ const ExecutiveRegistrationTable: React.FC<ExecutiveRegistrationTableProps> = ({
       table={table}
       count={registerList.total}
       emptyMessage="동아리 등록 신청 내역이 없습니다."
+      rowLink={row => `/executive/register-club/${row.id}`}
     />
   );
 };

--- a/packages/web/src/features/executive/register-club/frames/ExecutiveRegistrationClubFrame.tsx
+++ b/packages/web/src/features/executive/register-club/frames/ExecutiveRegistrationClubFrame.tsx
@@ -24,9 +24,10 @@ export const ExecutiveRegistrationClubFrame = () => {
   const limit = 10;
 
   const { data, isLoading, isError } = useGetRegisterClub({
-    pageOffset: 1,
+    pageOffset: currentPage,
     itemCount: 10,
   });
+
   const [clubData, setClubData] = useState<RegisterClubList>({
     items: [],
     total: 0,
@@ -42,11 +43,8 @@ export const ExecutiveRegistrationClubFrame = () => {
     if (!isLoading && data) {
       setClubData(data);
       setPaginatedData({
-        total: data?.total,
-        items: data?.items.slice(
-          (currentPage - 1) * limit,
-          currentPage * limit,
-        ),
+        total: data.total,
+        items: data.items.slice((currentPage - 1) * limit, currentPage * limit),
         offset: (currentPage - 1) * limit,
       });
     }
@@ -57,19 +55,17 @@ export const ExecutiveRegistrationClubFrame = () => {
   };
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>
-      {clubData.items.length > 0 && (
-        <TableWithPaginationWrapper>
-          <ExecutiveRegistrationTable registerList={paginatedData} />
-          <FlexWrapper direction="row" gap={16} justify="center">
-            <Pagination
-              totalPage={Math.ceil(clubData.total / limit)}
-              currentPage={currentPage}
-              limit={limit}
-              setPage={handlePageChange}
-            />
-          </FlexWrapper>
-        </TableWithPaginationWrapper>
-      )}
+      <TableWithPaginationWrapper>
+        <ExecutiveRegistrationTable registerList={paginatedData} />
+        <FlexWrapper direction="row" gap={16} justify="center">
+          <Pagination
+            totalPage={Math.ceil(clubData.total / limit)}
+            currentPage={currentPage}
+            limit={limit}
+            setPage={handlePageChange}
+          />
+        </FlexWrapper>
+      </TableWithPaginationWrapper>
     </AsyncBoundary>
   );
 };

--- a/packages/web/src/features/executive/register-club/services/useGetRegisterClub.ts
+++ b/packages/web/src/features/executive/register-club/services/useGetRegisterClub.ts
@@ -20,8 +20,13 @@ export const useGetRegisterClub = (requestQuery: ApiReg014RequestQuery) =>
       });
 
       switch (status) {
-        case 200:
+        case 200: {
+          if (data.total === 0 && data.items.length === 0 && data.offset)
+            // items = []일 때 isError = true 방지
+            return data;
           return apiReg014.responseBodyMap[200].parse(data);
+        }
+
         default:
           throw new UnexpectedAPIResponseError();
       }


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #803

### 피드백 받고 싶은 사항
디비에 우연히 테스트 데이터가 없어서 응답으로 빈 리스트가 올 때 (items: []) 어떻게 처리할 건지 고민할 수 있게 되었는데요,
처음에는 자꾸 isError = true가 되다보니 AsyncBoundary에 html 덩어리로 Error 이렇게 뜨더라구요.

왜 `isError = true`인걸까 생각해보니 useGetRegisterClub.ts 안의 `return apiReg014.responseBodyMap[200].parse(data);` 
여기서 파싱하면서 `isError = true`가 되는 게 아닐까 싶었습니다. 

파싱을 빼고 `return data;` 이렇게만 하면 이 문제가 해결되기는 했으나, 파싱의 역할이 중요하기 때문에 parse 함수는 안 쓰면서 나름대로 오류 없는 형식의 데이터가 응답으로 오는지 확인하는 조건문을 달아두었습니다. 

이렇게 처리해도 되는지, 조건문은 적절한지 봐주시면 좋을 것 같습니다.


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
#### Mock mode
<img width="1512" alt="스크린샷 2024-08-25 오후 11 46 31" src="https://github.com/user-attachments/assets/00767c3a-fa7e-44ca-9674-1850825fa978">

#### Dev DB (데이터가 없는 듯)
<img width="1512" alt="스크린샷 2024-08-25 오후 11 47 02" src="https://github.com/user-attachments/assets/1e518530-6ab3-44dd-8279-f95b12227307">

#### 상세페이지 연결
https://github.com/user-attachments/assets/d348d3ca-0c75-4d1c-aae2-4c18c1291211

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
