### PR TITLE
update meeting detail page, connect apiMee002, apiMee004, apiMee005

### DIFF
--- a/packages/web/src/app/meeting/[id]/page.tsx
+++ b/packages/web/src/app/meeting/[id]/page.tsx
@@ -93,12 +93,22 @@ const MeetingDetailFrame: React.FC = () => {
     if (data == null) return "";
     let content = data.announcementContent;
 
+    content = content.replace(
+      meetingType,
+      meetingEnumToText(data.meetingEnumId.toString()),
+    );
+    content = content.replace(
+      isRegular,
+      data.isRegular ? "정기회의" : "비정기회의",
+    );
+
     content = content.replace(dateTime, formatDateTime(data.startDate));
     content = content.replace(dateTime, formatDateTimeEn(data.startDate));
     content = content.replace(startDate, formatDateTime(data.startDate));
     if (data.endDate != null) {
       content = content.replace(endDate, formatDateTime(data.endDate));
     }
+
     content = content.replace(location, data.location);
     content = content.replace(locationEn, data.locationEn);
 

--- a/packages/web/src/app/meeting/[id]/page.tsx
+++ b/packages/web/src/app/meeting/[id]/page.tsx
@@ -1,90 +1,131 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 
-// 배포용 not found 페이지 (시작)
-import NotFound from "@sparcs-clubs/web/app/not-found";
+import Link from "next/link";
 
-const TemporaryNotFound = () => <NotFound />;
+import { useParams, useRouter } from "next/navigation";
+import { overlay } from "overlay-kit";
+import styled from "styled-components";
 
-export default TemporaryNotFound;
-// 배포용 not found 페이지 (끝)
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import Button from "@sparcs-clubs/web/common/components/Button";
+import Card from "@sparcs-clubs/web/common/components/Card";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
-// import Link from "next/link";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { meetingEnumToText } from "@sparcs-clubs/web/features/meeting/constants/getEnumType";
+import {
+  dateTime,
+  endDate,
+  isRegular,
+  location,
+  locationEn,
+  meetingType,
+  startDate,
+} from "@sparcs-clubs/web/features/meeting/constants/meetingTemplate";
+import useGetMeetingDetail from "@sparcs-clubs/web/features/meeting/services/useGetMeetingDetail";
+import {
+  formatDateTime,
+  formatDateTimeEn,
+} from "@sparcs-clubs/web/utils/Date/formatDate";
 
-// import { useRouter } from "next/navigation";
-// import { overlay } from "overlay-kit";
-// import styled from "styled-components";
+const RowStretchWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
 
-// import Button from "@sparcs-clubs/web/common/components/Button";
-// import Card from "@sparcs-clubs/web/common/components/Card";
-// import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
-// import Modal from "@sparcs-clubs/web/common/components/Modal";
-// import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
-// import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+const MeetingDetailFrame: React.FC = () => {
+  const router = useRouter();
+  const { id } = useParams();
 
-// import Typography from "@sparcs-clubs/web/common/components/Typography";
-// import { mockupData } from "@sparcs-clubs/web/features/meeting/services/_mock/mockupMeetingDetail";
+  const { data, isLoading, isError } = useGetMeetingDetail(+id);
 
-// const RowStretchWrapper = styled.div`
-//   display: flex;
-//   justify-content: space-between;
-//   align-items: center;
-//   align-self: stretch;
-// `;
+  const deleteHandler = () => {
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen}>
+        <CancellableModalContent
+          onConfirm={() => {
+            // TODO. 삭제 요청 api 연결
+            close();
+            router.replace("/meeting");
+          }}
+          onClose={close}
+        >
+          공고를 삭제하면 복구할 수 없습니다.
+          <br />
+          ㄱㅊ?
+        </CancellableModalContent>
+      </Modal>
+    ));
+  };
 
