### PR TITLE
Connect backend for /manage-club/members

### DIFF
--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -17,7 +17,10 @@ import TableButton from "@sparcs-clubs/web/common/components/Table/TableButton";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import { MemTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
+
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+import { patchClubMemberRegistration } from "../members/services/patchClubMemberRegistration";
 
 interface Members {
   id: number;
@@ -34,15 +37,28 @@ interface Members {
 interface MembersTableProps {
   memberList: Members[];
   clubName: string;
+  clubId: number;
 }
 
-const openApproveModal = (member: Members, clubName: string) => {
+const openApproveModal = (
+  member: Members,
+  clubName: string,
+  clubId: number,
+) => {
   overlay.open(({ isOpen, close }) => (
     <Modal isOpen={isOpen}>
       <CancellableModalContent
         confirmButtonText="승인"
         onConfirm={() => {
           // TODO: 승인 로직 넣기
+          patchClubMemberRegistration(
+            { applyId: member.id },
+            {
+              clubId,
+              applyStatusEnumId:
+                RegistrationApplicationStudentStatusEnum.Approved,
+            },
+          );
           close();
         }}
         onClose={() => {
@@ -59,13 +75,20 @@ const openApproveModal = (member: Members, clubName: string) => {
   ));
 };
 
-const openRejectModal = (member: Members, clubName: string) => {
+const openRejectModal = (member: Members, clubName: string, clubId: number) => {
   overlay.open(({ isOpen, close }) => (
     <Modal isOpen={isOpen}>
       <CancellableModalContent
         confirmButtonText="반려"
         onConfirm={() => {
-          // TODO: 승인 로직 넣기
+          patchClubMemberRegistration(
+            { applyId: member.id },
+            {
+              clubId,
+              applyStatusEnumId:
+                RegistrationApplicationStudentStatusEnum.Rejected,
+            },
+          );
           close();
         }}
         onClose={() => {
@@ -84,7 +107,7 @@ const openRejectModal = (member: Members, clubName: string) => {
 
 const columnHelper = createColumnHelper<Members>();
 
-const columnsFunction = (clubName: string) => [
+const columnsFunction = (clubName: string, clubId: number) => [
   columnHelper.accessor("applyStatusEnumId", {
     header: "상태",
     cell: info => {
@@ -128,10 +151,9 @@ const columnsFunction = (clubName: string) => [
         <TableButton
           text={["승인", "반려"]}
           onClick={[
-            () => openApproveModal(member, clubName),
-            () => openRejectModal(member, clubName),
+            () => openApproveModal(member, clubName, clubId),
+            () => openRejectModal(member, clubName, clubId),
           ]}
-          // TODO: 승인 반려 기능 넣기
         />
       ) : (
         " "
@@ -144,8 +166,9 @@ const columnsFunction = (clubName: string) => [
 const MembersTable: React.FC<MembersTableProps> = ({
   memberList,
   clubName,
+  clubId,
 }) => {
-  const columns = columnsFunction(clubName);
+  const columns = columnsFunction(clubName, clubId);
   const table = useReactTable({
     columns,
     data: memberList,

--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -17,11 +19,18 @@ import { MemTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import {
-  type Members,
-  MemberStatusEnum,
-} from "../services/_mock/mockManageClub";
-
+interface Members {
+  id: number;
+  createdAt: Date;
+  applyStatusEnumId: RegistrationApplicationStudentStatusEnum;
+  student: {
+    id: number;
+    name: string;
+    studentNumber: number;
+    email: string;
+    phoneNumber?: string | undefined;
+  };
+}
 interface MembersTableProps {
   memberList: Members[];
   clubName: string;
@@ -40,7 +49,7 @@ const openApproveModal = (member: Members, clubName: string) => {
           close();
         }}
       >
-        {member.studentId} {member.applicantName} 학생의{" "}
+        {member.student.studentNumber} {member.student.name} 학생의{" "}
         {new Date().getFullYear()}
         년도 {new Date().getMonth() < 7 ? "봄학기" : "가을학기"} {clubName}{" "}
         동아리 신청을
@@ -63,7 +72,7 @@ const openRejectModal = (member: Members, clubName: string) => {
           close();
         }}
       >
-        {member.studentId} {member.applicantName} 학생의{" "}
+        {member.student.studentNumber} {member.student.name} 학생의{" "}
         {new Date().getFullYear()}
         년도 {new Date().getMonth() < 7 ? "봄학기" : "가을학기"} {clubName}{" "}
         동아리 신청을
@@ -76,7 +85,7 @@ const openRejectModal = (member: Members, clubName: string) => {
 const columnHelper = createColumnHelper<Members>();
 
 const columnsFunction = (clubName: string) => [
-  columnHelper.accessor("status", {
+  columnHelper.accessor("applyStatusEnumId", {
     header: "상태",
     cell: info => {
       const { color, text } = getTagDetail(info.getValue(), MemTagList);
@@ -84,27 +93,27 @@ const columnsFunction = (clubName: string) => [
     },
     size: 5,
   }),
-  columnHelper.accessor("applicationDate", {
+  columnHelper.accessor("createdAt", {
     header: "신청 일시",
     cell: info => formatDateTime(info.getValue()),
     size: 30,
   }),
-  columnHelper.accessor("studentId", {
+  columnHelper.accessor("student.studentNumber", {
     header: "학번",
     cell: info => info.getValue(),
     size: 5,
   }),
-  columnHelper.accessor("applicantName", {
+  columnHelper.accessor("student.name", {
     header: "신청자",
     cell: info => info.getValue(),
     size: 5,
   }),
-  columnHelper.accessor("phoneNumber", {
+  columnHelper.accessor("student.phoneNumber", {
     header: "전화번호",
     cell: info => info.getValue(),
     size: 20,
   }),
-  columnHelper.accessor("email", {
+  columnHelper.accessor("student.email", {
     header: "이메일",
     cell: info => info.getValue(),
     size: 20,
@@ -114,7 +123,8 @@ const columnsFunction = (clubName: string) => [
     header: "비고",
     cell: info => {
       const member = info.row.original;
-      return member.status === MemberStatusEnum.Applied ? (
+      return member.applyStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Pending ? (
         <TableButton
           text={["승인", "반려"]}
           onClick={[

--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { ApiReg008ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
+
 import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import {
@@ -22,26 +24,14 @@ import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 import { patchClubMemberRegistration } from "../members/services/patchClubMemberRegistration";
 
-interface Members {
-  id: number;
-  createdAt: Date;
-  applyStatusEnumId: RegistrationApplicationStudentStatusEnum;
-  student: {
-    id: number;
-    name: string;
-    studentNumber: number;
-    email: string;
-    phoneNumber?: string | undefined;
-  };
-}
 interface MembersTableProps {
-  memberList: Members[];
+  memberList: ApiReg008ResponseOk["applies"];
   clubName: string;
   clubId: number;
 }
 
 const openApproveModal = (
-  member: Members,
+  member: ApiReg008ResponseOk["applies"][0],
   clubName: string,
   clubId: number,
 ) => {
@@ -49,9 +39,8 @@ const openApproveModal = (
     <Modal isOpen={isOpen}>
       <CancellableModalContent
         confirmButtonText="승인"
-        onConfirm={() => {
-          // TODO: 승인 로직 넣기
-          patchClubMemberRegistration(
+        onConfirm={async () => {
+          await patchClubMemberRegistration(
             { applyId: member.id },
             {
               clubId,
@@ -75,13 +64,17 @@ const openApproveModal = (
   ));
 };
 
-const openRejectModal = (member: Members, clubName: string, clubId: number) => {
+const openRejectModal = (
+  member: ApiReg008ResponseOk["applies"][0],
+  clubName: string,
+  clubId: number,
+) => {
   overlay.open(({ isOpen, close }) => (
     <Modal isOpen={isOpen}>
       <CancellableModalContent
         confirmButtonText="반려"
-        onConfirm={() => {
-          patchClubMemberRegistration(
+        onConfirm={async () => {
+          await patchClubMemberRegistration(
             { applyId: member.id },
             {
               clubId,
@@ -105,7 +98,7 @@ const openRejectModal = (member: Members, clubName: string, clubId: number) => {
   ));
 };
 
-const columnHelper = createColumnHelper<Members>();
+const columnHelper = createColumnHelper<ApiReg008ResponseOk["applies"][0]>();
 
 const columnsFunction = (clubName: string, clubId: number) => [
   columnHelper.accessor("applyStatusEnumId", {

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -26,8 +26,14 @@ const MembersManageFrame: React.FC = () => {
   };
 
   // 자신이 대표자인 동아리 clubId에 해당하는 동아리 세부정보 가져오기
-  const { data: clubData } = useGetClubDetail(idData.clubId.toString()) as {
+  const {
+    data: clubData,
+    isLoading: clubIsLoading,
+    isError: clubIsError,
+  } = useGetClubDetail(idData.clubId.toString()) as {
     data: ApiClb002ResponseOK;
+    isLoading: boolean;
+    isError: boolean;
   };
   const {
     data: memberData,
@@ -84,7 +90,10 @@ const MembersManageFrame: React.FC = () => {
 
   return (
     <FoldableSectionTitle title="회원 명단">
-      <AsyncBoundary isLoading={memberIsLoading} isError={memberIsError}>
+      <AsyncBoundary
+        isLoading={memberIsLoading && clubIsLoading}
+        isError={memberIsError && clubIsError}
+      >
         <FlexWrapper direction="column" gap={20}>
           <MoreDetailTitle
             title={isMobileView ? mobileTitle : title}

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -95,17 +95,20 @@ const MembersManageFrame: React.FC = () => {
         isError={memberIsError && clubIsError}
       >
         <FlexWrapper direction="column" gap={20}>
-          <MoreDetailTitle
-            title={isMobileView ? mobileTitle : title}
-            moreDetail="전체 보기"
-            moreDetailPath="/manage-club/members"
-          />
           {memberData && clubData && (
-            <MembersTable
-              memberList={memberData.applies}
-              clubName={clubData.name_kr}
-              clubId={idData.clubId}
-            />
+            <>
+              <MoreDetailTitle
+                title={isMobileView ? mobileTitle : title}
+                moreDetail="전체 보기"
+                moreDetailPath="/manage-club/members"
+              />
+
+              <MembersTable
+                memberList={memberData.applies}
+                clubName={clubData.name_kr}
+                clubId={idData.clubId}
+              />
+            </>
           )}
         </FlexWrapper>
       </AsyncBoundary>

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -139,6 +139,7 @@ const MembersManageFrame: React.FC = () => {
           <MembersTable
             memberList={registerMember}
             clubName={clubDetail.name_kr}
+            clubId={clubId}
           />
         </FlexWrapper>
       </AsyncBoundary>

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -91,7 +91,7 @@ const MembersManageFrame: React.FC = () => {
             moreDetail="전체 보기"
             moreDetailPath="/manage-club/members"
           />
-          {memberData && clubData && idData && (
+          {memberData && clubData && (
             <MembersTable
               memberList={memberData.applies}
               clubName={clubData.name_kr}

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react";
 
-import { ClubTypeEnum } from "@sparcs-clubs/interface/common/enum/club.enum";
+import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
+import { ApiClb015ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb015";
+import { ApiReg008ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
+
 import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import { useTheme } from "styled-components";
@@ -13,99 +16,51 @@ import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/service
 import MembersTable from "@sparcs-clubs/web/features/manage-club/components/MembersTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMemberRegistration";
 
-import { Members } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
-
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
 
-interface MyManageClubData {
-  clubId: number;
-  delegateEnumId: number;
-}
-
-interface MyManageClubDetail {
-  id: number;
-  name_kr: string;
-  name_en: string;
-  type: ClubTypeEnum; // 동아리 유형(정동아리 | 가동아리)
-  isPermanent: boolean; // 상임동아리 여부
-  characteristic: string; // 동아리 소개
-  representative: string; // 동아리 대표
-  advisor?: string; // 동아리 지도교수
-  totalMemberCnt: number;
-  description: string;
-  divisionName: string; // 분과명
-  foundingYear: number;
-  room: string; // 동아리방 위치
-}
-
 const MembersManageFrame: React.FC = () => {
-  const [clubId, setClubId] = useState<number>(0); // 자신이 대표자인 동아리의 clubId
-  const [clubDetail, setClubDetail] = useState<MyManageClubDetail>({
-    // 자신이 대표자인 동아리의 세부 정보
-    id: 0,
-    name_kr: "",
-    name_en: "",
-    type: ClubTypeEnum.Provisional,
-    isPermanent: false,
-    characteristic: "",
-    representative: "",
-    advisor: "",
-    totalMemberCnt: 1,
-    description: "",
-    divisionName: "",
-    foundingYear: 2024,
-    room: "",
-  });
-  const [registerMember, setRegisterMember] = useState<Members[]>([]);
-
   // 자신이 대표자인 동아리 clubId 가져오기
-  const { data: idData, isLoading: idIsLoading } = useGetMyManageClub() as {
-    data: MyManageClubData;
+  const { data: idData } = useGetMyManageClub() as {
+    data: ApiClb015ResponseOk;
     isLoading: boolean;
   };
 
-  useEffect(() => {
-    if (!idIsLoading && idData && Object.keys(idData).length > 0) {
-      setClubId(idData.clubId);
-    }
-  }, [idIsLoading, idData, clubId]);
-
   // 자신이 대표자인 동아리 clubId에 해당하는 동아리 세부정보 가져오기
-  const { data, isLoading } = useGetClubDetail(clubId.toString());
+  const { data: clubData } = useGetClubDetail(idData.clubId.toString()) as {
+    data: ApiClb002ResponseOK;
+  };
   const {
     data: memberData,
     isLoading: memberIsLoading,
     isError: memberIsError,
-  } = useGetMemberRegistration({ clubId });
+  } = useGetMemberRegistration({ clubId: idData.clubId }) as {
+    data: ApiReg008ResponseOk;
+    isLoading: boolean;
+    isError: boolean;
+  };
 
-  useEffect(() => {
-    if (!isLoading && data) {
-      setClubDetail(data);
-    }
-  }, [isLoading, data]);
-
-  useEffect(() => {
-    if (!memberIsLoading && memberData && memberData.applies) {
-      setRegisterMember(memberData.applies);
-    }
-  }, [memberIsLoading, memberData]);
-
-  const appliedCount = registerMember.filter(
-    member =>
-      member.applyStatusEnumId ===
-      RegistrationApplicationStudentStatusEnum.Pending,
-  ).length;
-  const approvedCount = registerMember.filter(
-    member =>
-      member.applyStatusEnumId ===
-      RegistrationApplicationStudentStatusEnum.Approved,
-  ).length;
-  const rejectedCount = registerMember.filter(
-    member =>
-      member.applyStatusEnumId ===
-      RegistrationApplicationStudentStatusEnum.Rejected,
-  ).length;
-  const totalCount = registerMember.length;
+  const appliedCount =
+    memberData &&
+    memberData.applies.filter(
+      member =>
+        member.applyStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Pending,
+    ).length;
+  const approvedCount =
+    memberData &&
+    memberData.applies.filter(
+      member =>
+        member.applyStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Approved,
+    ).length;
+  const rejectedCount =
+    memberData &&
+    memberData.applies.filter(
+      member =>
+        member.applyStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Rejected,
+    ).length;
+  const totalCount = memberData && memberData.applies.length;
 
   const title = `2024년 봄학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
   const mobileTitle = `2024년 봄학기`;
@@ -136,11 +91,13 @@ const MembersManageFrame: React.FC = () => {
             moreDetail="전체 보기"
             moreDetailPath="/manage-club/members"
           />
-          <MembersTable
-            memberList={registerMember}
-            clubName={clubDetail.name_kr}
-            clubId={clubId}
-          />
+          {memberData && clubData && idData && (
+            <MembersTable
+              memberList={memberData.applies}
+              clubName={clubData.name_kr}
+              clubId={idData.clubId}
+            />
+          )}
         </FlexWrapper>
       </AsyncBoundary>
     </FoldableSectionTitle>

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -29,9 +29,14 @@ const RegisterMemberList = () => {
     isLoading: boolean;
   };
 
-  const { data: clubData } = useGetClubDetail(idData.clubId.toString()) as {
+  const {
+    data: clubData,
+    isLoading: clubIsLoading,
+    isError: clubIsError,
+  } = useGetClubDetail(idData.clubId.toString()) as {
     data: ApiClb002ResponseOK;
     isLoading: boolean;
+    isError: boolean;
   };
 
   const {
@@ -48,7 +53,10 @@ const RegisterMemberList = () => {
 
   return (
     <TableWithPagination>
-      <AsyncBoundary isLoading={memberIsLoading} isError={memberIsError}>
+      <AsyncBoundary
+        isLoading={clubIsLoading && memberIsLoading}
+        isError={clubIsError && memberIsError}
+      >
         {clubData && memberData && (
           <MembersTable
             memberList={memberData.applies}

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -103,6 +103,7 @@ const RegisterMemberList = () => {
         <MembersTable
           memberList={registerMember}
           clubName={clubDetail.name_kr}
+          clubId={clubId}
         />
         {totalPage !== 1 && (
           <Pagination

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -49,7 +49,7 @@ const RegisterMemberList = () => {
   return (
     <TableWithPagination>
       <AsyncBoundary isLoading={memberIsLoading} isError={memberIsError}>
-        {idData && clubData && memberData && (
+        {clubData && memberData && (
           <MembersTable
             memberList={memberData.applies}
             clubName={clubData.name_kr}

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
-import { ClubTypeEnum } from "@sparcs-clubs/interface/common/enum/club.enum";
+import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
+import { ApiClb015ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb015";
+import { ApiReg008ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
 
 import styled from "styled-components";
 
@@ -9,7 +11,6 @@ import Pagination from "@sparcs-clubs/web/common/components/Pagination";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
 import MembersTable from "@sparcs-clubs/web/features/manage-club/components/MembersTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMemberRegistration";
-import { Members } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
 
 const TableWithPagination = styled.div`
@@ -20,91 +21,41 @@ const TableWithPagination = styled.div`
   align-self: stretch;
 `;
 
-interface MyManageClubData {
-  clubId: number;
-  delegateEnumId: number;
-}
-
-interface MyManageClubDetail {
-  id: number;
-  name_kr: string;
-  name_en: string;
-  type: ClubTypeEnum; // 동아리 유형(정동아리 | 가동아리)
-  isPermanent: boolean; // 상임동아리 여부
-  characteristic: string; // 동아리 소개
-  representative: string; // 동아리 대표
-  advisor?: string; // 동아리 지도교수
-  totalMemberCnt: number;
-  description: string;
-  divisionName: string; // 분과명
-  foundingYear: number;
-  room: string; // 동아리방 위치
-}
-
 const RegisterMemberList = () => {
   const [page, setPage] = useState<number>(1);
 
-  const [clubId, setClubId] = useState<number>(0); // 자신이 대표자인 동아리의 clubId
-  const [clubDetail, setClubDetail] = useState<MyManageClubDetail>({
-    // 자신이 대표자인 동아리의 세부 정보
-    id: 0,
-    name_kr: "",
-    name_en: "",
-    type: ClubTypeEnum.Provisional,
-    isPermanent: false,
-    characteristic: "",
-    representative: "",
-    advisor: "",
-    totalMemberCnt: 1,
-    description: "",
-    divisionName: "",
-    foundingYear: 2024,
-    room: "",
-  });
-  const [registerMember, setRegisterMember] = useState<Members[]>([]);
-
-  // 자신이 대표자인 동아리 clubId 가져오기
-  const { data: idData, isLoading: idIsLoading } = useGetMyManageClub() as {
-    data: MyManageClubData;
+  const { data: idData } = useGetMyManageClub() as {
+    data: ApiClb015ResponseOk;
     isLoading: boolean;
   };
 
-  useEffect(() => {
-    if (!idIsLoading && idData && Object.keys(idData).length > 0) {
-      setClubId(idData.clubId);
-    }
-  }, [idIsLoading, idData, clubId]);
+  const { data: clubData } = useGetClubDetail(idData.clubId.toString()) as {
+    data: ApiClb002ResponseOK;
+    isLoading: boolean;
+  };
 
-  // 자신이 대표자인 동아리 clubId에 해당하는 동아리 세부정보 가져오기
-  const { data, isLoading } = useGetClubDetail(clubId.toString());
   const {
     data: memberData,
     isLoading: memberIsLoading,
     isError: memberIsError,
-  } = useGetMemberRegistration({ clubId });
+  } = useGetMemberRegistration({ clubId: idData.clubId }) as {
+    data: ApiReg008ResponseOk;
+    isLoading: boolean;
+    isError: boolean;
+  };
 
-  useEffect(() => {
-    if (!isLoading && data) {
-      setClubDetail(data);
-    }
-  }, [isLoading, data]);
-
-  useEffect(() => {
-    if (!memberIsLoading && memberData && memberData.applies) {
-      setRegisterMember(memberData.applies);
-    }
-  }, [memberIsLoading, memberData]);
-
-  const totalPage = Math.ceil(registerMember.length / 10);
+  const totalPage = memberData && Math.ceil(memberData.applies.length / 10);
 
   return (
     <TableWithPagination>
       <AsyncBoundary isLoading={memberIsLoading} isError={memberIsError}>
-        <MembersTable
-          memberList={registerMember}
-          clubName={clubDetail.name_kr}
-          clubId={clubId}
-        />
+        {idData && clubData && memberData && (
+          <MembersTable
+            memberList={memberData.applies}
+            clubName={clubData.name_kr}
+            clubId={idData.clubId}
+          />
+        )}
         {totalPage !== 1 && (
           <Pagination
             totalPage={totalPage}

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 
 import { ClubTypeEnum } from "@sparcs-clubs/interface/common/enum/club.enum";
-import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import styled from "styled-components";
 
@@ -10,6 +9,7 @@ import Pagination from "@sparcs-clubs/web/common/components/Pagination";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
 import MembersTable from "@sparcs-clubs/web/features/manage-club/components/MembersTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMemberRegistration";
+import { Members } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
 
 const TableWithPagination = styled.div`
@@ -41,19 +41,6 @@ interface MyManageClubDetail {
   room: string; // 동아리방 위치
 }
 
-interface MyRegisterMember {
-  id: number;
-  createdAt: Date;
-  applyStatusEnumId: RegistrationApplicationStudentStatusEnum;
-  student: {
-    id: number;
-    name: string;
-    studentNumber: number;
-    email: string;
-    phoneNumber?: string | undefined;
-  };
-}
-
 const RegisterMemberList = () => {
   const [page, setPage] = useState<number>(1);
 
@@ -74,7 +61,7 @@ const RegisterMemberList = () => {
     foundingYear: 2024,
     room: "",
   });
-  const [registerMember, setRegisterMember] = useState<MyRegisterMember[]>([]);
+  const [registerMember, setRegisterMember] = useState<Members[]>([]);
 
   // 자신이 대표자인 동아리 clubId 가져오기
   const { data: idData, isLoading: idIsLoading } = useGetMyManageClub() as {

--- a/packages/web/src/features/manage-club/members/frames/_mock/mockMembers.ts
+++ b/packages/web/src/features/manage-club/members/frames/_mock/mockMembers.ts
@@ -1,4 +1,4 @@
-import { MemberStatusEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 const mockSemester = "봄";
 const mockDeadline = new Date();
@@ -18,51 +18,66 @@ const mockAllSemesters = {
 };
 
 const mockRegisterMembers = {
-  members: [
+  applies: [
     {
       id: 1,
-      status: MemberStatusEnum.Applied,
-      applicationDate: new Date(),
-      studentId: "20200510",
-      applicantName: "이지윤",
-      phoneNumber: "XXX-XXXX-XXXX",
-      email: "nicolelee2001@kaist.ac.kr",
+      applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+      createdAt: new Date("2024-03-04T21:00:00"),
+      student: {
+        id: 1,
+        name: "이지윤",
+        studentNumber: 20200510,
+        email: "nicolelee2001@kaist.ac.kr",
+        phoneNumber: "010-1234-5678",
+      },
     },
     {
       id: 2,
-      status: MemberStatusEnum.Applied,
-      applicationDate: new Date(),
-      studentId: "20200510",
-      applicantName: "박지호",
-      phoneNumber: "XXX-XXXX-XXXX",
-      email: "nicolelee2001@kaist.ac.kr",
+      applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+      createdAt: new Date("2024-03-04T21:00:00"),
+      student: {
+        id: 1,
+        name: "박지호",
+        studentNumber: 20200510,
+        email: "nicolelee2001@kaist.ac.kr",
+        phoneNumber: "010-1234-5678",
+      },
     },
     {
       id: 3,
-      status: MemberStatusEnum.Applied,
-      applicationDate: new Date(),
-      studentId: "20200510",
-      applicantName: "박병찬",
-      phoneNumber: "XXX-XXXX-XXXX",
-      email: "nicolelee2001@kaist.ac.kr",
+      applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+      createdAt: new Date("2024-03-04T21:00:00"),
+      student: {
+        id: 1,
+        name: "박병찬",
+        studentNumber: 20200510,
+        email: "nicolelee2001@kaist.ac.kr",
+        phoneNumber: "010-1234-5678",
+      },
     },
     {
       id: 4,
-      status: MemberStatusEnum.Approved,
-      applicationDate: new Date(),
-      studentId: "20200510",
-      applicantName: "이도라",
-      phoneNumber: "XXX-XXXX-XXXX",
-      email: "nicolelee2001@kaist.ac.kr",
+      applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Approved,
+      createdAt: new Date("2024-03-04T21:00:00"),
+      student: {
+        id: 1,
+        name: "이도라",
+        studentNumber: 20200510,
+        email: "nicolelee2001@kaist.ac.kr",
+        phoneNumber: "010-1234-5678",
+      },
     },
     {
       id: 5,
-      status: MemberStatusEnum.Rejected,
-      applicationDate: new Date(),
-      studentId: "20200510",
-      applicantName: "스팍스",
-      phoneNumber: "XXX-XXXX-XXXX",
-      email: "nicolelee2001@kaist.ac.kr",
+      applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Rejected,
+      createdAt: new Date("2024-03-04T21:00:00"),
+      student: {
+        id: 1,
+        name: "이지윤",
+        studentNumber: 20200510,
+        email: "nicolelee2001@kaist.ac.kr",
+        phoneNumber: "010-1234-5678",
+      },
     },
   ],
 };

--- a/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
@@ -23,6 +23,7 @@ export const useGetMemberRegistration = (requestParam: ApiReg008RequestParam) =>
       );
       switch (status) {
         case 200: {
+          if (data.applies.length === 0) return data;
           return apiReg008.responseBodyMap[200].parse(data);
         }
         default:

--- a/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
@@ -1,0 +1,37 @@
+import apiReg008 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
+import { useQuery } from "@tanstack/react-query";
+
+import { mockRegisterMembers } from "@sparcs-clubs/web/features/manage-club/members/frames/_mock/mockMembers";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+import type {
+  ApiReg008RequestParam,
+  ApiReg008ResponseOk,
+} from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
+
+export const useGetMemberRegistration = (requestParam: ApiReg008RequestParam) =>
+  useQuery<ApiReg008ResponseOk, Error>({
+    queryKey: [apiReg008.url(requestParam.clubId.toString())],
+    queryFn: async (): Promise<ApiReg008ResponseOk> => {
+      const { data, status } = await axiosClientWithAuth.get(
+        apiReg008.url(requestParam.clubId.toString()),
+      );
+      switch (status) {
+        case 200: {
+          return apiReg008.responseBodyMap[200].parse(data);
+        }
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+    enabled: !!requestParam.clubId,
+  });
+
+defineAxiosMock(mock => {
+  mock.onGet(apiReg008.url("1")).reply(() => [200, mockRegisterMembers]);
+});

--- a/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
@@ -1,0 +1,37 @@
+import apiReg007 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg007";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+import type {
+  ApiReg007RequestBody,
+  ApiReg007RequestParam,
+} from "@sparcs-clubs/interface/api/registration/endpoint/apiReg007";
+
+export const patchClubMemberRegistration = async (
+  requestParam: ApiReg007RequestParam,
+  requestBody: ApiReg007RequestBody,
+) => {
+  const { data, status } = await axiosClientWithAuth.patch(
+    apiReg007.url(requestParam.applyId.toString()),
+    requestBody,
+  );
+
+  switch (status) {
+    case 204: {
+      // console.log(data); Mock Mode 테스트 용
+      return apiReg007.responseBodyMap[204].parse(data);
+    }
+    default:
+      throw new UnexpectedAPIResponseError();
+  }
+};
+
+defineAxiosMock(mock => {
+  mock
+    .onPatch(apiReg007.url("1"), { clubId: 1, applyStatusEnumId: 2 })
+    .reply(() => [204, {}]);
+});

--- a/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
@@ -22,7 +22,7 @@ export const patchClubMemberRegistration = async (
 
   switch (status) {
     case 204: {
-      console.log(data);
+      // console.log(data);
       return apiReg007.responseBodyMap[204].parse(data);
     }
     default:

--- a/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
@@ -22,7 +22,7 @@ export const patchClubMemberRegistration = async (
 
   switch (status) {
     case 204: {
-      // console.log(data); Mock Mode 테스트 용
+      console.log(data);
       return apiReg007.responseBodyMap[204].parse(data);
     }
     default:
@@ -32,6 +32,6 @@ export const patchClubMemberRegistration = async (
 
 defineAxiosMock(mock => {
   mock
-    .onPatch(apiReg007.url("1"), { clubId: 1, applyStatusEnumId: 2 })
+    .onPatch(apiReg007.url("1"), { clubId: 1, applyStatusEnumId: 3 })
     .reply(() => [204, {}]);
 });

--- a/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
@@ -12,6 +12,7 @@ import type { ApiClb004ResponseOK } from "@sparcs-clubs/interface/api/club/endpo
 import type { ApiClb010ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb010";
 import type { ApiCms006ResponseOk } from "@sparcs-clubs/interface/api/common-space/endpoint/apiCms006";
 import type { ApiPrt001ResponseOk } from "@sparcs-clubs/interface/api/promotional-printing/endpoint/apiPrt001";
+import type { ApiReg008ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg008";
 import type { ApiRnt003ResponseOK } from "@sparcs-clubs/interface/api/rental/endpoint/apiRnt003";
 
 export interface Activity {
@@ -31,19 +32,6 @@ export interface Funding {
   itemName: string;
   requestedAmount: number;
   approvedAmount: number | null;
-}
-
-export interface Members {
-  id: number;
-  createdAt: Date;
-  applyStatusEnumId: RegistrationApplicationStudentStatusEnum;
-  student: {
-    id: number;
-    name: string;
-    studentNumber: number;
-    email: string;
-    phoneNumber?: string | undefined;
-  };
 }
 
 export enum ActivityStatusEnum {
@@ -135,7 +123,7 @@ const mockClubMembers: ApiClb010ResponseOk = {
   ],
 };
 
-const mockupManageMems: Members[] = [
+const mockupManageMems: ApiReg008ResponseOk["applies"][0][] = [
   {
     id: 1,
     createdAt: new Date("2024-03-04T21:00:00"),

--- a/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
+++ b/packages/web/src/features/manage-club/services/_mock/mockManageClub.ts
@@ -4,6 +4,7 @@ import {
   PromotionalPrintingOrderStatusEnum,
   PromotionalPrintingSizeEnum,
 } from "@sparcs-clubs/interface/common/enum/promotionalPrinting.enum";
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 import { RentalOrderStatusEnum } from "@sparcs-clubs/interface/common/enum/rental.enum";
 
 import type { ApiAcf003ResponseOk } from "@sparcs-clubs/interface/api/activity-certificate/endpoint/apiAcf003";
@@ -34,13 +35,15 @@ export interface Funding {
 
 export interface Members {
   id: number;
-  status: number;
-  applicationDate: Date;
-  studentId: string;
-  applicantName: string;
-  phoneNumber: string;
-  email: string;
-  memo?: string;
+  createdAt: Date;
+  applyStatusEnumId: RegistrationApplicationStudentStatusEnum;
+  student: {
+    id: number;
+    name: string;
+    studentNumber: number;
+    email: string;
+    phoneNumber?: string | undefined;
+  };
 }
 
 export enum ActivityStatusEnum {
@@ -135,49 +138,63 @@ const mockClubMembers: ApiClb010ResponseOk = {
 const mockupManageMems: Members[] = [
   {
     id: 1,
-    status: 1,
-    applicationDate: new Date("2024-03-04T21:00:00"),
-    studentId: "20200510",
-    applicantName: "이지윤",
-    phoneNumber: "XXX-XXXX-XXXX",
-    email: "nicolelee2001@kaist.ac.kr",
+    createdAt: new Date("2024-03-04T21:00:00"),
+    applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+    student: {
+      id: 1,
+      name: "이지윤",
+      studentNumber: 20200510,
+      email: "nicolelee2001@kaist.ac.kr",
+      phoneNumber: "XXX-XXXX-XXXX",
+    },
   },
   {
-    id: 2,
-    status: 1,
-    applicationDate: new Date("2024-03-04T22:00:00"),
-    studentId: "20200511",
-    applicantName: "박지호",
-    phoneNumber: "XXX-XXXX-XXXX",
-    email: "nicolelee2001@kaist.ac.kr",
+    id: 1,
+    createdAt: new Date("2024-03-04T21:00:00"),
+    applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+    student: {
+      id: 1,
+      name: "박지호",
+      studentNumber: 20200510,
+      email: "nicolelee2001@kaist.ac.kr",
+      phoneNumber: "XXX-XXXX-XXXX",
+    },
   },
   {
     id: 3,
-    status: 1,
-    applicationDate: new Date("2024-03-04T23:00:00"),
-    studentId: "20200512",
-    applicantName: "박병찬",
-    phoneNumber: "XXX-XXXX-XXXX",
-    email: "nicolelee2001@kaist.ac.kr",
+    createdAt: new Date("2024-03-04T21:00:00"),
+    applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Pending,
+    student: {
+      id: 1,
+      name: "박병찬",
+      studentNumber: 20200510,
+      email: "nicolelee2001@kaist.ac.kr",
+      phoneNumber: "XXX-XXXX-XXXX",
+    },
   },
   {
     id: 4,
-    status: 2,
-    applicationDate: new Date("2024-03-04T21:30:00"),
-    studentId: "20200513",
-    applicantName: "이도라",
-    phoneNumber: "XXX-XXXX-XXXX",
-    email: "nicolelee2001@kaist.ac.kr",
+    createdAt: new Date("2024-03-04T21:00:00"),
+    applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Approved,
+    student: {
+      id: 1,
+      name: "이도라",
+      studentNumber: 20200510,
+      email: "nicolelee2001@kaist.ac.kr",
+      phoneNumber: "XXX-XXXX-XXXX",
+    },
   },
   {
     id: 5,
-    status: 3,
-    applicationDate: new Date("2024-03-04T20:30:00"),
-    studentId: "20200514",
-    applicantName: "스팍스",
-    phoneNumber: "XXX-XXXX-XXXX",
-    email: "nicolelee2001@kaist.ac.kr",
-    memo: "휴동",
+    createdAt: new Date("2024-03-04T21:00:00"),
+    applyStatusEnumId: RegistrationApplicationStudentStatusEnum.Rejected,
+    student: {
+      id: 1,
+      name: "이지윤",
+      studentNumber: 20200510,
+      email: "nicolelee2001@kaist.ac.kr",
+      phoneNumber: "XXX-XXXX-XXXX",
+    },
   },
 ];
 


### PR DESCRIPTION
# 요약 \*

It closes #759

- [x] REG008 연결 (동아리 신청한 학생 목록 GET)
- [x] REG007 연결 (동아리 신청한 학생을 승인 or 반려)
- [ ] Dev DB로 테스트
(디비에 하마님으로 로그인 했을 때 대표자인 동아리가 없는데, 함부로 건드리면 안 될 것 같아서 디비로는 테스트를 못 해봤습니다)

목 데이터로 테스트할 때 쓰려고 `patchClubMemberRegistration.ts`에 `// console.log(data); Mock Mode 테스트 용` 이런 주석을 달아 놓았습니다. (목 모드로 테스트하실 때는 승인일 때는 enum 2, 반려일 때는 enum 3으로 직접 바꿔야 하는 것 같아요)
콘솔에 `{}` 이렇게 잘 뜨기는 합니다

그리고 변경사항이 /manage-club 페이지의 `MembersManageFrame.tsx`에도 영향을 미쳐서 여기도 API 연결했습니다.

### Update
await를 넣으니까 승인/반려 버튼을 누르면 테스트용 콘솔로그가 뜨고 나서 창이 닫히게 되었어요!
그리고 useEffect, useState 싹 정리했습니다!
피드백 덕분에 많이 배웠습니다 감사합니다ㅎㅎㅎ


# 스크린샷
<img width="1507" alt="스크린샷 2024-08-27 오전 12 12 07" src="https://github.com/user-attachments/assets/84db59a2-cd68-42ec-9577-e7a77e746676">
<img width="1507" alt="스크린샷 2024-08-27 오전 12 12 25" src="https://github.com/user-attachments/assets/442c1272-b569-4d7f-be0b-69ad3fae9df4">

# 이후 Task \*