### PR TITLE
Fix club member search filter

### DIFF
--- a/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { ApiClb010ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb010";
 import {
@@ -90,11 +90,17 @@ const AllMemberList: React.FC<AllMemberListProps> = ({
     semesterId: semester.id,
   });
 
-  const searchedMembers = members.members.filter(member =>
-    member.name.startsWith(searchText),
+  const [searchedMembers, setSearchedMembers] = useState(
+    members.members.filter(member => member.name.startsWith(searchText)),
   );
 
   const memberCount = searchedMembers.length;
+
+  useEffect(() => {
+    setSearchedMembers(
+      members.members.filter(member => member.name.startsWith(searchText)),
+    );
+  }, [members.members, searchText]);
 
   const table = useReactTable({
     columns,

--- a/packages/web/src/features/manage-club/members/frames/AllMemberListFrame.tsx
+++ b/packages/web/src/features/manage-club/members/frames/AllMemberListFrame.tsx
@@ -14,8 +14,6 @@ import MemberSearchAndFilter from "../components/MemberSearchAndFilter";
 import { useGetClubSemesters } from "../services/getClubSemesters";
 import { SemesterProps } from "../types/semesterList";
 
-import { mockSemesterMembers } from "./_mock/mockMembers";
-
 interface AllMemberListFrameProps {
   clubId: number;
 }
@@ -86,17 +84,14 @@ const AllMemberListFrame: React.FC<AllMemberListFrameProps> = ({ clubId }) => {
           ) : (
             selectedSemesters
               .sort((a, b) => b.id - a.id) // 최신 학기부터 정렬(ID가 클수록 최신 학기라고 가정)
-              .map(
-                semester =>
-                  mockSemesterMembers.members.length > 0 && (
-                    <AllMemberList
-                      key={semester.id}
-                      semester={semester}
-                      clubId={clubId}
-                      searchText={searchText}
-                    />
-                  ),
-              )
+              .map(semester => (
+                <AllMemberList
+                  key={semester.id}
+                  semester={semester}
+                  clubId={clubId}
+                  searchText={searchText}
+                />
+              ))
           )}
         </AllMemberListWrapper>
       </AsyncBoundary>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1154 

/manage-club/members 페이지의 무한로딩 현상 수정

AllMemberList 컴포넌트에서 검색창에 입력한 회원 목록을 필터링할 때 useEffect를 쓰게 해서 해결했습니다

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
