### PR TITLE
1032 fix reg activity report

### DIFF
--- a/packages/api/src/feature/activity/activity.module.ts
+++ b/packages/api/src/feature/activity/activity.module.ts
@@ -5,6 +5,8 @@ import { DrizzleModule } from "src/drizzle/drizzle.module";
 import { ClubModule } from "../club/club.module";
 import { FileModule } from "../file/file.module";
 
+import { ClubRegistrationModule } from "../registration/club-registration/club-registration.module";
+
 import ActivityActivityTermController from "./controller/activity.activity-term.controller";
 import ActivityController from "./controller/activity.controller";
 import ActivityActivityTermRepository from "./repository/activity.activity-term.repository";
@@ -14,7 +16,7 @@ import ActivityPublicService from "./service/activity.public.service";
 import ActivityService from "./service/activity.service";
 
 @Module({
-  imports: [ClubModule, DrizzleModule, FileModule],
+  imports: [ClubModule, DrizzleModule, FileModule, ClubRegistrationModule],
   controllers: [ActivityController, ActivityActivityTermController],
   providers: [
     ActivityRepository,

--- a/packages/api/src/feature/activity/controller/activity.controller.ts
+++ b/packages/api/src/feature/activity/controller/activity.controller.ts
@@ -210,6 +210,20 @@ export default class ActivityController {
   }
 
   @Student()
+  @Delete("/student/activities/activity/:activityId/provisional")
+  @UsePipes(new ZodPipe(apiAct004))
+  async deleteStudentActivityProvisional(
+    @GetStudent() user: GetStudent,
+    @Param() param: ApiAct004RequestParam,
+  ): Promise<ApiAct004ResponseOk> {
+    await this.activityService.deleteStudentActivityProvisional(
+      param.activityId,
+      user.studentId,
+    );
+    return {};
+  }
+
+  @Student()
   @Get("/student/activities/available-members")
   @UsePipes(new ZodPipe(apiAct010))
   async getStudentActivitiesAvailableMembers(

--- a/packages/api/src/feature/activity/repository/activity.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity.repository.ts
@@ -379,6 +379,7 @@ export default class ActivityRepository {
     evidenceFileIds: Array<string>;
     participantIds: Array<number>;
     activityDId: number;
+    activityStatusEnumId: ActivityStatusEnum;
   }) {
     const isUpdateSucceed = await this.db.transaction(async tx => {
       const deletedAt = new Date();
@@ -387,12 +388,13 @@ export default class ActivityRepository {
         .update(Activity)
         .set({
           name: param.name,
-          activityStatusEnumId: Number(param.activityTypeEnumId),
+          activityTypeEnumId: Number(param.activityTypeEnumId),
           location: param.location,
           purpose: param.purpose,
           detail: param.detail,
           evidence: param.evidence,
           activityDId: param.activityDId,
+          activityStatusEnumId: Number(param.activityStatusEnumId),
         })
         .where(eq(Activity.id, param.activityId));
       if (activitySetResult.affectedRows !== 1) {

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -424,6 +424,7 @@ export default class ActivityService {
       evidenceFileIds: body.evidenceFiles.map(e => e.fileId),
       participantIds: body.participants.map(e => e.studentId),
       activityDId: activity.activityDId,
+      activityStatusEnumId: ActivityStatusEnum.Applied,
     });
     if (!isUpdateSucceed)
       throw new HttpException(
@@ -459,6 +460,13 @@ export default class ActivityService {
           e.studentId,
       ),
     );
+
+    if (participantIds.length === 0)
+      throw new HttpException(
+        "There is no participant in the activity",
+        HttpStatus.BAD_REQUEST,
+      );
+
     // 파일 유효한지 검사합니다.
     const evidenceFiles = await Promise.all(
       body.evidenceFiles.map(key =>
@@ -491,7 +499,6 @@ export default class ActivityService {
     await this.checkIsStudentDelegate({ studentId, clubId: activity.clubId });
     // 오늘이 활동보고서 작성기간이거나, 예외적 작성기간인지 확인하지 않습니다.
     // 해당 활동이 지난 활동기간에 대한 활동인지 확인하지 않습니다.
-    const lastActivityD = await this.getLastActivityD();
 
     // 제출한 활동 기간들이 지난 활동기간 이내인지 확인하지 않습니다.
 
@@ -501,32 +508,29 @@ export default class ActivityService {
         this.filePublicService.getFileInfoById(key.fileId),
       ),
     );
-    // 참여 학생이 지난 활동기간 동아리의 소속원이였는지 확인합니다.
-    const activityDStartSemester =
-      await this.clubPublicService.dateToSemesterId(lastActivityD.startTerm);
-    const activityDEndSemester = await this.clubPublicService.dateToSemesterId(
-      lastActivityD.endTerm,
+    // 참여 학생이 지난 활동기간 동아리의 소속원이였는지 확인하지 않습니다.
+    const participantIds = await Promise.all(
+      body.participants.map(
+        async e =>
+          // if (
+          //   !(await this.clubPublicService.isStudentBelongsTo(
+          //     e.studentId,
+          //     body.clubId,
+          //   ))
+          // )
+          //   throw new HttpException(
+          //     "Some student is not belonged to the club",
+          //     HttpStatus.BAD_REQUEST,
+          // );
+          e.studentId,
+      ),
     );
-    const members = (
-      await this.clubPublicService.getMemberFromSemester({
-        semesterId: activityDStartSemester,
-        clubId: activity.clubId,
-      })
-    ).concat(
-      await this.clubPublicService.getMemberFromSemester({
-        semesterId: activityDEndSemester,
-        clubId: activity.clubId,
-      }),
-    );
-    body.participants.forEach(participant => {
-      if (
-        members.find(e => e.studentId === participant.studentId) === undefined
-      )
-        throw new HttpException(
-          "Some participant is not belonged to the club in the activity duration",
-          HttpStatus.BAD_REQUEST,
-        );
-    });
+
+    if (participantIds.length === 0)
+      throw new HttpException(
+        "There is no participant in the activity",
+        HttpStatus.BAD_REQUEST,
+      );
 
     // PUT 처리를 시작합니다.
     const isUpdateSucceed = this.activityRepository.updateActivity({
@@ -541,6 +545,7 @@ export default class ActivityService {
       evidenceFileIds: evidenceFiles.map(e => e.id),
       participantIds: body.participants.map(e => e.studentId),
       activityDId: activity.activityDId,
+      activityStatusEnumId: ActivityStatusEnum.Applied,
     });
     if (!isUpdateSucceed)
       throw new HttpException(
@@ -600,6 +605,22 @@ export default class ActivityService {
       activityTypeEnumId: activity.activityTypeEnumId,
       durations: activity.durations,
     }));
+  }
+
+  async deleteStudentActivityProvisional(
+    activityId: number,
+    studentId: number,
+  ) {
+    const activity = await this.getActivity({ activityId });
+    // 학생이 동아리 대표자 또는 대의원이 맞는지 확인합니다.
+    await this.checkIsStudentDelegate({ studentId, clubId: activity.clubId });
+
+    if (!(await this.activityRepository.deleteActivity({ activityId }))) {
+      throw new HttpException(
+        "Something got wrong...",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 
   /**

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -13,6 +13,7 @@ import {
 import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
 import ClubPublicService from "@sparcs-clubs/api/feature/club/service/club.public.service";
 import FilePublicService from "@sparcs-clubs/api/feature/file/service/file.public.service";
+import { ClubRegistrationPublicService } from "@sparcs-clubs/api/feature/registration/club-registration/service/club-registration.public.service";
 
 import ActivityActivityTermRepository from "../repository/activity.activity-term.repository";
 import ActivityRepository from "../repository/activity.repository";
@@ -57,6 +58,7 @@ export default class ActivityService {
     private activityActivityTermRepository: ActivityActivityTermRepository,
     private clubPublicService: ClubPublicService,
     private filePublicService: FilePublicService,
+    private clubRegistrationPublicService: ClubRegistrationPublicService,
   ) {}
 
   /**
@@ -487,6 +489,10 @@ export default class ActivityService {
         "Failed to insert",
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
+
+    this.clubRegistrationPublicService.resetClubRegistrationStatusEnum(
+      body.clubId,
+    );
   }
 
   async putStudentActivityProvisional(
@@ -552,6 +558,10 @@ export default class ActivityService {
         "Failed to update",
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
+
+    this.clubRegistrationPublicService.resetClubRegistrationStatusEnum(
+      activity.clubId,
+    );
   }
 
   /**

--- a/packages/api/src/feature/registration/club-registration/repository/club-registration.repository.ts
+++ b/packages/api/src/feature/registration/club-registration/repository/club-registration.repository.ts
@@ -236,7 +236,7 @@ export class ClubRegistrationRepository {
         .where(
           and(
             eq(Registration.id, applyId),
-            body.clubId === undefined
+            body.clubId === undefined || body.clubId === null
               ? undefined
               : eq(Registration.clubId, body.clubId),
             eq(
@@ -323,6 +323,7 @@ export class ClubRegistrationRepository {
           registrationClubRuleFileId: body.clubRuleFileId,
           registrationExternalInstructionFileId: body.externalInstructionFileId,
           registrationApplicationStatusEnumId: RegistrationStatusEnum.Pending,
+          professorApprovedAt: null,
         })
         .where(
           and(
@@ -1029,5 +1030,19 @@ export class ClubRegistrationRepository {
       );
 
     return { ...result, comments };
+  }
+
+  async resetClubRegistrationStatusEnum(clubId: number) {
+    await this.db.transaction(async tx => {
+      await tx
+        .update(Registration)
+        .set({
+          registrationApplicationStatusEnumId: RegistrationStatusEnum.Pending,
+          professorApprovedAt: null,
+        })
+        .where(
+          and(eq(Registration.clubId, clubId), isNull(Registration.deletedAt)),
+        );
+    });
   }
 }

--- a/packages/api/src/feature/registration/club-registration/service/club-registration.public.service.ts
+++ b/packages/api/src/feature/registration/club-registration/service/club-registration.public.service.ts
@@ -30,4 +30,15 @@ export class ClubRegistrationPublicService {
         return arr[0];
       });
   }
+
+  /**
+   * @param clubId
+   * @returns void
+   * @description clubId에 해당하는 동아리의 신청 상태를 초기화합니다.
+   */
+  async resetClubRegistrationStatusEnum(clubId: number) {
+    await this.clubRegistrationRepository.resetClubRegistrationStatusEnum(
+      clubId,
+    );
+  }
 }

--- a/packages/interface/src/api/registration/endpoint/apiReg001.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg001.ts
@@ -24,7 +24,7 @@ const requestQuery = z.object({});
 
 const requestBody = z
   .object({
-    clubId: z.coerce.number().int().min(1).optional(),
+    clubId: z.coerce.number().int().min(1).nullable().optional(),
     registrationTypeEnumId: z.nativeEnum(RegistrationTypeEnum),
     clubNameKr: zClubName,
     clubNameEn: zClubName,
@@ -52,6 +52,7 @@ const requestBody = z
           }),
         professorEnumId: z.nativeEnum(ProfessorEnum),
       })
+      .nullable()
       .optional(),
     divisionConsistency: z.coerce.string(),
     foundationPurpose: z.coerce.string(),

--- a/packages/interface/src/api/registration/endpoint/apiReg009.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg009.ts
@@ -26,7 +26,7 @@ const requestQuery = z.object({});
 const requestBody = z
   .object({
     registrationTypeEnumId: z.nativeEnum(RegistrationTypeEnum),
-    clubId: z.coerce.number().int().min(1).optional(),
+    clubId: z.coerce.number().int().nullable().optional(),
     clubNameKr: zClubName,
     clubNameEn: zClubName,
     phoneNumber: zKrPhoneNumber,
@@ -45,6 +45,7 @@ const requestBody = z
           }),
         professorEnumId: z.nativeEnum(ProfessorEnum),
       })
+      .nullable()
       .optional(),
     divisionConsistency: z.coerce.string(),
     foundationPurpose: z.coerce.string(),

--- a/packages/interface/src/api/registration/utils/registrationTypeEnumChecker.ts
+++ b/packages/interface/src/api/registration/utils/registrationTypeEnumChecker.ts
@@ -5,28 +5,28 @@ import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/regist
  */
 const registrationTypeEnumChecker = (param: {
   registrationTypeEnumId: RegistrationTypeEnum;
-  clubId?: number;
+  clubId?: number | null;
   activityPlanFileId?: string;
   clubRuleFileId?: string;
 }): boolean => {
   switch (param.registrationTypeEnumId) {
     case RegistrationTypeEnum.NewProvisional:
-      if (param.clubId !== undefined) return false;
-      if (param.activityPlanFileId === undefined) return false;
-      if (param.clubRuleFileId !== undefined) return false;
+      if (param.clubId !== null) return false; // clubId는 null이어야 한다
+      if (!param.activityPlanFileId) return false; // activityPlanFileId는 반드시 있어야 한다
+      if (param.clubRuleFileId !== undefined) return false; // clubRuleFileId는 없어야 한다
       break;
     case RegistrationTypeEnum.ReProvisional:
-      if (param.clubId === undefined) return false;
+      if (param.clubId === undefined || param.clubId === null) return false;
       if (param.activityPlanFileId === undefined) return false;
       if (param.clubRuleFileId !== undefined) return false;
       break;
     case RegistrationTypeEnum.Promotional:
-      if (param.clubId === undefined) return false;
+      if (param.clubId === undefined || param.clubId === null) return false;
       if (param.activityPlanFileId === undefined) return false;
       if (param.clubRuleFileId === undefined) return false;
       break;
     case RegistrationTypeEnum.Renewal:
-      if (param.clubId === undefined) return false;
+      if (param.clubId === undefined || param.clubId === null) return false;
       if (param.activityPlanFileId !== undefined) return false;
       if (param.clubRuleFileId !== undefined) return false;
       break;


### PR DESCRIPTION
# 요약 \*

 활보 생성 수정 시 인원 비어있으면 안됨
 활보 삭제 기간 아님 → 별도 삭제 api 만들기
 활보 수정시 활동인원 기간 체크 안함
 활보 수정하면 집행부 승인 status and 지도교수 승인 status reset 되어야 함 (아직 안되는듯?)
 등록 수정 시 지도교수 승인상태 초기화
 가등록(신규)는 clubId가 존재하지 않음 (맞죠?). 생성 시에는 문제가 없는데 수정 시에 다음과 같은 에러가 떠욧

It closes #issue_number

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