-// const MeetingDetailFrame: React.FC = () => {
-//   const router = useRouter();
+  const announcementTitle = useMemo(() => {
+    if (data == null) return "";
+    let title = data.announcementTitle;
 
-//   const deleteHandler = () => {
-//     overlay.open(({ isOpen, close }) => (
-//       <Modal isOpen={isOpen}>
-//         <CancellableModalContent
-//           onConfirm={() => {
-//             // TODO. 삭제 요청 api 연결
-//             close();
-//             router.replace("/meeting");
-//           }}
-//           onClose={close}
-//         >
-//           공고를 삭제하면 복구할 수 없습니다.
-//           <br />
-//           ㄱㅊ?
-//         </CancellableModalContent>
-//       </Modal>
-//     ));
-//   };
+    title = title.replace(
+      meetingType,
+      meetingEnumToText(data.meetingEnumId.toString()),
+    );
+    title = title.replace(
+      isRegular,
+      data.isRegular ? "정기회의" : "비정기회의",
+    );
 
-//   // TODO. 공고 상세조회 api 연결
-//   const data = mockupData;
+    return title;
+  }, [data]);
 
-//   return (
-//     <FlexWrapper direction="column" gap={60}>
-//       <PageHead
-//         items={[{ name: "의결기구", path: `/meeting` }]}
-//         title={data.title}
-//         enableLast
-//       />
-//       <Card outline>
-//         <Typography fs={16} lh={20} style={{ whiteSpace: "pre-line" }}>
-//           {data.content}
-//         </Typography>
-//       </Card>
-//       <RowStretchWrapper>
-//         <Link href="/meeting">
-//           <Button type="default">목록으로 돌아가기</Button>
-//         </Link>
-//         <FlexWrapper direction="row" gap={10}>
-//           <Button type="default" onClick={deleteHandler}>
-//             삭제
-//           </Button>
-//           <Link href={`/meeting/${data.id}/edit`}>
-//             <Button type="default">수정</Button>
-//           </Link>
-//         </FlexWrapper>
-//       </RowStretchWrapper>
-//     </FlexWrapper>
-//   );
-// };
+  const announcementContent = useMemo(() => {
+    if (data == null) return "";
+    let content = data.announcementContent;
 
-// export default MeetingDetailFrame;
+    content = content.replace(dateTime, formatDateTime(data.startDate));
+    content = content.replace(dateTime, formatDateTimeEn(data.startDate));
+    content = content.replace(startDate, formatDateTime(data.startDate));
+    if (data.endDate != null) {
+      content = content.replace(endDate, formatDateTime(data.endDate));
+    }
+    content = content.replace(location, data.location);
+    content = content.replace(locationEn, data.locationEn);
+
+    return content;
+  }, [data]);
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <FlexWrapper direction="column" gap={60}>
+        <PageHead
+          items={[{ name: "의결기구", path: `/meeting` }]}
+          title={announcementTitle}
+          enableLast
+        />
+        <Card outline>
+          <Typography fs={16} lh={20} style={{ whiteSpace: "pre-line" }}>
+            {announcementContent}
+          </Typography>
+        </Card>
+        <RowStretchWrapper>
+          <Link href="/meeting">
+            <Button type="default">목록으로 돌아가기</Button>
+          </Link>
+          <FlexWrapper direction="row" gap={10}>
+            <Button type="default" onClick={deleteHandler}>
+              삭제
+            </Button>
+            <Link href={`/meeting/${id}/edit`}>
+              <Button type="default">수정</Button>
+            </Link>
+          </FlexWrapper>
+        </RowStretchWrapper>
+      </FlexWrapper>
+    </AsyncBoundary>
+  );
+};
+
+export default MeetingDetailFrame;

