### PR TITLE
Show current semester club list on /manage-club

### DIFF
--- a/packages/web/src/features/manage-club/frames/ManageClubFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/ManageClubFrame.tsx
@@ -13,8 +13,9 @@ import NoManageClub from "@sparcs-clubs/web/common/frames/NoManageClub";
 // import ActivityManageFrame from "@sparcs-clubs/web/features/manage-club/frames/ActivityManageFrame";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import InfoManageFrame from "@sparcs-clubs/web/features/manage-club/frames/InfoManageFrame";
-import MembersManageFrame from "@sparcs-clubs/web/features/manage-club/frames/MembersManageFrame";
+import MemberManageFrame from "@sparcs-clubs/web/features/manage-club/frames/MemberManageFrame";
 // import ServiceManageFrame from "@sparcs-clubs/web/features/manage-club/frames/ServiceManageFrame";
+import RegistrationManageFrame from "@sparcs-clubs/web/features/manage-club/frames/RegistrationManageFrame";
 import { useCheckManageClub } from "@sparcs-clubs/web/hooks/checkManageClub";
 
 const ManageClubFrame: React.FC = () => {
@@ -65,7 +66,12 @@ const ManageClubFrame: React.FC = () => {
         isRepresentative={delegate === ClubDelegateEnum.Representative}
       />
       {/* <ActivityManageFrame /> */}
-      {isRegistrationPeriod && <MembersManageFrame />}
+      {isRegistrationPeriod ? (
+        <RegistrationManageFrame />
+      ) : (
+        <MemberManageFrame />
+      )}
+
       {/* <ServiceManageFrame /> */}
     </FlexWrapper>
   );

--- a/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+
+import { ApiClb002ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb002";
+import { ApiClb010ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb010";
+import { ApiClb015ResponseOk } from "@sparcs-clubs/interface/api/club/endpoint/apiClb015";
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
+import Table from "@sparcs-clubs/web/common/components/Table";
+import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
+
+import { useGetClubMembers } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMembers";
+import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
+
+const columnHelper =
+  createColumnHelper<ApiClb010ResponseOk["members"][number]>();
+
+const columns = [
+  columnHelper.accessor("studentNumber", {
+    id: "studentNumber",
+    header: "학번",
+    cell: info => info.getValue(),
+    size: 20,
+  }),
+  columnHelper.accessor("name", {
+    id: "name",
+    header: "신청자",
+    cell: info => info.getValue(),
+    size: 20,
+  }),
+  columnHelper.accessor("phoneNumber", {
+    id: "phoneNumber",
+    header: "전화번호",
+    cell: info => info.getValue(),
+    size: 20,
+    enableSorting: false,
+  }),
+  columnHelper.accessor("email", {
+    id: "email",
+    header: "이메일",
+    cell: info => info.getValue(),
+    size: 20,
+    enableSorting: false,
+  }),
+  columnHelper.display({
+    id: "remarks",
+    header: "비고",
+    cell: () => " ",
+    size: 20,
+    enableSorting: false,
+  }),
+];
+
+const MemberManageFrame: React.FC = () => {
+  // 자신이 대표자인 동아리 clubId 가져오기
+  const { data: idData } = useGetMyManageClub() as {
+    data: ApiClb015ResponseOk;
+    isLoading: boolean;
+  };
+
+  const {
+    data: membersData,
+    isLoading: memberIsLoading,
+    isError: memberIsError,
+  } = useGetClubMembers({
+    clubId: idData.clubId,
+    semesterId: 16, // TODO: 현재 학기를 받아와서 수정
+  });
+
+  const membersCount = membersData.members.length;
+
+  const table = useReactTable({
+    columns,
+    data: membersData.members,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  // 자신이 대표자인 동아리 clubId에 해당하는 동아리 세부정보 가져오기
+  const {
+    data: clubData,
+    isLoading: clubIsLoading,
+    isError: clubIsError,
+  } = useGetClubDetail(idData.clubId.toString()) as {
+    data: ApiClb002ResponseOK;
+    isLoading: boolean;
+    isError: boolean;
+  };
+
+  const title = `2024년 가을학기(총 ${membersCount}명)`;
+  // TODO: 학기 받아올 수 있도록 수정
+
+  return (
+    <FoldableSectionTitle title="회원 명단">
+      <AsyncBoundary
+        isLoading={clubIsLoading || memberIsLoading}
+        isError={clubIsError || memberIsError}
+      >
+        {clubData && membersData && (
+          <FlexWrapper direction="column" gap={16}>
+            <MoreDetailTitle
+              title={title}
+              moreDetail="전체 보기"
+              moreDetailPath="/manage-club/members"
+            />
+            <Table table={table} />
+          </FlexWrapper>
+        )}
+      </AsyncBoundary>
+    </FoldableSectionTitle>
+  );
+};
+
+export default MemberManageFrame;

--- a/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
@@ -18,7 +18,7 @@ import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club
 
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
 
-const MembersManageFrame: React.FC = () => {
+const RegistrationManageFrame: React.FC = () => {
   // 자신이 대표자인 동아리 clubId 가져오기
   const { data: idData } = useGetMyManageClub() as {
     data: ApiClb015ResponseOk;
@@ -119,4 +119,4 @@ const MembersManageFrame: React.FC = () => {
   );
 };
 
-export default MembersManageFrame;
+export default RegistrationManageFrame;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1156 

회원 등록 기간 --> 회원 등록 명단 표 출력

회원 등록 기간 X --> 현재 학기 회원 명단 표 출력

현재 학기를 받아올 수 있는 api가 없어서 임시로 semester.id를 16(2024 가을)으로 지정해서 받아왔는데 추후 수정이 필요합니다

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/12e28a52-d6da-4bd1-82c8-0dda133066d4)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
