### PR TITLE
Fix MemberRegistration Error in MembersManageTable

### DIFF
--- a/packages/web/src/features/clubDetails/services/getClubDetail.ts
+++ b/packages/web/src/features/clubDetails/services/getClubDetail.ts
@@ -23,9 +23,8 @@ export const useGetClubDetail = (club_id: string) =>
       switch (status) {
         case 200:
         case 304:
-          return apiClb002.responseBodyMap[200].parse(data);
-        // console.log(data);
-        // return data;
+          // return apiClb002.responseBodyMap[200].parse(data);
+          return data;
         default:
           throw new UnexpectedAPIResponseError();
       }

--- a/packages/web/src/features/clubDetails/services/getClubDetail.ts
+++ b/packages/web/src/features/clubDetails/services/getClubDetail.ts
@@ -24,6 +24,8 @@ export const useGetClubDetail = (club_id: string) =>
         case 200:
         case 304:
           return apiClb002.responseBodyMap[200].parse(data);
+        // console.log(data);
+        // return data;
         default:
           throw new UnexpectedAPIResponseError();
       }

--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -139,17 +139,31 @@ const columnsFunction = (clubName: string, clubId: number) => [
     header: "비고",
     cell: info => {
       const member = info.row.original;
-      return member.applyStatusEnumId ===
-        RegistrationApplicationStudentStatusEnum.Pending ? (
-        <TableButton
-          text={["승인", "반려"]}
-          onClick={[
-            () => openApproveModal(member, clubName, clubId),
-            () => openRejectModal(member, clubName, clubId),
-          ]}
-        />
-      ) : (
-        " "
+      return (
+        (member.applyStatusEnumId ===
+          RegistrationApplicationStudentStatusEnum.Pending && (
+          <TableButton
+            text={["승인", "반려"]}
+            onClick={[
+              () => openApproveModal(member, clubName, clubId),
+              () => openRejectModal(member, clubName, clubId),
+            ]}
+          />
+        )) ||
+        (member.applyStatusEnumId ===
+          RegistrationApplicationStudentStatusEnum.Approved && (
+          <TableButton
+            text={["반려"]}
+            onClick={[() => openRejectModal(member, clubName, clubId)]}
+          />
+        )) ||
+        (member.applyStatusEnumId ===
+          RegistrationApplicationStudentStatusEnum.Rejected && (
+          <TableButton
+            text={["승인"]}
+            onClick={[() => openApproveModal(member, clubName, clubId)]}
+          />
+        ))
       );
     },
     size: 15,

--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -28,12 +28,14 @@ interface MembersTableProps {
   memberList: ApiReg008ResponseOk["applies"];
   clubName: string;
   clubId: number;
+  refetch: () => void;
 }
 
 const openApproveModal = (
   member: ApiReg008ResponseOk["applies"][0],
   clubName: string,
   clubId: number,
+  refetch: () => void,
 ) => {
   overlay.open(({ isOpen, close }) => (
     <Modal isOpen={isOpen}>
@@ -49,6 +51,7 @@ const openApproveModal = (
             },
           );
           close();
+          refetch();
         }}
         onClose={() => {
           close();
@@ -68,6 +71,7 @@ const openRejectModal = (
   member: ApiReg008ResponseOk["applies"][0],
   clubName: string,
   clubId: number,
+  refetch: () => void,
 ) => {
   overlay.open(({ isOpen, close }) => (
     <Modal isOpen={isOpen}>
@@ -83,6 +87,7 @@ const openRejectModal = (
             },
           );
           close();
+          refetch();
         }}
         onClose={() => {
           close();
@@ -100,7 +105,11 @@ const openRejectModal = (
 
 const columnHelper = createColumnHelper<ApiReg008ResponseOk["applies"][0]>();
 
-const columnsFunction = (clubName: string, clubId: number) => [
+const columnsFunction = (
+  clubName: string,
+  clubId: number,
+  refetch: () => void,
+) => [
   columnHelper.accessor("applyStatusEnumId", {
     header: "상태",
     cell: info => {
@@ -145,8 +154,8 @@ const columnsFunction = (clubName: string, clubId: number) => [
           <TableButton
             text={["승인", "반려"]}
             onClick={[
-              () => openApproveModal(member, clubName, clubId),
-              () => openRejectModal(member, clubName, clubId),
+              () => openApproveModal(member, clubName, clubId, refetch),
+              () => openRejectModal(member, clubName, clubId, refetch),
             ]}
           />
         )) ||
@@ -154,14 +163,16 @@ const columnsFunction = (clubName: string, clubId: number) => [
           RegistrationApplicationStudentStatusEnum.Approved && (
           <TableButton
             text={["반려"]}
-            onClick={[() => openRejectModal(member, clubName, clubId)]}
+            onClick={[() => openRejectModal(member, clubName, clubId, refetch)]}
           />
         )) ||
         (member.applyStatusEnumId ===
           RegistrationApplicationStudentStatusEnum.Rejected && (
           <TableButton
             text={["승인"]}
-            onClick={[() => openApproveModal(member, clubName, clubId)]}
+            onClick={[
+              () => openApproveModal(member, clubName, clubId, refetch),
+            ]}
           />
         ))
       );
@@ -174,8 +185,9 @@ const MembersTable: React.FC<MembersTableProps> = ({
   memberList,
   clubName,
   clubId,
+  refetch,
 }) => {
-  const columns = columnsFunction(clubName, clubId);
+  const columns = columnsFunction(clubName, clubId, refetch);
   const table = useReactTable({
     columns,
     data: memberList,

--- a/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MembersManageFrame.tsx
@@ -39,10 +39,12 @@ const MembersManageFrame: React.FC = () => {
     data: memberData,
     isLoading: memberIsLoading,
     isError: memberIsError,
+    refetch: memberRefetch,
   } = useGetMemberRegistration({ clubId: idData.clubId }) as {
     data: ApiReg008ResponseOk;
     isLoading: boolean;
     isError: boolean;
+    refetch: () => void;
   };
 
   const appliedCount =
@@ -91,8 +93,8 @@ const MembersManageFrame: React.FC = () => {
   return (
     <FoldableSectionTitle title="회원 명단">
       <AsyncBoundary
-        isLoading={memberIsLoading && clubIsLoading}
-        isError={memberIsError && clubIsError}
+        isLoading={memberIsLoading || clubIsLoading}
+        isError={memberIsError || clubIsError}
       >
         <FlexWrapper direction="column" gap={20}>
           {memberData && clubData && (
@@ -107,6 +109,7 @@ const MembersManageFrame: React.FC = () => {
                 memberList={memberData.applies}
                 clubName={clubData.name_kr}
                 clubId={idData.clubId}
+                refetch={memberRefetch}
               />
             </>
           )}

--- a/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/RegisterMemberList.tsx
@@ -43,10 +43,12 @@ const RegisterMemberList = () => {
     data: memberData,
     isLoading: memberIsLoading,
     isError: memberIsError,
+    refetch: memberRefetch,
   } = useGetMemberRegistration({ clubId: idData.clubId }) as {
     data: ApiReg008ResponseOk;
     isLoading: boolean;
     isError: boolean;
+    refetch: () => void;
   };
 
   const totalPage = memberData && Math.ceil(memberData.applies.length / 10);
@@ -54,14 +56,15 @@ const RegisterMemberList = () => {
   return (
     <TableWithPagination>
       <AsyncBoundary
-        isLoading={clubIsLoading && memberIsLoading}
-        isError={clubIsError && memberIsError}
+        isLoading={clubIsLoading || memberIsLoading}
+        isError={clubIsError || memberIsError}
       >
-        {clubData && memberData && (
+        {memberData && (
           <MembersTable
             memberList={memberData.applies}
             clubName={clubData.name_kr}
             clubId={idData.clubId}
+            refetch={memberRefetch}
           />
         )}
         {totalPage !== 1 && (

--- a/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
@@ -26,7 +26,7 @@ export const useGetMemberRegistration = (requestParam: ApiReg008RequestParam) =>
           if (data.applies.length === 0) return data;
           // console.log(data);
           return apiReg008.responseBodyMap[200].parse(data);
-          return data;
+          // return data;
         }
         default:
           throw new UnexpectedAPIResponseError();

--- a/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
@@ -24,7 +24,9 @@ export const useGetMemberRegistration = (requestParam: ApiReg008RequestParam) =>
       switch (status) {
         case 200: {
           if (data.applies.length === 0) return data;
+          // console.log(data);
           return apiReg008.responseBodyMap[200].parse(data);
+          return data;
         }
         default:
           throw new UnexpectedAPIResponseError();

--- a/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/getClubMemberRegistration.ts
@@ -24,7 +24,6 @@ export const useGetMemberRegistration = (requestParam: ApiReg008RequestParam) =>
       switch (status) {
         case 200: {
           if (data.applies.length === 0) return data;
-          // console.log(data);
           return apiReg008.responseBodyMap[200].parse(data);
           // return data;
         }

--- a/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
+++ b/packages/web/src/features/manage-club/members/services/patchClubMemberRegistration.ts
@@ -22,7 +22,8 @@ export const patchClubMemberRegistration = async (
 
   switch (status) {
     case 204: {
-      return apiReg007.responseBodyMap[204].parse(data);
+      return data;
+      // return apiReg007.responseBodyMap[204].parse(data);
     }
     default:
       throw new UnexpectedAPIResponseError();


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1087
대표자로 로그인하여 /manage-club 들어가면 동아리 등록 신청자 내역이 제대로 뜨지 않음 + 승인 반려 제대로 되게 고치기

***2줄 요약***
- MembersTable의 승**인 반려 버튼이 스크린샷처럼** 나타나는 게 맞는지
- patchClubMemberRegistration return data type이 **object 여야 하는데 string이어서 생기는 문제 근본적 해결은 못했음**





- [x] 문제 1: 조드 타입 호환이 안 돼서
getClubDetail 조드 에러 : SPARCS TEST 동아리의 소개 문구가 db에 null이기 때문
getClubMemberRegistration 조드 에러 : email 끝에 \r 붙었기 때문
해결: 테스트 시에만 `return data`로 바꿔 해보고, 그대로 파싱을 남겨 놓았습니다

- [x] 문제 2: 승인 된 신청자 row에 반려 버튼 제대로 안 나타남
해결: 승인 상태 => 반려 버튼 나타나게 / 반려 상태 => 승인 버튼 나타나게 / 신청 상태 => 둘 다 나타나게 수정했습니다

- [x] 문제 3: 승인 잘 되는지 확인 (처음에는 에러가 뜨고, 새로고침 해야만 해결된다는 문제) 
`patchClubMemberRegistration` data type이 object 여야 하는데 string이어서 생기는 조드 에러 문제가 있습니다.
해결: `return data`로 수정. refetch를 받아와서 새로고침 실행하는 것으로 해결했습니다. (@wjeongchoi 🫶)
api를 까 봤는데도 거기서는 {}를 잘 주더라고요 왜 문제가 되는지 모르겠습니다 ㅠㅠ
(까본 것은 `member-registration.repository.ts>patchMemberRegistration`)


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="1507" alt="스크린샷 2024-09-24 오전 12 23 53" src="https://github.com/user-attachments/assets/71f4ed5e-480d-47ab-8583-668dcae1a8aa">


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
