### PR TITLE
connect api to meeting create page

### DIFF
--- a/packages/web/src/app/meeting/[id]/edit/page.tsx
+++ b/packages/web/src/app/meeting/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
+import { withAuthorization } from "@sparcs-clubs/web/common/components/withAuthorization";
 import MeetingAnnouncementFrame from "@sparcs-clubs/web/features/meeting/components/MeetingAnnouncementFrame";
 import MeetingInformationFrame from "@sparcs-clubs/web/features/meeting/components/MeetingInformationFrame";
 import useGetMeetingDetail from "@sparcs-clubs/web/features/meeting/services/useGetMeetingDetail";
@@ -124,4 +125,4 @@ const EditMeetingPage: React.FC = () => {
   );
 };
 
-export default EditMeetingPage;
+export default withAuthorization(EditMeetingPage, ["executive"], -1);

--- a/packages/web/src/app/meeting/[id]/edit/page.tsx
+++ b/packages/web/src/app/meeting/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import styled from "styled-components";
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import MeetingAnnouncementFrame from "@sparcs-clubs/web/features/meeting/components/MeetingAnnouncementFrame";
@@ -67,6 +68,7 @@ const EditMeetingPage: React.FC = () => {
           queryClient.invalidateQueries({ queryKey: [apiMee002.url(+id)] });
           router.replace(`/meeting/${id}`);
         },
+        onError: () => errorHandler("수정에 실패하였습니다"),
       },
     );
   };

