### PR TITLE
update apiAcf002 findClubActivities

### DIFF
--- a/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
+++ b/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
@@ -11,6 +11,9 @@ import apiAcf007 from "@sparcs-clubs/interface/api/activity-certificate/endpoint
 
 import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
 
+import { Student } from "@sparcs-clubs/api/common/util/decorators/method-decorator";
+import { GetStudent } from "@sparcs-clubs/api/common/util/decorators/param-decorator";
+
 import { ActivityCertificateService } from "../service/activity-certificate.service";
 
 import type {
@@ -37,11 +40,16 @@ export class ActivityCertificateController {
     return {};
   }
 
+  @Student()
   @Get("/student/activity-certificates/club-history")
   @UsePipes(new ZodPipe(apiAcf002))
-  async getStudentActivityCertificatesClubHistory(): Promise<ApiAcf002ResponseOk> {
+  async getStudentActivityCertificatesClubHistory(
+    @GetStudent() user: GetStudent,
+  ): Promise<ApiAcf002ResponseOk> {
     const clubHistory =
-      await this.activityCertificateService.getStudentActivityCertificatesClubHistory();
+      await this.activityCertificateService.getStudentActivityCertificatesClubHistory(
+        { stduentId: user.id },
+      );
     return clubHistory;
   }
 

--- a/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
+++ b/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
@@ -48,7 +48,7 @@ export class ActivityCertificateController {
   ): Promise<ApiAcf002ResponseOk> {
     const clubHistory =
       await this.activityCertificateService.getStudentActivityCertificatesClubHistory(
-        { stduentId: user.id },
+        { studentId: user.id },
       );
     return clubHistory;
   }

--- a/packages/api/src/feature/activity-certificate/service/activity-certificate.service.ts
+++ b/packages/api/src/feature/activity-certificate/service/activity-certificate.service.ts
@@ -36,11 +36,11 @@ export class ActivityCertificateService {
     });
   }
 
-  async getStudentActivityCertificatesClubHistory() {
+  async getStudentActivityCertificatesClubHistory(param: {
+    studentId: number;
+  }) {
     const clubHistory =
-      await this.clubPublicService.getClubBelongDurationOfStudent({
-        studentId: 1,
-      }); // TODO: 실제 studentId 적용
+      await this.clubPublicService.getClubBelongDurationOfStudent(param); // TODO: 실제 studentId 적용
     return clubHistory;
   }
 

--- a/packages/api/src/feature/club/repository/club.repository.ts
+++ b/packages/api/src/feature/club/repository/club.repository.ts
@@ -193,8 +193,7 @@ export default class ClubRepository {
       id: number;
       name_kr: string;
       name_en: string;
-      startMonth: Date;
-      endMonth: Date;
+      dateRange: { startMonth: Date; endMonth: Date }[];
     }[];
   }> {
     const clubActivities = await this.db
@@ -211,7 +210,58 @@ export default class ClubRepository {
           endMonth: row.club_student_t.endTerm,
         })),
       );
-    return { clubs: clubActivities };
+
+    const groupedActivities = clubActivities.reduce(
+      (acc, activity) => {
+        const {
+          id,
+          name_kr: nameKr,
+          name_en: nameEn,
+          startMonth,
+          endMonth,
+        } = activity;
+
+        if (!acc[id]) {
+          Object.assign(acc[id], {
+            id,
+            name_kr: nameKr,
+            name_en: nameEn,
+            dateRange: [],
+          });
+        }
+
+        let updated = false;
+        const { dateRange } = acc[id];
+
+        for (let i = 0; i < dateRange.length; i += 1) {
+          const dates = dateRange[i];
+
+          if (
+            startMonth.getTime() - dates.endMonth.getTime() ===
+            24 * 60 * 60 * 1000
+          ) {
+            dates.endMonth = endMonth;
+            updated = true;
+            break;
+          }
+        }
+
+        if (!updated) {
+          acc[id].dateRange.push({ startMonth, endMonth });
+        }
+
+        return acc;
+      },
+      {} as {
+        [key: number]: {
+          id: number;
+          name_kr: string;
+          name_en: string;
+          dateRange: { startMonth: Date; endMonth: Date | null }[];
+        };
+      },
+    );
+    return { clubs: Object.values(groupedActivities) };
   }
 
   async findClubName(

--- a/packages/api/src/feature/club/repository/club.repository.ts
+++ b/packages/api/src/feature/club/repository/club.repository.ts
@@ -193,7 +193,7 @@ export default class ClubRepository {
       id: number;
       name_kr: string;
       name_en: string;
-      dateRange: { startMonth: Date; endMonth: Date }[];
+      dateRange: { startMonth: Date; endMonth: Date | null }[];
     }[];
   }> {
     const clubActivities = await this.db

--- a/packages/interface/src/api/activity-certificate/endpoint/apiAcf002.ts
+++ b/packages/interface/src/api/activity-certificate/endpoint/apiAcf002.ts
@@ -24,8 +24,9 @@ const responseBodyMap = {
         id: z.number().int(),
         name_kr: zClubName,
         name_en: zClubName,
-        startMonth: z.date(),
-        endMonth: z.date(),
+        dateRange: z.array(
+          z.object({ startMonth: z.date(), endMonth: z.date().optional() }),
+        ),
       }),
     ),
   }),
@@ -51,8 +52,8 @@ type ApiAcf002ResponseOk = z.infer<(typeof apiAcf002.responseBodyMap)[200]>;
 export default apiAcf002;
 
 export type {
+  ApiAcf002RequestBody,
   ApiAcf002RequestParam,
   ApiAcf002RequestQuery,
-  ApiAcf002RequestBody,
   ApiAcf002ResponseOk,
 };


### PR DESCRIPTION
# 요약 \*

It closes #1181 

기존 반환 데이터: 
- {id: number, name_kr: string, name_en: string, startMonth: Date, endMonth: Date | null} 의 타입으로 반환하였음
- 예시: [{id: 1, name_kr: '동아리1', name_en: 'club1', startMonth: 2024.04.28, endMonth: 2024. 05.27}, {id: 1, name_kr: '동아리1', name_en: '동아리2', startMonth: 2024.05.28, endMonth: 2024. 06.27}, {id: 2, name_kr: '동아리2', name_en: 'club2', startMonth: 2024.09.01, endMonth: 2024. 10.27}]

수정 후 반환 데이터:
- {id: number, name_kr: string, name_en: string, dateRange: Array<{startMonth: Date, endMonth: Date | null}>} 의 타입으로 반환
- 예시: [{id: 1, name_kr: '동아리1', name_en: 'club1', startMonth: 2024.04.28, endMonth: 2024. 06.27}, {id: 2, name_kr: '동아리2', name_en: 'club2', startMonth: 2024.09.01, endMonth: 2024. 10.27}]


# 이후 Task \*
- 없음
