### PR TITLE
Connect backend for /executive/register-member/[id]

### DIFF
--- a/packages/web/src/features/executive/register-member/[id]/_mock/mockClubMemberRegister.tsx
+++ b/packages/web/src/features/executive/register-member/[id]/_mock/mockClubMemberRegister.tsx
@@ -1,9 +1,9 @@
-import { MemberStatusEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 const registerState = [
-  MemberStatusEnum.Approved,
-  MemberStatusEnum.Applied,
-  MemberStatusEnum.Rejected,
+  RegistrationApplicationStudentStatusEnum.Approved,
+  RegistrationApplicationStudentStatusEnum.Pending,
+  RegistrationApplicationStudentStatusEnum.Rejected,
 ];
 
 const studentIDList = [
@@ -14,19 +14,33 @@ const studentIDList = [
   20245642, // 2
 ];
 
-const applies = Array.from({ length: 100 }, (_, index) => ({
-  registrationStatus: registerState[index % registerState.length],
-  id: index + 1,
-  studentID: studentIDList[index % studentIDList.length],
-  studentName: "임가은",
-  studentEmail: "casio@sparcs.org",
-  studentPhoneNumber: "010-xxxx-xxxx",
+const regularMemberState = [true, false];
+
+const items = Array.from({ length: 100 }, (_, index) => ({
+  memberRegistrationId: index + 1,
+  RegistrationApplicationStudentStatusEnumId:
+    registerState[index % registerState.length],
+  isRegularMemberRegistration:
+    regularMemberState[index % regularMemberState.length],
+  student: {
+    id: 1,
+    studentNumber: studentIDList[index % studentIDList.length],
+    name: "임가은",
+    phoneNumber: "010-1234-5678",
+    email: "casio@sparcs.org",
+  },
 }));
 
-const mockupClubMemberRegister = {
-  total: applies.length,
-  applies,
-  offset: 0,
+export const mockupClubMemberRegister = {
+  totalRegistrations: 100,
+  totalWaitings: 20,
+  totalApprovals: 70,
+  totalRejections: 10,
+  regularMemberRegistrations: 50,
+  regularMemberWaitings: 10,
+  regularMemberApprovals: 35,
+  regularMemberRejections: 5,
+  items,
+  total: items.length,
+  offset: 1,
 };
-
-export default mockupClubMemberRegister;

--- a/packages/web/src/features/executive/register-member/[id]/services/calcRegisterInfo.tsx
+++ b/packages/web/src/features/executive/register-member/[id]/services/calcRegisterInfo.tsx
@@ -1,6 +1,6 @@
-import { MemberStatusEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
-import mockupClubMemberRegister from "../_mock/mockClubMemberRegister";
+import { mockupClubMemberRegister } from "@sparcs-clubs/web/features/executive/register-member/[id]/_mock/mockClubMemberRegister";
 
 const calcStudentStatus = (studentID: number) => {
   if (
@@ -16,21 +16,31 @@ const calcStudentStatus = (studentID: number) => {
 const calcRegisterInfo = (data: typeof mockupClubMemberRegister) => {
   // Map 생성 및 초기화
   const result: Map<
-    MemberStatusEnum | string,
+    RegistrationApplicationStudentStatusEnum | string,
     { Regular: number; NonRegular: number; Total: number }
   > = new Map<
-    MemberStatusEnum | string,
+    RegistrationApplicationStudentStatusEnum | string,
     { Regular: number; NonRegular: number; Total: number }
   >([
-    [MemberStatusEnum.Applied, { Regular: 0, NonRegular: 0, Total: 0 }],
-    [MemberStatusEnum.Approved, { Regular: 0, NonRegular: 0, Total: 0 }],
-    [MemberStatusEnum.Rejected, { Regular: 0, NonRegular: 0, Total: 0 }],
+    [
+      RegistrationApplicationStudentStatusEnum.Pending,
+      { Regular: 0, NonRegular: 0, Total: 0 },
+    ],
+    [
+      RegistrationApplicationStudentStatusEnum.Approved,
+      { Regular: 0, NonRegular: 0, Total: 0 },
+    ],
+    [
+      RegistrationApplicationStudentStatusEnum.Rejected,
+      { Regular: 0, NonRegular: 0, Total: 0 },
+    ],
     ["Total", { Regular: 0, NonRegular: 0, Total: 0 }],
   ]);
 
-  data.applies.forEach(apply => {
-    const status = apply.registrationStatus as MemberStatusEnum;
-    const studentStatus = calcStudentStatus(apply.studentID);
+  data.items.forEach(item => {
+    const status =
+      item.RegistrationApplicationStudentStatusEnumId as RegistrationApplicationStudentStatusEnum;
+    const studentStatus = calcStudentStatus(item.student.studentNumber);
 
     if (result.has(status)) {
       const statusInfo = result.get(status)!;

--- a/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
+++ b/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
@@ -1,0 +1,43 @@
+import apiReg020 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg020";
+import { useQuery } from "@tanstack/react-query";
+
+import { mockupClubMemberRegister } from "@sparcs-clubs/web/features/executive/register-member/[id]/_mock/mockClubMemberRegister";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+import type {
+  ApiReg020RequestQuery,
+  ApiReg020ResponseOk,
+} from "@sparcs-clubs/interface/api/registration/endpoint/apiReg020";
+
+export const useGetRegisterMemberDetail = (
+  requestQuery: ApiReg020RequestQuery,
+) =>
+  useQuery<ApiReg020ResponseOk, Error>({
+    queryKey: [apiReg020.url(), requestQuery],
+    queryFn: async (): Promise<ApiReg020ResponseOk> => {
+      const { data, status } = await axiosClientWithAuth.get(apiReg020.url(), {
+        params: requestQuery,
+      });
+
+      switch (status) {
+        case 200: {
+          // console.log(data);
+          return apiReg020.responseBodyMap[200].parse(data);
+        }
+
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+defineAxiosMock(mock => {
+  mock
+    .onGet(apiReg020.url(), { clubId: 1, pageOffset: 1, itemCount: 10 })
+    .reply(() => [200, mockupClubMemberRegister]);
+});

--- a/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
+++ b/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
@@ -26,8 +26,8 @@ export const useGetRegisterMemberDetail = (
 
       switch (status) {
         case 200: {
-          // console.log(data);
           return apiReg020.responseBodyMap[200].parse(data);
+          // return data;
         }
 
         default:

--- a/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
+++ b/packages/web/src/features/executive/register-member/[id]/services/getRegisterMemberDetail.tsx
@@ -26,8 +26,8 @@ export const useGetRegisterMemberDetail = (
 
       switch (status) {
         case 200: {
-          return apiReg020.responseBodyMap[200].parse(data);
-          // return data;
+          // return apiReg020.responseBodyMap[200].parse(data); TODO: check this again
+          return data;
         }
 
         default:

--- a/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 
+import { ApiReg020ResponseOk } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg020";
+
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -13,13 +17,11 @@ import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import { MemTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { MemberStatusEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
+
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import mockupClubMemberRegister from "../[id]/_mock/mockClubMemberRegister";
-
 interface RegisterInfoTableProps {
-  memberRegisterInfoList: typeof mockupClubMemberRegister;
+  memberRegisterInfoList: ApiReg020ResponseOk;
 }
 
 const ToggleWrapper = styled.div`
@@ -29,11 +31,10 @@ const ToggleWrapper = styled.div`
   direction: row;
   display: flex;
 `;
-const columnHelper =
-  createColumnHelper<(typeof mockupClubMemberRegister)["applies"][number]>();
+const columnHelper = createColumnHelper<ApiReg020ResponseOk["items"][number]>();
 
 const columns = [
-  columnHelper.accessor("registrationStatus", {
+  columnHelper.accessor("RegistrationApplicationStudentStatusEnumId", {
     id: "registrationStatus",
     header: "상태",
     cell: info => {
@@ -42,50 +43,48 @@ const columns = [
     },
     size: 90,
   }),
-  columnHelper.accessor("studentID", {
-    id: "studentID",
+  columnHelper.accessor("isRegularMemberRegistration", {
+    id: "isRegularMemberRegistration",
     header: "구분",
     cell: info => {
-      if (
-        parseInt(info.getValue().toString().slice(-4)) < 2000 ||
-        (parseInt(info.getValue().toString().slice(-4)) < 7000 &&
-          parseInt(info.getValue().toString().slice(-4)) > 6000)
-      ) {
-        return <Tag color="BLUE">정회원</Tag>;
-      }
+      if (info.getValue()) return <Tag color="BLUE">정회원</Tag>;
+
       return <Tag color="GRAY">준회원</Tag>;
     },
     size: 220,
   }),
-  columnHelper.accessor("studentID", {
-    id: "studentID",
+  columnHelper.accessor("student.studentNumber", {
+    id: "student.studentNumber",
     header: "학번",
     cell: info => info.getValue(),
     size: 100,
   }),
-  columnHelper.accessor("studentName", {
-    id: "studentName",
+  columnHelper.accessor("student.name", {
+    id: "student.name",
     header: "신청자",
     cell: info => info.getValue(),
     size: 120,
   }),
-  columnHelper.accessor("studentPhoneNumber", {
-    id: "studentPhoneNumber",
+  columnHelper.accessor("student.phoneNumber", {
+    id: "student.phoneNumber",
     header: "전화번호",
     cell: info => info.getValue(),
     size: 160,
   }),
-  columnHelper.accessor("studentEmail", {
-    id: "studentEmail",
+  columnHelper.accessor("student.email", {
+    id: "student.email",
     header: "이메일",
     cell: info => info.getValue(),
     size: 240,
   }),
-  columnHelper.accessor("registrationStatus", {
-    id: "registrationStatus",
+  columnHelper.accessor("RegistrationApplicationStudentStatusEnumId", {
+    id: "RegistrationApplicationStudentStatusEnumId",
     header: "이메일",
     cell: info => {
-      if (info.row.original.registrationStatus === MemberStatusEnum.Approved) {
+      if (
+        info.row.original.RegistrationApplicationStudentStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Approved
+      ) {
         return (
           <ToggleWrapper>
             <TextButton text="승인" disabled />
@@ -94,7 +93,10 @@ const columns = [
           </ToggleWrapper>
         );
       }
-      if (info.row.original.registrationStatus === MemberStatusEnum.Applied) {
+      if (
+        info.row.original.RegistrationApplicationStudentStatusEnumId ===
+        RegistrationApplicationStudentStatusEnum.Pending
+      ) {
         return (
           <ToggleWrapper>
             <TextButton text="승인" />
@@ -120,7 +122,7 @@ const RegisterInfoTable: React.FC<RegisterInfoTableProps> = ({
 }) => {
   const table = useReactTable({
     columns,
-    data: mrInfoList.applies,
+    data: mrInfoList.items,
     getCoreRowModel: getCoreRowModel(),
     enableSorting: false,
   });

--- a/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
@@ -79,7 +79,7 @@ const columns = [
   }),
   columnHelper.accessor("RegistrationApplicationStudentStatusEnumId", {
     id: "RegistrationApplicationStudentStatusEnumId",
-    header: "이메일",
+    header: "비고",
     cell: info => {
       if (
         info.row.original.RegistrationApplicationStudentStatusEnumId ===

--- a/packages/web/src/features/executive/register-member/components/StatusInfoFrame.tsx
+++ b/packages/web/src/features/executive/register-member/components/StatusInfoFrame.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 
+import { RegistrationApplicationStudentStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
 import styled from "styled-components";
 
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import { MemTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { MemberStatusEnum } from "@sparcs-clubs/web/features/manage-club/services/_mock/mockManageClub";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface StatusInfoFrameProps {
   statusInfo: { Regular: number; NonRegular: number; Total: number };
-  status: MemberStatusEnum;
+  status: RegistrationApplicationStudentStatusEnum;
 }
 
 const StatusWrapper = styled.div`

--- a/packages/web/src/features/executive/register-member/components/TotalInfoFrame.tsx
+++ b/packages/web/src/features/executive/register-member/components/TotalInfoFrame.tsx
@@ -13,7 +13,7 @@ const StatusWrapper = styled.div`
   padding-left: 28px;
 `;
 
-const TotalCountContationer = styled.div`
+const TotalCountContainer = styled.div`
   width: 120px;
   height: 24px;
   justify-content: space-between;
@@ -22,7 +22,7 @@ const TotalCountContationer = styled.div`
   flex-direction: row;
 `;
 
-const StatusCountContationer = styled.div`
+const StatusCountContainer = styled.div`
   width: 160px;
   height: 24px;
   justify-content: space-between;
@@ -31,7 +31,7 @@ const StatusCountContationer = styled.div`
   flex-direction: row;
 `;
 
-const StatusContentsContationer = styled.div`
+const StatusContentsContainer = styled.div`
   width: 60px;
   height: 24px;
   justify-content: center;
@@ -42,7 +42,7 @@ const StatusContentsContationer = styled.div`
   line-height: 20px;
 `;
 
-const TotalContentsContationer = styled.div`
+const TotalContentsContainer = styled.div`
   width: 40px;
   height: 24px;
   justify-content: center;
@@ -53,7 +53,7 @@ const TotalContentsContationer = styled.div`
   line-height: 20px;
 `;
 
-const TotalTitleContatiner = styled.div`
+const TotalTitleContainer = styled.div`
   width: fit-content;
   padding: 4px 12px;
   height: 24px;
@@ -68,24 +68,22 @@ const TotalTitleContatiner = styled.div`
 const TotalInfoFrame: React.FC<StatusInfoFrameProps> = ({ statusInfo }) => (
   <StatusWrapper>
     <FlexWrapper gap={40} direction="row">
-      <TotalCountContationer>
-        <TotalTitleContatiner>전체</TotalTitleContatiner>
-        <TotalContentsContationer>
-          {statusInfo.Total}명
-        </TotalContentsContationer>
-      </TotalCountContationer>
-      <StatusCountContationer>
+      <TotalCountContainer>
+        <TotalTitleContainer>전체</TotalTitleContainer>
+        <TotalContentsContainer>{statusInfo.Total}명</TotalContentsContainer>
+      </TotalCountContainer>
+      <StatusCountContainer>
         <Tag color="BLUE">정회원</Tag>
-        <StatusContentsContationer>
+        <StatusContentsContainer>
           {statusInfo.Regular}명
-        </StatusContentsContationer>
-      </StatusCountContationer>
-      <StatusCountContationer>
+        </StatusContentsContainer>
+      </StatusCountContainer>
+      <StatusCountContainer>
         <Tag color="GRAY">준회원</Tag>
-        <StatusContentsContationer>
+        <StatusContentsContainer>
           {statusInfo.NonRegular}명
-        </StatusContentsContationer>
-      </StatusCountContationer>
+        </StatusContentsContainer>
+      </StatusCountContainer>
     </FlexWrapper>
   </StatusWrapper>
 );

--- a/packages/web/src/features/executive/register-member/services/getMemberRegistration.ts
+++ b/packages/web/src/features/executive/register-member/services/getMemberRegistration.ts
@@ -18,7 +18,9 @@ export const useGetMemberRegistration = (requestQuery: ApiReg019RequestQuery) =>
   useQuery<ApiReg019ResponseOk, Error>({
     queryKey: [apiReg019.url(), requestQuery],
     queryFn: async (): Promise<ApiReg019ResponseOk> => {
-      const { data, status } = await axiosClientWithAuth.get(apiReg019.url());
+      const { data, status } = await axiosClientWithAuth.get(apiReg019.url(), {
+        params: requestQuery,
+      });
       switch (status) {
         case 200:
           return apiReg019.responseBodyMap[200].parse(data);


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #822

- [x] REG020 연결 완료
- [x] REG019 dev db 테스트
- [x] REG020 dev db 테스트

## 리뷰 요청 사항
dev db에 연결해서 REG020 테스트를 해보니 에러가 뜨는데, 그 원인으로는
db에 있는 이메일 끝에 캐리지 리턴(\r)이 있어서 parse를 못 통과하는 것으로 추정됩니다.. (예: `hippo0419@kaist.ac.kr\r`)
(apiReg020.ts에서 `email: z.string().trim().email(),` 로 수정해서 확인해보니 에러가 안 뜨는 걸로 보아 맞는 것 같아요)

이런 일이 있을 걸 대비해 
- .trim() 옵션을 추가하거나 
- 서비스 코드에서 parse를 빼고 그냥 `return data;` 하거나
할 수 있을 것 같은데 어떻게 생각하시는지 피드백 해주시면 감사하겠습니다

**스샷도 저 두 옵션 중 하나를 임의로 추가했을 때 찍은 거라 지금 푸시된 코드에는 반영이 안 되어 있어서,**
어떻게 할 지 피드백 받은 후에 반영하겠습니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
#### AgreementModal이 안 꺼지는 오류 때문에 일단 이렇게라도 확인했습니다..

<img width="1185" alt="스크린샷 2024-09-09 오후 3 31 18" src="https://github.com/user-attachments/assets/c9d1d771-a5f2-4c58-9f38-c8f230dc18b3">
<img width="1191" alt="스크린샷 2024-09-09 오후 3 30 57" src="https://github.com/user-attachments/assets/0a1c5a9f-13af-498f-9cd8-edc26af04fc2">

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
