### PR TITLE
feat: club available check logic in reg-005

### DIFF
--- a/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
+++ b/packages/api/src/feature/registration/member-registration/service/member-registration.service.ts
@@ -66,6 +66,27 @@ export class MemberRegistrationService {
         "Not a member registration available",
         HttpStatus.BAD_REQUEST,
       );
+
+    // 해당 동아리가 존재하는지 확인
+    const club = await this.clubPublicService.getClubByClubId({ clubId });
+    if (club.length === 0) {
+      throw new HttpException("The club does not exist.", HttpStatus.NOT_FOUND);
+    }
+
+    // 해당 동아리가 이번 학기에 활동중이어서 신청이 가능한 지 확인
+    const clubExistedSemesters =
+      await this.clubPublicService.getClubsExistedSemesters({ clubId });
+    const isClubOperatingThisSemester = clubExistedSemesters.some(
+      semester => semester.id === semesterId,
+    );
+
+    if (!isClubOperatingThisSemester) {
+      throw new HttpException(
+        "The club is not operating in the current semester.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     // 이미 해당 동아리에 해당 학생의 반려되지 않은 신청이 존재하는지 확인하기
     const isAlreadyApplied =
       await this.memberRegistrationRepository.getMemberClubRegistrationExceptRejected(


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->
REG-005에서 신청을 처리할 때, 해당 동아리가 이번 학기에 활동 중인지를 검사하는 로직이 추가되었습니다.
추가로 동아리가 활동중인지 검사하려면 일단 그 동아리가 존재하는 지 부터 확인해야할 것 같아서 그러한 로직도 추가했습니다.

It closes #1055 

# 스크린샷
<img width="796" alt="Screenshot 2024-09-15 at 19 36 22" src="https://github.com/user-attachments/assets/a5a7131b-1d1a-4b8e-a54b-6bd7c55dc176">

이번학기에 활동중이지 않은 동아리에 요청을 넣으면 이런 에러를 반환 합니다.
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
