### PR TITLE
Add optional width prop to Modal 

### DIFF
--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useRef } from "react";
 
+import isPropValid from "@emotion/is-prop-valid";
 import styled from "styled-components";
 
 export interface ModalProps {
@@ -25,7 +26,9 @@ const ModalBackground = styled.div`
   z-index: 100;
 `;
 
-const ModalContainer = styled.div<{ width?: string }>`
+const ModalContainer = styled.div.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ width?: string }>`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 export interface ModalProps {
   isOpen?: boolean;
   onClose?: () => void;
+  width?: string;
 }
 
 const ModalBackground = styled.div`
@@ -24,7 +25,7 @@ const ModalBackground = styled.div`
   z-index: 100;
 `;
 
-const ModalContainer = styled.div`
+const ModalContainer = styled.div<{ width?: string }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -34,9 +35,11 @@ const ModalContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.WHITE};
   border-radius: ${({ theme }) => theme.round.md};
   box-shadow: ${({ theme }) => theme.shadow.md};
+  width: ${({ width }) => width};
 `;
 
 const ModalScrollContainer = styled.div`
+  width: inherit;
   display: inline-flex;
   flex-direction: column;
   overflow: auto;
@@ -59,6 +62,7 @@ const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
   isOpen = false,
   onClose = () => {},
   children = <div />,
+  width = "fit-content",
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -73,7 +77,7 @@ const Modal: FC<React.PropsWithChildren<ModalProps>> = ({
           onClose();
         }}
       >
-        <ModalContainer>
+        <ModalContainer width={width}>
           <ModalScrollContainer>{children}</ModalScrollContainer>
         </ModalContainer>
       </ModalBackground>

--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 export interface ModalProps {
   isOpen?: boolean;
   onClose?: () => void;
-  width?: string;
+  width?: "fit-content" | "full";
 }
 
 const ModalBackground = styled.div`
@@ -28,7 +28,7 @@ const ModalBackground = styled.div`
 
 const ModalContainer = styled.div.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
-})<{ width?: string }>`
+})<{ width: string }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -38,7 +38,20 @@ const ModalContainer = styled.div.withConfig({
   background-color: ${({ theme }) => theme.colors.WHITE};
   border-radius: ${({ theme }) => theme.round.md};
   box-shadow: ${({ theme }) => theme.shadow.md};
-  width: ${({ width }) => width};
+  width: ${({ width, theme }) =>
+    width === "full" ? theme.responsive.CONTENT.xxl : width};
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
+    max-width: ${({ theme }) => theme.responsive.CONTENT.xl};
+    width: ${({ width, theme }) =>
+      width === "full" ? theme.responsive.CONTENT.xl : width};
+  }
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
+    max-width: ${({ theme }) => theme.responsive.CONTENT.lg};
+    width: ${({ width, theme }) =>
+      width === "full" ? theme.responsive.CONTENT.lg : width};
+  }
 `;
 
 const ModalScrollContainer = styled.div`
@@ -49,16 +62,6 @@ const ModalScrollContainer = styled.div`
   overflow-x: hidden;
 
   padding: 32px;
-
-  max-width: ${({ theme }) => theme.responsive.CONTENT.xxl};
-
-  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
-    max-width: ${({ theme }) => theme.responsive.CONTENT.xl};
-  }
-
-  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.md}) {
-    max-width: ${({ theme }) => theme.responsive.CONTENT.lg};
-  }
 `;
 
 const Modal: FC<React.PropsWithChildren<ModalProps>> = ({

--- a/packages/web/src/common/components/Modal/index.tsx
+++ b/packages/web/src/common/components/Modal/index.tsx
@@ -28,7 +28,7 @@ const ModalBackground = styled.div`
 
 const ModalContainer = styled.div.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
-})<{ width: string }>`
+})<{ width: "fit-content" | "full" }>`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/web/src/features/register-club/components/_atomic/CreateActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/_atomic/CreateActivityReportModal.tsx
@@ -88,7 +88,7 @@ const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
   return (
     <FormProvider {...formCtx}>
       <form onSubmit={handleSubmit(submitHandler)}>
-        <Modal isOpen={isOpen}>
+        <Modal isOpen={isOpen} width="full">
           <FlexWrapper direction="column" gap={32}>
             <FormController
               name="name"

--- a/packages/web/src/features/register-club/components/_atomic/PastActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/_atomic/PastActivityReportModal.tsx
@@ -92,7 +92,7 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
   }, [isDeleteSuccess, isDeleteError]);
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} width="100%">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper gap={20} direction="column">
           <FlexWrapper gap={16} direction="column">

--- a/packages/web/src/features/register-club/components/_atomic/PastActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/_atomic/PastActivityReportModal.tsx
@@ -92,7 +92,7 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
   }, [isDeleteSuccess, isDeleteError]);
 
   return (
-    <Modal isOpen={isOpen} width="100%">
+    <Modal isOpen={isOpen} width="full">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper gap={20} direction="column">
           <FlexWrapper gap={16} direction="column">


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1015

`Modal/index.tsx` ModalProps 에 optional한 width prop을 추가했습니다.

모달에 width을 안 주면 `ModalContainer`의 width default 값이 `fit-content`로 되고, width를 주면 그 값으로 적용됩니다.
ModalScrollContainer의 경우 모달컨테이너의 자식 컴포넌트라서, `width: inherit;`을 추가했습니다. (ModalContainer는 너비가 100%인데 스크롤 범위는 작으면 이상해서..)

PastActivityReportModal에는 `width: 100%`로 주었습니다.

# 스크린샷

### width: 100%로 주었을 때
<img width="1512" alt="스크린샷 2024-09-04 오후 4 39 52" src="https://github.com/user-attachments/assets/60953ecd-75db-4e44-97dd-3194a2f00e0a">

### width 안 줬을 때
<img width="1512" alt="스크린샷 2024-09-04 오후 4 40 06" src="https://github.com/user-attachments/assets/05de5a81-8df4-49f7-a903-bec0e531d8f2">

## Update
### width full로 줬을 때 반응형 
<img width="1512" alt="스크린샷 2024-09-04 오후 5 18 51" src="https://github.com/user-attachments/assets/04cb35b2-6a0c-4967-a8f6-4a37607cb47f">
<img width="1024" alt="스크린샷 2024-09-04 오후 5 19 09" src="https://github.com/user-attachments/assets/e13c9adc-b0ff-40ed-87b5-5c1cec231c35">




<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
