### PR TITLE
fix: set min-width of DateRangeInput resolve infinite update

### DIFF
--- a/packages/web/src/common/components/Forms/DateRangeInput.tsx
+++ b/packages/web/src/common/components/Forms/DateRangeInput.tsx
@@ -23,6 +23,7 @@ interface DateRangeInputProps
 }
 
 const DateRangeInputErrorFrameInner = styled.div`
+  min-width: 300px;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoSecondFrame.tsx
+++ b/packages/web/src/features/activity-certificate/frames/ActivityCertificateInfoFrame/ActivityCertificateInfoSecondFrame.tsx
@@ -60,11 +60,13 @@ const InputFrameInner = styled.div`
 `;
 
 const DescriptionInputFrameInner = styled.div`
-  width: 100%;
+  /* width: 100%; */
   justify-content: flex-start;
   align-items: center;
   gap: 12px;
   display: flex;
+  flex: 1;
+  min-width: 300px;
 `;
 
 const ActivityCertificateInfoSecondFrame: React.FC<

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
@@ -81,7 +81,7 @@ const ActivityReportEditFrame: React.FC<{ id: string }> = ({ id }) => {
         { startTerm: parsedStartDate, endTerm: parsedEndDate },
       ]);
     }
-  }, [duration, handleFormChange]);
+  }, [duration]);
 
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
# 요약 \*

set min-width of DateRangeInput to 300px and resolve infinite update bug of date input in ActivityReportEditFrame

It closes #1162

# 스크린샷

<img width="1440" alt="스크린샷 2024-10-09 오후 11 09 44" src="https://github.com/user-attachments/assets/df254464-9f2b-47ff-b61e-23343da8c104">


# 이후 Task \*

- 없음
