### PR TITLE
Fix regular member classification /executive/register-member/[id]

### DIFF
--- a/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
@@ -47,9 +47,16 @@ const columns = [
     id: "isRegularMemberRegistration",
     header: "구분",
     cell: info => {
-      if (info.getValue()) return <Tag color="BLUE">정회원</Tag>;
-
+      if (info.row.original.student.studentNumber % 10000 < 2000)
+        return <Tag color="BLUE">정회원</Tag>;
+      if (info.row.original.student.studentNumber % 10000 < 6000)
+        return <Tag color="GRAY">준회원</Tag>;
+      if (info.row.original.student.studentNumber % 10000 < 7000)
+        return <Tag color="BLUE">정회원</Tag>;
       return <Tag color="GRAY">준회원</Tag>;
+
+      // if (info.getValue()) return <Tag color="BLUE">정회원</Tag>;
+      // return <Tag color="GRAY">준회원</Tag>;
     },
     size: 220,
   }),


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1131

회원 구분이 정회원인지 준회원인지를 학번을 놓고 구분을 해야 합니다.
그런데 한 대학원생 분의 구분이 정회원으로 되어 있어요

코드 구조 상 디비에서 정회원/준회원 여부를 boolean으로 가져와서 그대로 나타내기만 하면 되는데 디비에 들어있는 값에 문제가 있는 것 같아요

**일단은 프론트에 로직을 강제로 끼워 넣은 상태예요 디비에서 가져온 값 안쓰도록(?!)**

월요일에 학교 가서 디비 열어보고 코드 수정하겠습니다 

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
