### PR TITLE
fix: /credits layout fix

### DIFF
--- a/packages/web/src/app/credits/page.tsx
+++ b/packages/web/src/app/credits/page.tsx
@@ -21,7 +21,7 @@ const CreditCardsFlexWrapper = styled(FlexWrapper)`
 `;
 
 const ResponsiveMemberCardSectionWrapper = styled.div`
-  margin-left: 24px;
+  margin-left: 0px;
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
     margin-left: 16px;
@@ -40,7 +40,7 @@ const Credits: React.FC = () => (
           <>
             <SectionTitle size="lg">{credit.semester}</SectionTitle>
             <ResponsiveMemberCardSectionWrapper>
-              <MemberCardSection semesterCredit={credit} leftMargin={0} />
+              <MemberCardSection semesterCredit={credit} leftMargin={24} />
             </ResponsiveMemberCardSectionWrapper>
           </>
         ) : (

--- a/packages/web/src/app/credits/page.tsx
+++ b/packages/web/src/app/credits/page.tsx
@@ -21,7 +21,6 @@ const CreditCardsFlexWrapper = styled(FlexWrapper)`
 `;
 
 const ResponsiveMemberCardSectionWrapper = styled.div`
-  margin-left: 0px;
 
   @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
     margin-left: 16px;

--- a/packages/web/src/features/credits/credits.ts
+++ b/packages/web/src/features/credits/credits.ts
@@ -21,6 +21,18 @@ export interface SemesterCredit {
 
 const credits: SemesterCredit[] = [
   {
+    semester: "2024년 가을",
+    members: [
+      {
+        nickname: "shiro",
+        name: "이재환",
+        role: "인턴",
+        roleType: RoleType.intern,
+        comment: "ㅇㅅㅇ",
+      },
+    ],
+  },
+  {
     semester: "2024년 여름",
     members: [
       {


### PR DESCRIPTION
# 요약 \*

/credits 페이지에 2024 가을 인원 추가, 기존 레이아웃 버그 픽스(최근학기 인원 외에는 카드들이 우측으로 24px 밀려있었음)

It closes #1056

# 스크린샷

![image](https://github.com/user-attachments/assets/8ddbec38-b5f6-4ab3-b175-1aa2cad6173a)
before

![image](https://github.com/user-attachments/assets/4a9d7e85-ca66-43ca-a288-4b8df49316a7)
after

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 타 참여인원 명단에 추가
