### PR TITLE
1184 fix findclubactivities object assign issue

### DIFF
--- a/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
+++ b/packages/api/src/feature/activity-certificate/controller/activity-certificate.controller.ts
@@ -48,7 +48,7 @@ export class ActivityCertificateController {
   ): Promise<ApiAcf002ResponseOk> {
     const clubHistory =
       await this.activityCertificateService.getStudentActivityCertificatesClubHistory(
-        { studentId: user.id },
+        { studentId: user.studentId },
       );
     return clubHistory;
   }

--- a/packages/api/src/feature/club/repository/club.repository.ts
+++ b/packages/api/src/feature/club/repository/club.repository.ts
@@ -20,6 +20,7 @@ import {
   ProfessorT,
   Student,
 } from "@sparcs-clubs/api/drizzle/schema/user.schema";
+
 import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import type { ApiClb001ResponseOK } from "@sparcs-clubs/interface/api/club/endpoint/apiClb001";
@@ -193,7 +194,7 @@ export default class ClubRepository {
       id: number;
       name_kr: string;
       name_en: string;
-      dateRange: { startMonth: Date; endMonth: Date | null }[];
+      dateRange: { startMonth: Date; endMonth: Date | undefined }[];
     }[];
   }> {
     const clubActivities = await this.db
@@ -221,13 +222,15 @@ export default class ClubRepository {
           endMonth,
         } = activity;
 
-        if (!acc[id]) {
-          Object.assign(acc[id], {
+        const updatedAcc = { ...acc };
+        if (!updatedAcc[id]) {
+          updatedAcc[id] = {
             id,
             name_kr: nameKr,
             name_en: nameEn,
-            dateRange: [],
-          });
+            dateRange: [{ startMonth, endMonth }],
+          };
+          return updatedAcc;
         }
 
         let updated = false;
@@ -257,7 +260,7 @@ export default class ClubRepository {
           id: number;
           name_kr: string;
           name_en: string;
-          dateRange: { startMonth: Date; endMonth: Date | null }[];
+          dateRange: { startMonth: Date; endMonth: Date | undefined }[];
         };
       },
     );


### PR DESCRIPTION
# 요약 \*

It closes #1184 

1. acf002 > findClubActivities 함수에서 object assigning 과정에서 에러 발생!
알고보니 object가 null이거나 undefined인 경우에는 Object.assign 쓰면 안됨.. (사실 acc[id] = {} 이렇게 바로 하려다가 lint 에러 나길래 object.assign 한거라 다시 원래대로 돌려놓고 object 복사해서 사용하는 방법으로 lint 에러 해결함)

2. acf002 controller에 Student() annotation 붙일 때 studentId param을 user.studentId 가 아닌 user.id로 넘겨줘서 해당 부분 수정함


# 이후 Task \*

- 없음
