### PR TITLE
member registration display membersmanageframe when member registration period

### DIFF
--- a/packages/web/src/constants/manageClubMembers.ts
+++ b/packages/web/src/constants/manageClubMembers.ts
@@ -1,8 +1,6 @@
-import { getDate, getHours, getMinutes, getMonth, getYear } from "date-fns";
+import { formatDateTime } from "../utils/Date/formatDate";
 
 const newMemberListSectionInfoText = (semester: string, deadline: Date) =>
-  `현재는 ${semester}학기 동아리 신청 기간입니다 
-(신청 마감 : ${getYear(deadline)}년 ${getMonth(deadline)}월 ${getDate(deadline)}일 
-${getHours(deadline)}:${getMinutes(deadline)})`;
+  `현재는 ${semester}학기 동아리 신청 기간입니다 (신청 마감 : ${formatDateTime(deadline)})`;
 
 export { newMemberListSectionInfoText };

--- a/packages/web/src/features/manage-club/frames/ManageClubFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/ManageClubFrame.tsx
@@ -1,24 +1,54 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { ClubDelegateEnum } from "@sparcs-clubs/interface/common/enum/club.enum";
+
+import { RegistrationDeadlineEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import NoManageClub from "@sparcs-clubs/web/common/frames/NoManageClub";
 // import ActivityManageFrame from "@sparcs-clubs/web/features/manage-club/frames/ActivityManageFrame";
+import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import InfoManageFrame from "@sparcs-clubs/web/features/manage-club/frames/InfoManageFrame";
-// import MembersManageFrame from "@sparcs-clubs/web/features/manage-club/frames/MembersManageFrame";
+import MembersManageFrame from "@sparcs-clubs/web/features/manage-club/frames/MembersManageFrame";
 // import ServiceManageFrame from "@sparcs-clubs/web/features/manage-club/frames/ServiceManageFrame";
 import { useCheckManageClub } from "@sparcs-clubs/web/hooks/checkManageClub";
 
 const ManageClubFrame: React.FC = () => {
   const { delegate, isLoading } = useCheckManageClub();
 
-  if (isLoading) {
-    return <AsyncBoundary isLoading={isLoading} isError />;
+  const { data, isLoading: termIsLoading } = useGetRegistrationTerm();
+  const [isRegistrationPeriod, setIsRegistrationPeriod] =
+    useState<boolean>(false);
+
+  useEffect(() => {
+    if (data) {
+      const now = new Date();
+      const currentEvents = data.events.filter(
+        event => now >= event.startTerm && now <= event.endTerm,
+      );
+      if (currentEvents.length === 0) {
+        setIsRegistrationPeriod(false);
+        return;
+      }
+      const registrationEvent = currentEvents.filter(
+        event =>
+          event.registrationEventEnumId ===
+          RegistrationDeadlineEnum.StudentRegistrationApplication,
+      );
+      if (registrationEvent.length > 0) {
+        setIsRegistrationPeriod(true);
+      } else {
+        setIsRegistrationPeriod(false);
+      }
+    }
+  }, [data]);
+
+  if (isLoading || termIsLoading) {
+    return <AsyncBoundary isLoading={isLoading || termIsLoading} isError />;
   }
 
   if (delegate === undefined) {
@@ -34,10 +64,9 @@ const ManageClubFrame: React.FC = () => {
       <InfoManageFrame
         isRepresentative={delegate === ClubDelegateEnum.Representative}
       />
-      {/* TODO: 회원 등록 배포 때 MembersManageFrame 주석 해제 */}
-      {/* <ActivityManageFrame />
-      <MembersManageFrame />
-      <ServiceManageFrame /> */}
+      {/* <ActivityManageFrame /> */}
+      {isRegistrationPeriod && <MembersManageFrame />}
+      {/* <ServiceManageFrame /> */}
     </FlexWrapper>
   );
 };

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -68,8 +68,8 @@ const MembersManageFrame: React.FC = () => {
     ).length;
   const totalCount = memberData && memberData.applies.length;
 
-  const title = `2024년 봄학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
-  const mobileTitle = `2024년 봄학기`;
+  const title = `2024년 가을학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
+  const mobileTitle = `2024년 가을학기`;
   // TODO: 학기 받아올 수 있도록 수정
 
   const theme = useTheme();

--- a/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
+++ b/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
@@ -8,8 +8,6 @@ import { newMemberListSectionInfoText } from "@sparcs-clubs/web/constants/manage
 
 import RegisterMemberList from "../components/RegisterMemberList";
 
-import { mockDeadline, mockSemester } from "./_mock/mockMembers";
-
 const RegisterMemberListWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -19,7 +17,8 @@ const RegisterMemberListWrapper = styled.div`
 const RegisterMemberListFrame = () => (
   <FoldableSectionTitle title="신청 회원 명단" childrenMargin="20px">
     <RegisterMemberListWrapper>
-      <Info text={newMemberListSectionInfoText(mockSemester, mockDeadline)} />
+      {/* TODO: 실제 신청기간 보여주기 */}
+      <Info text={newMemberListSectionInfoText("2024년 가을", new Date())} />
       <RegisterMemberList />
     </RegisterMemberListWrapper>
   </FoldableSectionTitle>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1068 


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 신청 회원 리스트 존재할 때 한 번 더 테스트해보긴 해야할듯
- info text에 실제 신청 기간 보여줘야 함