--- a/packages/web/src/app/meeting/[id]/edit/page.tsx
+++ b/packages/web/src/app/meeting/[id]/edit/page.tsx
@@ -35,7 +35,6 @@ const EditMeetingPage: React.FC = () => {
   });
 
   const {
-    resetField,
     getValues,
     handleSubmit,
     watch,
@@ -97,14 +96,7 @@ const EditMeetingPage: React.FC = () => {
               title="공고 수정"
             />
             <MeetingInformationFrame />
-            <MeetingAnnouncementFrame
-              isTemplateVisible
-              onReset={() => {
-                resetField("announcementContent", {
-                  defaultValue: data?.announcementContent,
-                });
-              }}
-            />
+            <MeetingAnnouncementFrame isTemplateVisible />
             <ButtonWrapper>
               <Button
                 type={isUpdateLoading ? "disabled" : "default"}

--- a/packages/web/src/app/meeting/[id]/edit/page.tsx
+++ b/packages/web/src/app/meeting/[id]/edit/page.tsx
@@ -98,7 +98,7 @@ const EditMeetingPage: React.FC = () => {
               title="공고 수정"
             />
             <MeetingInformationFrame />
-            <MeetingAnnouncementFrame isTemplateVisible />
+            <MeetingAnnouncementFrame isTemplateVisible isEditMode />
             <ButtonWrapper>
               <Button
                 type={isUpdateLoading ? "disabled" : "default"}

--- a/packages/web/src/app/meeting/[id]/page.tsx
+++ b/packages/web/src/app/meeting/[id]/page.tsx
@@ -14,6 +14,7 @@ import Card from "@sparcs-clubs/web/common/components/Card";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import Typography from "@sparcs-clubs/web/common/components/Typography";
@@ -59,6 +60,7 @@ const MeetingDetailFrame: React.FC = () => {
                 onSuccess: () => {
                   router.replace("/meeting");
                 },
+                onError: () => errorHandler("삭제에 실패하였습니다"),
               },
             );
             close();

--- a/packages/web/src/app/meeting/announcement/create/page.tsx
+++ b/packages/web/src/app/meeting/announcement/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { ApiMee001RequestBody } from "@sparcs-clubs/interface/api/meeting/apiMee001";
 import Link from "next/link";
@@ -26,28 +26,24 @@ const CreateMeetingPage: React.FC = () => {
   const router = useRouter();
   const formCtx = useForm<ApiMee001RequestBody>({
     mode: "all",
+    defaultValues: {
+      announcementTitle: "",
+      announcementContent: "",
+    },
   });
 
   const {
-    resetField,
+    watch,
     getValues,
     handleSubmit,
-    watch,
     formState: { isValid },
   } = formCtx;
 
-  const announcementTitle = watch("announcementTitle");
-  const announcementContent = watch("announcementContent");
+  const meetingEnumId = watch("meetingEnumId");
 
   const [isTemplateVisible, setIsTemplateVisible] = useState(false);
-
   const { mutate: createMeeting, isPending: isCreateLoading } =
     useCreateMeeting();
-
-  const isFormValid = useMemo(
-    () => isValid && announcementTitle != null && announcementContent != null,
-    [announcementContent, announcementTitle, isValid],
-  );
 
   const submitHandler = useCallback(() => {
     createMeeting(
@@ -59,6 +55,12 @@ const CreateMeetingPage: React.FC = () => {
       },
     );
   }, [createMeeting, getValues, router]);
+
+  useEffect(() => {
+    if (meetingEnumId != null) {
+      setIsTemplateVisible(false);
+    }
+  }, [meetingEnumId]);
 
   return (
     <FormProvider {...formCtx}>
@@ -82,12 +84,7 @@ const CreateMeetingPage: React.FC = () => {
               setIsTemplateVisible(true);
             }}
           />
-          <MeetingAnnouncementFrame
-            isTemplateVisible={isTemplateVisible}
-            onReset={defaultValue => {
-              resetField("announcementContent", { defaultValue });
-            }}
-          />
+          <MeetingAnnouncementFrame isTemplateVisible={isTemplateVisible} />
           <ButtonWrapper>
             <Link href="/meeting">
               <Button type={isCreateLoading ? "disabled" : "outlined"}>
@@ -96,7 +93,11 @@ const CreateMeetingPage: React.FC = () => {
             </Link>
             <Button
               buttonType="submit"
-              type={isFormValid && !isCreateLoading ? "default" : "disabled"}
+              type={
+                isValid && !isCreateLoading && isTemplateVisible
+                  ? "default"
+                  : "disabled"
+              }
             >
               저장
             </Button>

--- a/packages/web/src/app/meeting/announcement/create/page.tsx
+++ b/packages/web/src/app/meeting/announcement/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { ApiMee001RequestBody } from "@sparcs-clubs/interface/api/meeting/apiMee001";
 import Link from "next/link";
@@ -15,6 +15,7 @@ import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import MeetingAnnouncementFrame from "@sparcs-clubs/web/features/meeting/components/MeetingAnnouncementFrame";
 import MeetingInformationFrame from "@sparcs-clubs/web/features/meeting/components/MeetingInformationFrame";
+import useCreateMeeting from "@sparcs-clubs/web/features/meeting/services/useCreateMeeting";
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -29,7 +30,7 @@ const CreateMeetingPage: React.FC = () => {
 
   const {
     resetField,
-    // getValues,
+    getValues,
     handleSubmit,
     watch,
     formState: { isValid },
@@ -40,17 +41,23 @@ const CreateMeetingPage: React.FC = () => {
 
   const [isTemplateVisible, setIsTemplateVisible] = useState(false);
 
+  const { mutate: createMeeting } = useCreateMeeting();
+
   const isFormValid = useMemo(
     () => isValid && announcementTitle != null && announcementContent != null,
     [announcementContent, announcementTitle, isValid],
   );
 
-  const submitHandler = () => {
-    // TODO. api 연결
-
-    // console.log("values: ", getValues());
-    router.replace("/meeting");
-  };
+  const submitHandler = useCallback(() => {
+    createMeeting(
+      { body: { ...getValues() } },
+      {
+        onSuccess: () => {
+          router.replace("/meeting");
+        },
+      },
+    );
+  }, [createMeeting, getValues, router]);
 
   return (
     <FormProvider {...formCtx}>

--- a/packages/web/src/app/meeting/announcement/create/page.tsx
+++ b/packages/web/src/app/meeting/announcement/create/page.tsx
@@ -41,7 +41,8 @@ const CreateMeetingPage: React.FC = () => {
 
   const [isTemplateVisible, setIsTemplateVisible] = useState(false);
 
-  const { mutate: createMeeting } = useCreateMeeting();
+  const { mutate: createMeeting, isPending: isCreateLoading } =
+    useCreateMeeting();
 
   const isFormValid = useMemo(
     () => isValid && announcementTitle != null && announcementContent != null,
@@ -89,11 +90,13 @@ const CreateMeetingPage: React.FC = () => {
           />
           <ButtonWrapper>
             <Link href="/meeting">
-              <Button type="outlined">취소</Button>
+              <Button type={isCreateLoading ? "disabled" : "outlined"}>
+                취소
+              </Button>
             </Link>
             <Button
               buttonType="submit"
-              type={isFormValid ? "default" : "disabled"}
+              type={isFormValid && !isCreateLoading ? "default" : "disabled"}
             >
               저장
             </Button>

--- a/packages/web/src/app/meeting/announcement/create/page.tsx
+++ b/packages/web/src/app/meeting/announcement/create/page.tsx
@@ -11,6 +11,7 @@ import styled from "styled-components";
 
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import MeetingAnnouncementFrame from "@sparcs-clubs/web/features/meeting/components/MeetingAnnouncementFrame";
@@ -52,6 +53,7 @@ const CreateMeetingPage: React.FC = () => {
         onSuccess: () => {
           router.replace("/meeting");
         },
+        onError: () => errorHandler("생성에 실패하였습니다"),
       },
     );
   }, [createMeeting, getValues, router]);

--- a/packages/web/src/app/meeting/announcement/create/page.tsx
+++ b/packages/web/src/app/meeting/announcement/create/page.tsx
@@ -14,6 +14,7 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
+import { withAuthorization } from "@sparcs-clubs/web/common/components/withAuthorization";
 import MeetingAnnouncementFrame from "@sparcs-clubs/web/features/meeting/components/MeetingAnnouncementFrame";
 import MeetingInformationFrame from "@sparcs-clubs/web/features/meeting/components/MeetingInformationFrame";
 import useCreateMeeting from "@sparcs-clubs/web/features/meeting/services/useCreateMeeting";
@@ -110,4 +111,4 @@ const CreateMeetingPage: React.FC = () => {
   );
 };
 
-export default CreateMeetingPage;
+export default withAuthorization(CreateMeetingPage, ["executive"]);

--- a/packages/web/src/common/components/Modal/ErrorModal.tsx
+++ b/packages/web/src/common/components/Modal/ErrorModal.tsx
@@ -1,0 +1,15 @@
+import { overlay } from "overlay-kit";
+
+import ConfirmModalContent from "./ConfirmModalContent";
+
+import Modal from ".";
+
+export const errorHandler = (message?: string) => {
+  overlay.open(({ isOpen, close }) => (
+    <Modal isOpen={isOpen}>
+      <ConfirmModalContent onConfirm={close}>
+        {message ?? "실패하였습니다"}
+      </ConfirmModalContent>
+    </Modal>
+  ));
+};

--- a/packages/web/src/common/components/withAuthorization.tsx
+++ b/packages/web/src/common/components/withAuthorization.tsx
@@ -1,0 +1,89 @@
+import { ComponentType } from "react";
+
+import { jwtDecode } from "jwt-decode";
+
+import { useRouter } from "next/navigation";
+
+import styled from "styled-components";
+
+import { UserType } from "@sparcs-clubs/web/utils/getUserType";
+import { getLocalStorageItem } from "@sparcs-clubs/web/utils/localStorage";
+
+import ErrorPageTemplate from "../frames/ErrorPageTemplate";
+import LoginRequired from "../frames/LoginRequired";
+import getLogin from "../services/getLogin";
+
+const ErrorMessage = styled.div`
+  color: ${({ theme }) => theme.colors.BLACK};
+  text-align: center;
+  font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
+  font-size: 32px;
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
+  line-height: 48px;
+  word-break: keep-all;
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
+    font-size: 28px;
+  }
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.xs}) {
+    font-size: 20px;
+    line-height: 32px;
+  }
+`;
+
+export const withAuthorization = <P extends object>(
+  WrappedComponent: ComponentType<P>,
+  acceptedAuthorization: UserType[],
+  redirectUrl?: string | -1,
+) => {
+  const login = async () => {
+    try {
+      const response = await getLogin();
+      window.location.href = response.url;
+    } catch (error) {
+      console.error("Login failed", error);
+    }
+  };
+
+  const WithAuth = (props: P) => {
+    const token = getLocalStorageItem("accessToken");
+    const router = useRouter();
+
+    if (!token) {
+      return <LoginRequired login={login} />;
+    }
+
+    const decoded: { name?: string; type?: string } = jwtDecode(token);
+    const userType = decoded.type as UserType;
+
+    if (!acceptedAuthorization.includes(userType)) {
+      return (
+        <ErrorPageTemplate
+          message={
+            <ErrorMessage>
+              현재 페이지에 대한
+              <br />
+              접근 권한이 없습니다
+            </ErrorMessage>
+          }
+          buttons={[
+            {
+              text: "이동하기",
+              onClick: () => {
+                if (redirectUrl === -1) {
+                  router.back();
+                } else {
+                  router.replace(redirectUrl ?? "/");
+                }
+              },
+            },
+          ]}
+        />
+      );
+    }
+
+    return <WrappedComponent {...props} />;
+  };
+
+  return WithAuth;
+};

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
@@ -17,12 +17,18 @@ import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/C
 import { MeetingTemplate } from "../constants/meetingTemplate";
 import useGetMeetingDegree from "../services/useGetMeetingDegree";
 
+interface MeetingAnnouncementFormProps {
+  isEditMode?: boolean;
+}
+
 const AlignEnd = styled.div`
   display: flex;
   justify-content: flex-end;
 `;
 
-const MeetingAnnouncementForm: React.FC = () => {
+const MeetingAnnouncementForm: React.FC<MeetingAnnouncementFormProps> = ({
+  isEditMode = false,
+}) => {
   const formCtx = useFormContext<ApiMee001RequestBody>();
   const { control, watch, resetField } = formCtx;
 
@@ -53,6 +59,8 @@ const MeetingAnnouncementForm: React.FC = () => {
   };
 
   useEffect(() => {
+    if (isEditMode) return;
+
     if (meetingEnumId !== MeetingEnum.divisionMeeting && data?.degree != null) {
       const template = MeetingTemplate.defaultTemplate(
         meetingEnumId,
@@ -67,7 +75,7 @@ const MeetingAnnouncementForm: React.FC = () => {
       resetField("announcementTitle", { defaultValue: template.title });
       resetField("announcementContent", { defaultValue: template.content });
     }
-  }, [meetingEnumId, data, resetField]);
+  }, [isEditMode, meetingEnumId, data, resetField]);
 
   useEffect(() => {
     if (meetingEnumId !== MeetingEnum.divisionMeeting) {

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
@@ -29,7 +29,9 @@ const MeetingAnnouncementForm: React.FC = () => {
   const meetingEnumId = watch("meetingEnumId");
   const announcementContent = watch("announcementContent");
 
-  const { data, isLoading, isError } = useGetMeetingDegree({ meetingEnumId });
+  const { data, isLoading, isError, refetch } = useGetMeetingDegree({
+    meetingEnumId,
+  });
 
   const openResetModal = () => {
     overlay.open(({ isOpen, close }) => (
@@ -66,6 +68,12 @@ const MeetingAnnouncementForm: React.FC = () => {
       resetField("announcementContent", { defaultValue: template.content });
     }
   }, [meetingEnumId, data, resetField]);
+
+  useEffect(() => {
+    if (meetingEnumId !== MeetingEnum.divisionMeeting) {
+      refetch();
+    }
+  }, [meetingEnumId, refetch]);
 
   const contentLength = announcementContent?.split(/\r\n|\r|\n/).length;
 

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementForm.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from "react";
+
+import { ApiMee001RequestBody } from "@sparcs-clubs/interface/api/meeting/apiMee001";
+import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
+import { overlay } from "overlay-kit";
+
+import { useFormContext } from "react-hook-form";
+import styled from "styled-components";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
+import FormController from "@sparcs-clubs/web/common/components/FormController";
+import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+
+import { MeetingTemplate } from "../constants/meetingTemplate";
+import useGetMeetingDegree from "../services/useGetMeetingDegree";
+
+const AlignEnd = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const MeetingAnnouncementForm: React.FC = () => {
+  const formCtx = useFormContext<ApiMee001RequestBody>();
+  const { control, watch, resetField } = formCtx;
+
+  const meetingEnumId = watch("meetingEnumId");
+  const announcementContent = watch("announcementContent");
+
+  const { data, isLoading, isError } = useGetMeetingDegree({ meetingEnumId });
+
+  const openResetModal = () => {
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen}>
+        <CancellableModalContent
+          onConfirm={() => {
+            resetField("announcementTitle");
+            resetField("announcementContent");
+            close();
+          }}
+          onClose={close}
+        >
+          공고 템플릿에 수정사항이 있을 경우 모두 초기화됩니다.
+          <br />
+          ㄱㅊ?
+        </CancellableModalContent>
+      </Modal>
+    ));
+  };
+
+  useEffect(() => {
+    if (meetingEnumId !== MeetingEnum.divisionMeeting && data?.degree != null) {
+      const template = MeetingTemplate.defaultTemplate(
+        meetingEnumId,
+        data.degree,
+      );
+
+      resetField("announcementTitle", { defaultValue: template.title });
+      resetField("announcementContent", { defaultValue: template.content });
+    } else if (meetingEnumId === MeetingEnum.divisionMeeting) {
+      const template = MeetingTemplate.divisionMeetingTemplate();
+
+      resetField("announcementTitle", { defaultValue: template.title });
+      resetField("announcementContent", { defaultValue: template.content });
+    }
+  }, [meetingEnumId, data, resetField]);
+
+  const contentLength = announcementContent?.split(/\r\n|\r|\n/).length;
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <FormController
+        name="announcementTitle"
+        required
+        control={control}
+        renderItem={props => (
+          <TextInput {...props} label="제목" placeholder="" />
+        )}
+      />
+      <FormController
+        name="announcementContent"
+        required
+        control={control}
+        renderItem={props => (
+          <TextInput
+            {...props}
+            label="본문"
+            placeholder=""
+            area
+            style={{
+              height: contentLength ? contentLength * 25 : 100,
+              whiteSpace: "pre-line",
+            }}
+          />
+        )}
+      />
+      <AlignEnd>
+        <TextButton text="초기화" onClick={openResetModal} />
+      </AlignEnd>
+    </AsyncBoundary>
+  );
+};
+
+export default MeetingAnnouncementForm;

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
@@ -1,143 +1,38 @@
-import React, { useEffect, useMemo } from "react";
+import React from "react";
 
-import { ApiMee001RequestBody } from "@sparcs-clubs/interface/api/meeting/apiMee001";
-import { MeetingEnum } from "@sparcs-clubs/interface/common/enum/meeting.enum";
-import { overlay } from "overlay-kit";
-
-import { useFormContext } from "react-hook-form";
-import styled from "styled-components";
-
-import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
-import FormController from "@sparcs-clubs/web/common/components/FormController";
-import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
-import Modal from "@sparcs-clubs/web/common/components/Modal";
-import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
-import { MeetingTemplate } from "../constants/meetingTemplate";
-import useGetMeetingDegree from "../services/useGetMeetingDegree";
+import MeetingAnnouncementForm from "./MeetingAnnouncementForm";
 
 interface MeetingAnnouncementFrameProps {
   isTemplateVisible: boolean;
-  onReset?: (defaultValue: string) => void;
 }
-
-const AlignEnd = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`;
 
 const MeetingAnnouncementFrame: React.FC<MeetingAnnouncementFrameProps> = ({
   isTemplateVisible = false,
-  onReset = _ => {},
-}) => {
-  const formCtx = useFormContext<ApiMee001RequestBody>();
-  const { control, watch, setValue } = formCtx;
-
-  const meetingEnumId = watch("meetingEnumId");
-  const announcementTitle = watch("announcementTitle");
-  const announcementContent = watch("announcementContent");
-
-  const { data, isLoading, isError } = useGetMeetingDegree({ meetingEnumId });
-
-  const template = useMemo(() => {
-    if (meetingEnumId == null) return null;
-
-    if (meetingEnumId === MeetingEnum.divisionMeeting) {
-      return MeetingTemplate.divisionMeetingTemplate();
-    }
-    return MeetingTemplate.defaultTemplate(meetingEnumId, data?.degree);
-  }, [data, meetingEnumId]);
-
-  const openResetModal = () => {
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen}>
-        <CancellableModalContent
-          onConfirm={() => {
-            onReset(template?.content ?? "");
-            close();
-          }}
-          onClose={close}
+}) => (
+  <FlexWrapper direction="column" gap={40}>
+    <SectionTitle>최종 공고</SectionTitle>
+    <Card outline gap={32} style={{ marginLeft: 24 }}>
+      {!isTemplateVisible ? (
+        <Typography
+          fs={16}
+          lh={24}
+          fw="REGULAR"
+          color="GRAY.300"
+          style={{ textAlign: "center" }}
         >
-          공고 템플릿에 수정사항이 있을 경우 모두 초기화됩니다.
-          <br />
-          ㄱㅊ?
-        </CancellableModalContent>
-      </Modal>
-    ));
-  };
-
-  useEffect(() => {
-    if (
-      template != null &&
-      announcementTitle == null &&
-      announcementContent == null
-    ) {
-      setValue("announcementTitle", template.title, { shouldValidate: true });
-      setValue("announcementContent", template.content, {
-        shouldValidate: true,
-      });
-    }
-  }, [announcementContent, announcementTitle, setValue, template]);
-
-  const contentLength = announcementContent?.split(/\r\n|\r|\n/).length;
-
-  return (
-    <FlexWrapper direction="column" gap={40}>
-      <SectionTitle>최종 공고</SectionTitle>
-      <Card outline gap={32} style={{ marginLeft: 24 }}>
-        {!isTemplateVisible || template == null ? (
-          <Typography
-            fs={16}
-            lh={24}
-            fw="REGULAR"
-            color="GRAY.300"
-            style={{ textAlign: "center" }}
-          >
-            공고 템플릿을 생성해주세요
-          </Typography>
-        ) : (
-          <AsyncBoundary isLoading={isLoading} isError={isError}>
-            <FormController
-              name="announcementTitle"
-              required
-              control={control}
-              defaultValue={template?.title}
-              renderItem={props => (
-                <TextInput {...props} label="제목" placeholder="" />
-              )}
-            />
-            <FormController
-              name="announcementContent"
-              required
-              control={control}
-              defaultValue={template?.content}
-              renderItem={props => (
-                <TextInput
-                  {...props}
-                  label="본문"
-                  placeholder=""
-                  area
-                  style={{
-                    height: contentLength ? contentLength * 25 : 100,
-                    whiteSpace: "pre-line",
-                  }}
-                />
-              )}
-            />
-            <AlignEnd>
-              <TextButton text="초기화" onClick={openResetModal} />
-            </AlignEnd>
-          </AsyncBoundary>
-        )}
-      </Card>
-    </FlexWrapper>
-  );
-};
+          공고 템플릿을 생성해주세요
+        </Typography>
+      ) : (
+        <MeetingAnnouncementForm />
+      )}
+    </Card>
+  </FlexWrapper>
+);
 
 export default MeetingAnnouncementFrame;

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
@@ -88,57 +88,55 @@ const MeetingAnnouncementFrame: React.FC<MeetingAnnouncementFrameProps> = ({
   const contentLength = announcementContent?.split(/\r\n|\r|\n/).length;
 
   return (
-    <AsyncBoundary isLoading={isLoading} isError={isError}>
-      <FlexWrapper direction="column" gap={40}>
-        <SectionTitle>최종 공고</SectionTitle>
-        <Card outline gap={32} style={{ marginLeft: 24 }}>
-          {!isTemplateVisible || template == null ? (
-            <Typography
-              fs={16}
-              lh={24}
-              fw="REGULAR"
-              color="GRAY.300"
-              style={{ textAlign: "center" }}
-            >
-              공고 템플릿을 생성해주세요
-            </Typography>
-          ) : (
-            <>
-              <FormController
-                name="announcementTitle"
-                required
-                control={control}
-                defaultValue={template?.title}
-                renderItem={props => (
-                  <TextInput {...props} label="제목" placeholder="" />
-                )}
-              />
-              <FormController
-                name="announcementContent"
-                required
-                control={control}
-                defaultValue={template?.content}
-                renderItem={props => (
-                  <TextInput
-                    {...props}
-                    label="본문"
-                    placeholder=""
-                    area
-                    style={{
-                      height: contentLength ? contentLength * 25 : 100,
-                      whiteSpace: "pre-line",
-                    }}
-                  />
-                )}
-              />
-              <AlignEnd>
-                <TextButton text="초기화" onClick={openResetModal} />
-              </AlignEnd>
-            </>
-          )}
-        </Card>
-      </FlexWrapper>
-    </AsyncBoundary>
+    <FlexWrapper direction="column" gap={40}>
+      <SectionTitle>최종 공고</SectionTitle>
+      <Card outline gap={32} style={{ marginLeft: 24 }}>
+        {!isTemplateVisible || template == null ? (
+          <Typography
+            fs={16}
+            lh={24}
+            fw="REGULAR"
+            color="GRAY.300"
+            style={{ textAlign: "center" }}
+          >
+            공고 템플릿을 생성해주세요
+          </Typography>
+        ) : (
+          <AsyncBoundary isLoading={isLoading} isError={isError}>
+            <FormController
+              name="announcementTitle"
+              required
+              control={control}
+              defaultValue={template?.title}
+              renderItem={props => (
+                <TextInput {...props} label="제목" placeholder="" />
+              )}
+            />
+            <FormController
+              name="announcementContent"
+              required
+              control={control}
+              defaultValue={template?.content}
+              renderItem={props => (
+                <TextInput
+                  {...props}
+                  label="본문"
+                  placeholder=""
+                  area
+                  style={{
+                    height: contentLength ? contentLength * 25 : 100,
+                    whiteSpace: "pre-line",
+                  }}
+                />
+              )}
+            />
+            <AlignEnd>
+              <TextButton text="초기화" onClick={openResetModal} />
+            </AlignEnd>
+          </AsyncBoundary>
+        )}
+      </Card>
+    </FlexWrapper>
   );
 };
 

--- a/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
+++ b/packages/web/src/features/meeting/components/MeetingAnnouncementFrame.tsx
@@ -10,10 +10,12 @@ import MeetingAnnouncementForm from "./MeetingAnnouncementForm";
 
 interface MeetingAnnouncementFrameProps {
   isTemplateVisible: boolean;
+  isEditMode?: boolean;
 }
 
 const MeetingAnnouncementFrame: React.FC<MeetingAnnouncementFrameProps> = ({
   isTemplateVisible = false,
+  isEditMode = false,
 }) => (
   <FlexWrapper direction="column" gap={40}>
     <SectionTitle>최종 공고</SectionTitle>
@@ -29,7 +31,7 @@ const MeetingAnnouncementFrame: React.FC<MeetingAnnouncementFrameProps> = ({
           공고 템플릿을 생성해주세요
         </Typography>
       ) : (
-        <MeetingAnnouncementForm />
+        <MeetingAnnouncementForm isEditMode={isEditMode} />
       )}
     </Card>
   </FlexWrapper>

--- a/packages/web/src/features/meeting/components/MeetingInformationFrame.tsx
+++ b/packages/web/src/features/meeting/components/MeetingInformationFrame.tsx
@@ -82,8 +82,8 @@ const MeetingInformationFrame: React.FC<MeetingInformationFrameProps> = ({
     if (!isDivisionMeeting && timePattern.test(time)) {
       const [hour, minute] = time.split(":").map(part => +part);
       const newDate = new Date();
-      newDate.setHours(hour);
-      newDate.setMinutes(minute);
+      newDate.setUTCHours(hour);
+      newDate.setUTCMinutes(minute);
 
       setValue("startDate", newDate);
     }

--- a/packages/web/src/features/meeting/constants/meetingTemplate.ts
+++ b/packages/web/src/features/meeting/constants/meetingTemplate.ts
@@ -59,7 +59,7 @@ Date & Time : ${dateTime}
 Location : ${locationEn}
 
 - Precautions Related to Attendance -
-The students who is obligated to attend in this legislative is based on the registration of ${getFullSemester(now)} semester.
+The students who is obligated to attend in this legislative is based on the registration of ${getFullSemester(now, true)} semester.
 If the club representative is unable to attend, another delegate (with voting right) or deputy (without voting right) can also be admitted.
 
 Thank you.`;

--- a/packages/web/src/features/meeting/services/useCreateMeeting.ts
+++ b/packages/web/src/features/meeting/services/useCreateMeeting.ts
@@ -1,0 +1,34 @@
+import apiMee001, {
+  ApiMee001RequestBody,
+  ApiMee001ResponseCreated,
+} from "@sparcs-clubs/interface/api/meeting/apiMee001";
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+  UnexpectedAPIResponseError,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useCreateMeeting = () =>
+  useMutation<ApiMee001ResponseCreated, Error, { body: ApiMee001RequestBody }>({
+    mutationFn: async ({ body }): Promise<ApiMee001ResponseCreated> => {
+      const { data, status } = await axiosClientWithAuth.post(
+        apiMee001.url(),
+        body,
+      );
+
+      switch (status) {
+        case 201:
+          return apiMee001.responseBodyMap[201].parse(data);
+        default:
+          throw new UnexpectedAPIResponseError();
+      }
+    },
+  });
+
+export default useCreateMeeting;
+
+defineAxiosMock(mock => {
+  mock.onPost(apiMee001.url()).reply(() => [201, {}]);
+});

--- a/packages/web/src/features/meeting/services/useUpdateMeeting.ts
+++ b/packages/web/src/features/meeting/services/useUpdateMeeting.ts
@@ -27,6 +27,7 @@ const useUpdateMeeting = () =>
       );
 
       switch (status) {
+        case 200:
         case 201:
           return apiMee003.responseBodyMap[201].parse(data);
         default:

--- a/packages/web/src/utils/getSemester.ts
+++ b/packages/web/src/utils/getSemester.ts
@@ -1,15 +1,15 @@
 // month 동적처리 가능하면 수정하기
 export const getSemester = (month: number) => {
-  if (month in [3, 4, 5, 6]) {
+  if ([3, 4, 5, 6].includes(month)) {
     return { ko: "봄학기", en: "spring" };
   }
-  if (month in [7, 8]) {
+  if ([7, 8].includes(month)) {
     return { ko: "여름학기", en: "summer" };
   }
-  if (month in [9, 10, 11, 12]) {
+  if ([9, 10, 11, 12].includes(month)) {
     return { ko: "가을학기", en: "fall" };
   }
-  if (month in [1, 2]) {
+  if ([1, 2].includes(month)) {
     return { ko: "겨울학기", en: "winter" };
   }
   return undefined;
@@ -18,7 +18,7 @@ export const getSemester = (month: number) => {
 export const getFullSemester = (date?: Date, inEnglish: boolean = false) => {
   const targetDate = date ?? new Date();
   const year = targetDate.getFullYear();
-  const month = targetDate.getMonth();
+  const month = targetDate.getMonth() + 1;
 
   return `${year} ${inEnglish ? getSemester(month)?.en ?? "" : getSemester(month)?.ko ?? ""}`;
 };

--- a/packages/web/src/utils/getUserType.ts
+++ b/packages/web/src/utils/getUserType.ts
@@ -1,5 +1,13 @@
 import { ProfessorEnum } from "@sparcs-clubs/interface/common/enum/user.enum";
 
+export type UserType =
+  | "undergraduate"
+  | "master"
+  | "doctor"
+  | "executive"
+  | "professor"
+  | "employee";
+
 export const getUserType = (type: string) => {
   switch (type) {
     case "undergraduate":


### PR DESCRIPTION
# 요약 \*

It closes #1113 

# 참고사항
**의결기구 공고** 의 마지막 pr입니다! 
- 피그마 링크: 
https://www.figma.com/design/gm0BeqvuY5dsA86XyRgEc3/%ED%95%99%EC%88%A0%ED%98%91%EB%A0%A5-02.-%5B%EB%8F%99%EC%97%B0%ED%98%91%EB%A0%A5%EC%82%AC%EC%97%85%5D?node-id=5903-56832

의결기구 > 공고 와 관련된 **모든 사항** 한번씩 확인 부탁드립니다. (페이지 ui, 라우팅, api 연결 등등 이상한 곳 없는지)

# 스크린샷
![image](https://github.com/user-attachments/assets/c6710fb3-06df-45f6-ab94-34918288cbed)


# 이후 Task \*

- [ ] 생성, 수정 페이지 집행부원만 가능하도록 변경 (삭제 기능도?)
- [x] 공고 create 페이지에서는 초기에 meetingEnumId가 없어서 get degree api 호출하다가 에러 발생!
- [x] 전동대회 템플릿 space가 두개 들어감
- [x] 템플릿 본문에 X차가 아닌 0차로 들어감
- [x] 미팅 타입 변경 시 템플릿 변경 안됨
- [ ] 공고 생성 후 바로 생성된 공고 상세 페이지로 이동할 수 있도록 수정 (백엔드 api 수정 필요)
- [x] 시간 utc 확인
- [x] 전동대회 제목 차수 대입 안되는 것 같음
- [x] 수정페이지 저장 클릭 시 /meeting으로 이동하도록 변경
- [x] 수정 페이지 들어가면 "시간" 안 채워져 있음 (이건 dateinput 볼 때 같이 보면 될듯) --> dateinput 브랜치에서 처리 예정
- [ ] 삭제 API 404 not found 나옴 **>> 확인 결과 백엔드 controller랑 interface api url 싱크가 안 맞음! 근데 api url 바꾸면 200 뜨는데 실제 db에서 삭제는 안 되는 것 같음**
- [x] 초기에 템플릿 생성 안 되었는데 저장 버튼 활성화 되어 있음
- [x] 생성, 수정, 삭제 실패 시 모달창 띄우기. 
- [ ] 현재 데브 모드에서 분과회의 생성 잘 안됨 (백엔드 이슈 같음--> 분과회의는 location 정보 필요없는데 거기서 validation 실패하는듯..?)

<img width="474" alt="image" src="https://github.com/user-attachments/assets/ccaea226-1262-4269-b1a2-ef2e16435b8d">