--- a/packages/web/src/features/meeting/constants/getEnumType.ts
+++ b/packages/web/src/features/meeting/constants/getEnumType.ts
@@ -3,7 +3,7 @@ import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
 export const meetingEnumToText = (meetingEnum: string) => {
   switch (meetingEnum) {
     case MeetingEnum.clubRepresentativesCouncilMeeting.toString():
-      return "전동대회";
+      return "전체동아리대표자회의";
     case MeetingEnum.expansiveOperativeCommittee.toString():
       return "확대운영위원회";
     case MeetingEnum.operativeCommittee.toString():

--- a/packages/web/src/features/meeting/constants/meetingTemplate.ts
+++ b/packages/web/src/features/meeting/constants/meetingTemplate.ts
@@ -2,8 +2,6 @@ import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
 
 import { getFullSemester } from "@sparcs-clubs/web/utils/getSemester";
 
-import { CreateMeetingModel } from "../types/meeting";
-
 export type TemplateType = {
   title: string;
   content: string;
@@ -18,16 +16,16 @@ export const location = "[[[LOCATION_KR]]]";
 export const locationEn = "[[[LOCATION_EN]]]";
 
 export class MeetingTemplate {
-  static getContent(data: CreateMeetingModel) {
+  static getContent(type: MeetingEnum, count?: number) {
     const now = new Date();
 
     if (
-      data.meetingEnumId === MeetingEnum.expansiveOperativeCommittee ||
-      data.meetingEnumId === MeetingEnum.operativeCommittee
+      type === MeetingEnum.expansiveOperativeCommittee ||
+      type === MeetingEnum.operativeCommittee
     ) {
       return `안녕하세요, 동아리연합회 부회장입니다.
         
-본회 회칙 제${data.meetingEnumId === MeetingEnum.expansiveOperativeCommittee ? 35 : 40}조에 따라, 제${data.count ?? "X"}차 ${meetingType} (${now.getMonth() + 1}월, ${isRegular})를 아래와 같이 진행합니다.
+본회 회칙 제${type === MeetingEnum.expansiveOperativeCommittee ? 35 : 40}조에 따라, 제${count ?? "X"}차 ${meetingType} (${now.getMonth() + 1}월, ${isRegular})를 아래와 같이 진행합니다.
 
 일시 : ${dateTime}
 장소 : ${location}
@@ -35,7 +33,7 @@ export class MeetingTemplate {
 감사합니다.`;
     }
 
-    if (data.meetingEnumId === MeetingEnum.clubRepresentativesCouncilMeeting) {
+    if (type === MeetingEnum.clubRepresentativesCouncilMeeting) {
       return `(English Notice on the bottom)
 
 안녕하세요, 학부 동아리연합회 부회장입니다.
@@ -69,12 +67,12 @@ Thank you.`;
     return "";
   }
 
-  static defaultTemplate(data: CreateMeetingModel): TemplateType {
+  static defaultTemplate(type: MeetingEnum, count?: number): TemplateType {
     const now = new Date();
 
     return {
-      title: `${now.getFullYear()}년 제${data.count ?? "X"}차 ${meetingType} (${now.getMonth() + 1}월, ${isRegular})`,
-      content: this.getContent(data),
+      title: `${now.getFullYear()}년 제${count ?? "X"}차 ${meetingType} (${now.getMonth() + 1}월, ${isRegular})`,
+      content: this.getContent(type, count),
     };
   }
 
@@ -85,7 +83,7 @@ Thank you.`;
       title: `${now.getMonth()}월 ${meetingType} 기간 공고`,
       content: `안녕하세요, 부회장입니다.
 
-7월 분과회의 기간을 다음과 같이 공고합니다.
+${now.getMonth()}월 분과회의 기간을 다음과 같이 공고합니다.
 ${startDate} ~ ${endDate}
 
 감사합니다.`,

--- a/packages/web/src/features/meeting/services/_mock/mockupMeetingDetail.ts
+++ b/packages/web/src/features/meeting/services/_mock/mockupMeetingDetail.ts
@@ -1,44 +1,22 @@
+import { ApiMee002ResponseOk } from "@sparcs-clubs/interface/api/meeting/apiMee002";
 import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
 
-import { MeetingDetail } from "@sparcs-clubs/web/features/meeting/types/meeting";
+import { MeetingTemplate } from "@sparcs-clubs/web/features/meeting/constants/meetingTemplate";
 
-// TODO. mock data api에 맞게 수정
-export const mockupData: MeetingDetail = {
-  id: 1,
-  announcementTitle: "2024년 3월 제1차 정기 전체동아리대표자회의 공고",
-  announcementContent: `(English Notice on the bottom)
-  
-  안녕하세요, 학부 동아리연합회 부회장입니다.
-  
-  다음과 같이 전체동아리대표자회의의 일시와 장소를 공고합니다.
-  
-  일시 : 2024년 3월 20일(수) 19시 30분
-  장소 : 전산학부동 제1공동강의실 (E3-1 1501호) 
-  
-  - 출결 관련 유의사항 (본회 회칙 제17조 참고) -
-  이번 회의의 재적 인원은 2023 가을학기 등록을 기준으로 합니다.
-  출석은 1인 당 1개 직에 대해서만 인정하며, 동아리 대표자 본인의 출석이 불가한 경우 대의원(의결권 O) 혹은 대리인(의결권 X)도 출석이 인정됩니다.
-  
-  감사합니다.
-  
-  ---
-  
-  Hello, this is the vice-president of KAIST Undergraduate Students Clubs Union.
-  
-  The date and location of the 1st Council of the Club Representatives in 2024 is announced as follows:
-  
-  Date & Time : MAR 20, 2024 (Wed) 7:30pm 
-  Location : E3-1 Room No.1501 (School of CS Bldg. 1F)
-  
-  - Precautions Related to Attendance -
-  The students who is obligated to attend in this legislative is based on the registration of 2023 fall semester.
-  If the club representative is unable to attend, another delegate (with voting right) or deputy (without voting right) can also be admitted.
-  
-  Thank you.`,
-  count: 1,
+// meetingType 변경하여 각 케이스에 대한 mock 데이터 확인 가능
+const meetingType = MeetingEnum.divisionMeeting;
+const mockupMeetingTemplate =
+  meetingType === MeetingEnum.divisionMeeting
+    ? MeetingTemplate.divisionMeetingTemplate()
+    : MeetingTemplate.defaultTemplate(meetingType, 100);
+
+export const mockupMeetingDetail: ApiMee002ResponseOk = {
+  announcementTitle: mockupMeetingTemplate.title,
+  announcementContent: mockupMeetingTemplate.content,
   isRegular: false,
-  meetingEnumId: MeetingEnum.divisionMeeting,
+  meetingEnumId: meetingType,
   startDate: new Date(),
+  endDate: new Date(),
   location: "장소",
   locationEn: "location",
 };

--- a/packages/web/src/features/meeting/services/useDeleteMeeting.ts
+++ b/packages/web/src/features/meeting/services/useDeleteMeeting.ts
@@ -1,0 +1,33 @@
+import apiMee004, {
+  ApiMee004RequestParam,
+  ApiMee004ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/apiMee004";
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useDeleteMeeting = () =>
+  useMutation<ApiMee004ResponseOk, Error, { param: ApiMee004RequestParam }>({
+    mutationFn: async ({ param }): Promise<ApiMee004ResponseOk> => {
+      const { status } = await axiosClientWithAuth.delete(
+        apiMee004.url(param.announcementId),
+      );
+
+      switch (status) {
+        case 200:
+          return apiMee004.responseBodyMap[200];
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+export default useDeleteMeeting;
+
+defineAxiosMock(mock => {
+  mock.onDelete(apiMee004.url(1)).reply(() => [200]);
+});

--- a/packages/web/src/features/meeting/services/useGetMeetingDegree.ts
+++ b/packages/web/src/features/meeting/services/useGetMeetingDegree.ts
@@ -1,0 +1,34 @@
+import apiMee005, {
+  ApiMee005RequestQuery,
+  ApiMee005ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/apiMee005";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetMeetingDegree = (query: ApiMee005RequestQuery) =>
+  useQuery<ApiMee005ResponseOk, Error>({
+    queryKey: [apiMee005.url()],
+    queryFn: async (): Promise<ApiMee005ResponseOk> => {
+      const { data, status } = await axiosClientWithAuth.get(apiMee005.url(), {
+        params: query,
+      });
+
+      switch (status) {
+        case 200:
+          return apiMee005.responseBodyMap[200].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+export default useGetMeetingDegree;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiMee005.url()).reply(() => [200, { degree: 100 }]);
+});

--- a/packages/web/src/features/meeting/services/useGetMeetingDetail.ts
+++ b/packages/web/src/features/meeting/services/useGetMeetingDetail.ts
@@ -1,0 +1,36 @@
+import apiMee002, {
+  ApiMee002ResponseOk,
+} from "@sparcs-clubs/interface/api/meeting/apiMee002";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+import { mockupMeetingDetail } from "./_mock/mockupMeetingDetail";
+
+const useGetMeetingDetail = (id: number) =>
+  useQuery<ApiMee002ResponseOk, Error>({
+    queryKey: [apiMee002.url(id)],
+    queryFn: async (): Promise<ApiMee002ResponseOk> => {
+      const { data, status } = await axiosClientWithAuth.get(
+        apiMee002.url(id),
+        {},
+      );
+
+      switch (status) {
+        case 200:
+          return apiMee002.responseBodyMap[200].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+export default useGetMeetingDetail;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiMee002.url(1)).reply(() => [200, mockupMeetingDetail]);
+});

--- a/packages/web/src/utils/Date/formatDate.ts
+++ b/packages/web/src/utils/Date/formatDate.ts
@@ -21,6 +21,9 @@ const formatSlashDate = (date: Date) =>
 const formatDateTime = (date: Date) =>
   format(formatKST(date), "yyyy년 M월 d일 (iii) HH:mm", { locale: ko });
 
+const formatDateTimeEn = (date: Date) =>
+  format(formatKST(date), "MMM dd, yyyy (iii) HH:mm");
+
 const formatTime = (date: Date) =>
   format(formatKST(date), "HH:mm", { locale: ko });
 
@@ -38,13 +41,14 @@ const formatDotDetailDate = (date: Date) =>
 
 export {
   formatDate,
-  formatDotSimpleDate,
   formatDateTime,
+  formatDateTimeEn,
   formatDotDate,
   formatDotDetailDate,
+  formatDotSimpleDate,
   formatMonth,
-  formatSimpleSlashDate,
   formatSimplerSlashDate,
+  formatSimpleSlashDate,
   formatSlashDate,
   formatSlashDateTime,
   formatTime,


### PR DESCRIPTION
# 요약 \*

It closes #1100 

# 작업내용 요약
1. 공고 상세조회 페이지(meeting/1) 템플릿의 토큰 치환 작업 추가
2. 상세조회 페이지 api 연결(apiMee002)
3. 공고 삭제하기 api 연결(apiMee004)
4. 회의 차수 조회 api 연결(apiMee005)

# 테스트
1. 미팅 타입별로 조회 페이지 토큰 치환되는 부분 표시 잘 되는지 확인 (mockupMeetingDetail 데이터 변경하면서 확인)
2. 삭제하기 기능 잘 되는지 확인 
3. 목록으로 돌아가기, 삭제 후 목록으로 돌아가기 등 라우팅 처리 잘 되어있는지 확인

# 스크린샷
![image](https://github.com/user-attachments/assets/6c448cd4-22d3-467e-9bd2-fe1e947f8688)
![image](https://github.com/user-attachments/assets/fb4b948d-b5cd-4e59-b493-46445a2955f6)

# 이후 Task \*

- 없음
