### PR TITLE
Add label to radio & Add children to info

### DIFF
--- a/packages/web/src/common/components/Info.tsx
+++ b/packages/web/src/common/components/Info.tsx
@@ -17,6 +17,13 @@ const InfoTextWrapper = styled.div`
   gap: 8px;
 `;
 
+const InfoChildWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  margin-left: 28px;
+`;
+
 const InfoInner = styled.div`
   display: flex;
   flex-direction: column;
@@ -56,17 +63,24 @@ const IconWrapper = styled.div`
   align-items: center;
 `;
 
-const Info: React.FC<InfoProps> = ({ text, children = null }) => (
-  <InfoInner>
-    <InfoTextWrapper>
-      <IconWrapper>
-        <ResponsiveIcon type="info_outlined" size={20} />
-      </IconWrapper>
-      <ResponsiveTypography fw="REGULAR">{text}</ResponsiveTypography>
-    </InfoTextWrapper>
-
-    {children}
-  </InfoInner>
-);
+const Info: React.FC<InfoProps> = ({ text, children = null }) => {
+  const transformedChildren = React.Children.map(children, child => {
+    if (React.isValidElement(child) && child.type === Typography) {
+      return <ResponsiveTypography {...child.props} />;
+    }
+    return child;
+  });
+  return (
+    <InfoInner>
+      <InfoTextWrapper>
+        <IconWrapper>
+          <ResponsiveIcon type="info_outlined" size={20} />
+        </IconWrapper>
+        <ResponsiveTypography>{text}</ResponsiveTypography>
+      </InfoTextWrapper>
+      <InfoChildWrapper>{transformedChildren}</InfoChildWrapper>
+    </InfoInner>
+  );
+};
 
 export default Info;

--- a/packages/web/src/common/components/Info.tsx
+++ b/packages/web/src/common/components/Info.tsx
@@ -8,10 +8,18 @@ import Icon from "./Icon";
 
 interface InfoProps {
   text: string;
+  children?: React.ReactNode;
 }
+
+const InfoTextWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+`;
 
 const InfoInner = styled.div`
   display: flex;
+  flex-direction: column;
   padding: 12px 16px;
   align-items: flex-start;
   gap: 8px;
@@ -48,12 +56,16 @@ const IconWrapper = styled.div`
   align-items: center;
 `;
 
-const Info: React.FC<InfoProps> = ({ text }) => (
+const Info: React.FC<InfoProps> = ({ text, children = null }) => (
   <InfoInner>
-    <IconWrapper>
-      <ResponsiveIcon type="info_outlined" size={20} />
-    </IconWrapper>
-    <ResponsiveTypography fw="REGULAR">{text}</ResponsiveTypography>
+    <InfoTextWrapper>
+      <IconWrapper>
+        <ResponsiveIcon type="info_outlined" size={20} />
+      </IconWrapper>
+      <ResponsiveTypography fw="REGULAR">{text}</ResponsiveTypography>
+    </InfoTextWrapper>
+
+    {children}
   </InfoInner>
 );
 

--- a/packages/web/src/common/components/Radio/index.tsx
+++ b/packages/web/src/common/components/Radio/index.tsx
@@ -5,12 +5,15 @@ import React, { cloneElement, ReactElement, ReactNode } from "react";
 import isPropValid from "@emotion/is-prop-valid";
 import styled from "styled-components";
 
+import Label from "@sparcs-clubs/web/common/components/FormLabel";
+
 import RadioOption, { type RadioOptionProps } from "./RadioOption";
 
 type RadioProps<T extends string> = {
   children: ReactElement<RadioOptionProps<T>>[];
   value: T;
   onChange: (value: T) => void;
+  label?: string;
   direction?: "row" | "column";
   gap?: string;
 };
@@ -20,6 +23,13 @@ function isRadioOptionElement<T extends string>(
 ): child is ReactElement<RadioOptionProps<T>> {
   return React.isValidElement(child) && "value" in child.props;
 }
+
+const RadioWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+`;
 
 const StyledRadioInner = styled.div.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
@@ -37,6 +47,7 @@ const Radio = <T extends string>({
   gap = "12px",
   value,
   onChange,
+  label = "",
   children,
 }: RadioProps<T>) => {
   const handleChange = (newValue: T) => {
@@ -46,17 +57,20 @@ const Radio = <T extends string>({
   };
 
   return (
-    <StyledRadioInner direction={direction} gap={gap}>
-      {React.Children.map(children, child => {
-        if (isRadioOptionElement<T>(child)) {
-          return cloneElement(child, {
-            checked: child.props.value === value,
-            onClick: () => handleChange(child.props.value),
-          });
-        }
-        return child;
-      })}
-    </StyledRadioInner>
+    <RadioWrapper>
+      {label && <Label>{label}</Label>}
+      <StyledRadioInner direction={direction} gap={gap}>
+        {React.Children.map(children, child => {
+          if (isRadioOptionElement<T>(child)) {
+            return cloneElement(child, {
+              checked: child.props.value === value,
+              onClick: () => handleChange(child.props.value),
+            });
+          }
+          return child;
+        })}
+      </StyledRadioInner>
+    </RadioWrapper>
   );
 };
 Radio.Option = RadioOption;

--- a/packages/web/src/features/printing-business/component/PrintingBusinessForm/_atomic/BinaryRadio.tsx
+++ b/packages/web/src/features/printing-business/component/PrintingBusinessForm/_atomic/BinaryRadio.tsx
@@ -22,18 +22,6 @@ const BinaryRadioInner = styled.div`
   gap: 16px;
 `;
 
-const StyledLabel = styled.label`
-  display: block;
-  margin: 0 2px;
-  gap: 10px;
-  font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-size: 16px;
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
-  color: ${({ theme }) => theme.colors.BLACK};
-  line-height: 20px;
-  text-align: left;
-`;
-
 const BinaryRadio: React.FC<BinaryRadioProps> = ({
   label = undefined,
   firstOptionLabel,
@@ -42,8 +30,8 @@ const BinaryRadio: React.FC<BinaryRadioProps> = ({
   setIsFirstOptionSelected,
 }) => (
   <BinaryRadioInner>
-    <StyledLabel>{label}</StyledLabel>
     <Radio
+      label={label}
       value={String(isFirstOptionSelected)}
       onChange={(boolStr: string) =>
         setIsFirstOptionSelected(JSON.parse(boolStr))

--- a/packages/web/src/features/rental-business/components/Rentals/Vacuum.tsx
+++ b/packages/web/src/features/rental-business/components/Rentals/Vacuum.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Radio from "@sparcs-clubs/web/common/components/Radio";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
 import {
   RentalFrameProps,
   RentalLimitProps,
@@ -26,10 +25,8 @@ const Vacuum: React.FC<RentalLimitProps> = ({
 
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>
-      <Typography fs={16} lh={20} fw="MEDIUM">
-        청소기 종류
-      </Typography>
       <Radio
+        label="청소기 종류"
         value={rental?.vacuum as string}
         onChange={value =>
           setRental({


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #84 

![image](https://github.com/user-attachments/assets/91629f4f-7858-4c8d-af01-3ca72c176e9f)

- radio 위에 label 추가 가능하도록 수정
- info에 텍스트가 아닌 다른 것을 추가할 수 있도록 수정

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/e9c06bd5-2c6e-4bf5-9535-8638b3917394)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
