### PR TITLE
Modify meeting.schema.ts

### DIFF
--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -1,7 +1,7 @@
 import {
   boolean,
   datetime,
-  // foreignKey,
+  foreignKey,
   int,
   mysqlTable,
   text,
@@ -17,7 +17,7 @@ export const MeetingRoleEnum = mysqlTable("meeting_role_enum", {
   id: int("id").primaryKey(),
   name: varchar("name", { length: 30 }).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   deletedAt: timestamp("deleted_at"),
 });
 
@@ -26,26 +26,34 @@ export const MeetingAnnouncement = mysqlTable("meeting_announcement", {
   announcementTitle: varchar("title", { length: 255 }).notNull(),
   announcementContent: text("content").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   deletedAt: timestamp("deleted_at"),
 });
 
-export const Meeting = mysqlTable("meeting", {
-  id: int("id").autoincrement().primaryKey(),
-  announcementId: int("meeting_announcement_id").references(
-    () => MeetingAnnouncement.id,
-  ),
-  meetingEnumId: int("meeting_type_enum").notNull(),
-  isRegular: boolean("is_regular_meeting").notNull(),
-  location: varchar("location_kr", { length: 255 }),
-  locationEn: varchar("location_en", { length: 255 }),
-  startDate: datetime("start_datetime").notNull(),
-  endDate: datetime("end_datetime"),
-  tag: varchar("meeting_group_tag", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
+export const Meeting = mysqlTable(
+  "meeting",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    announcementId: int("meeting_announcement_id"),
+    meetingEnumId: int("meeting_type_enum").notNull(),
+    isRegular: boolean("is_regular_meeting").notNull(),
+    location: varchar("location_kr", { length: 255 }),
+    locationEn: varchar("location_en", { length: 255 }),
+    startDate: datetime("start_datetime").notNull(),
+    endDate: datetime("end_datetime"),
+    tag: varchar("meeting_group_tag", { length: 255 }).notNull().unique(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  table => ({
+    meetingMeetingAnnouncementIdFk: foreignKey({
+      name: "meeting_announcement_id_fk",
+      columns: [table.announcementId],
+      foreignColumns: [MeetingAnnouncement.id],
+    }),
+  }),
+);
 
 export const MeetingAgenda = mysqlTable("meeting_agenda", {
   id: int("id").autoincrement().primaryKey(),
@@ -58,7 +66,7 @@ export const MeetingAgenda = mysqlTable("meeting_agenda", {
   isEditableRepresentative: boolean("is_editable_representative").notNull(),
   isEditableSelf: boolean("is_editable_self").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   deletedAt: timestamp("deleted_at"),
 });
 
@@ -66,93 +74,158 @@ export const MeetingAgendaContent = mysqlTable("meeting_agenda_content", {
   id: int("id").autoincrement().primaryKey(),
   content: text("content").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   deletedAt: timestamp("deleted_at"),
 });
 
-export const MeetingAttendanceDay = mysqlTable("meeting_attendance_day", {
-  id: int("id").autoincrement().primaryKey(),
-  meetingId: int("meeting_id")
-    .references(() => Meeting.id)
-    .notNull(),
-  meetingRoleEnum: int("meeting_role_enum")
-    .references(() => MeetingRoleEnum.id)
-    .notNull(),
-  whichClubId: int("which_club_id").references(() => Club.id),
-  whichDivisionId: int("which_division_id").references(() => Division.id),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
+export const MeetingAttendanceDay = mysqlTable(
+  "meeting_attendance_day",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    meetingId: int("meeting_id").notNull(),
+    meetingRoleEnum: int("meeting_role_enum").notNull(),
+    whichClubId: int("which_club_id").references(() => Club.id),
+    whichDivisionId: int("which_division_id").references(() => Division.id),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  table => ({
+    meetingMeetingAttendanceDayIdFk: foreignKey({
+      name: "meeting_meeting_attendance_day_id_fk",
+      columns: [table.meetingId],
+      foreignColumns: [Meeting.id],
+    }),
+    meetingAttendanceDayRoleEnumFk: foreignKey({
+      name: "meeting_attendance_day_role_enum_fk",
+      columns: [table.meetingRoleEnum],
+      foreignColumns: [MeetingRoleEnum.id],
+    }),
+  }),
+);
 
-export const MeetingAttendanceTimeT = mysqlTable("meeting_attendance_time_t", {
-  id: int("id").autoincrement().primaryKey(),
-  meetingId: int("meeting_id")
-    .references(() => Meeting.id)
-    .notNull(),
-  userId: int("user_id")
-    .references(() => User.id)
-    .notNull(),
-  startTerm: datetime("start_term").notNull(),
-  endTerm: datetime("end_term"),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
+export const MeetingAttendanceTimeT = mysqlTable(
+  "meeting_attendance_time_t",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    meetingId: int("meeting_id")
+      .references(() => Meeting.id)
+      .notNull(),
+    userId: int("user_id")
+      .references(() => User.id)
+      .notNull(),
+    startTerm: datetime("start_term").notNull(),
+    endTerm: datetime("end_term"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  table => ({
+    meetingMeetingAttendanceTimeTIdFk: foreignKey({
+      name: "meeting_meeting_attendance_time_t_id_fk",
+      columns: [table.meetingId],
+      foreignColumns: [Meeting.id],
+    }),
+    userMeetingAttendanceTimeTIdFk: foreignKey({
+      name: "user_meeting_attendance_time_t_id_fk",
+      columns: [table.userId],
+      foreignColumns: [User.id],
+    }),
+  }),
+);
 
 export const MeetingAgendaVote = mysqlTable("meeting_agenda_vote", {
   id: int("id").autoincrement().primaryKey(),
   title: varchar("title", { length: 255 }).notNull(),
   description: text("description").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   deletedAt: timestamp("deleted_at"),
 });
 
-export const MeetingVoteChoice = mysqlTable("meeting_vote_choice", {
-  id: int("id").autoincrement().primaryKey(),
-  voteId: int("vote_id")
-    .references(() => MeetingAgendaVote.id)
-    .notNull(),
-  choice: varchar("choice", { length: 255 }).notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
+export const MeetingVoteChoice = mysqlTable(
+  "meeting_vote_choice",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    voteId: int("vote_id").notNull(),
+    choice: varchar("choice", { length: 255 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  table => ({
+    meetingAgendaVoteChoiceIdFk: foreignKey({
+      name: "meeting_agenda_vote_choice_id_fk",
+      columns: [table.voteId],
+      foreignColumns: [MeetingAgendaVote.id],
+    }),
+  }),
+);
 
-export const MeetingVoteResult = mysqlTable("meeting_vote_result", {
-  id: int("id").autoincrement().primaryKey(),
-  voteId: int("vote_id")
-    .references(() => MeetingAgendaVote.id)
-    .notNull(),
-  userId: int("user_id")
-    .references(() => User.id)
-    .notNull(),
-  choiceId: int("choice_id")
-    .references(() => MeetingVoteChoice.id)
-    .notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
+export const MeetingVoteResult = mysqlTable(
+  "meeting_vote_result",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    voteId: int("vote_id").notNull(),
+    userId: int("user_id").notNull(),
+    choiceId: int("choice_id").notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  table => ({
+    meetingAgendaVoteResultIdFk: foreignKey({
+      name: "meeting_agenda_vote_result_id_fk",
+      columns: [table.voteId],
+      foreignColumns: [MeetingAgendaVote.id],
+    }),
+    userMeetingVoteResultIdFk: foreignKey({
+      name: "user_meeting_vote_result_id_fk",
+      columns: [table.userId],
+      foreignColumns: [User.id],
+    }),
+    meetingVoteChoiceResultIdFk: foreignKey({
+      name: "meeting_vote_choice_result_id_fk",
+      columns: [table.choiceId],
+      foreignColumns: [MeetingVoteChoice.id],
+    }),
+  }),
+);
 
-export const MeetingMapping = mysqlTable("meeting_mapping", {
-  id: int("id").autoincrement().primaryKey(),
-  meetingId: int("meeting_id")
-    .references(() => Meeting.id)
-    .notNull(),
-  meetingAgendaId: int("meeting_agenda_id")
-    .references(() => MeetingAgenda.id)
-    .notNull(),
-  meetingAgendaPosition: int("meeting_agenda_position").autoincrement(),
-  meetingAgendaEntityType: int("meeting_agenda_entity_type").notNull(),
-  meetingAgendaContentId: int("meeting_agenda_content_id").references(
-    () => MeetingAgendaContent.id,
-  ),
-  meetingAgendaVoteId: int("meeting_agenda_vote_id").references(
-    () => MeetingAgendaVote.id,
-  ),
-  meetingAgendaEntityPosition: int(
-    "meeting_agenda_entity_position",
-  ).autoincrement(),
-});
+export const MeetingMapping = mysqlTable(
+  "meeting_mapping",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    meetingId: int("meeting_id").notNull(),
+    meetingAgendaId: int("meeting_agenda_id").notNull(),
+    meetingAgendaPosition: int("meeting_agenda_position").autoincrement(),
+    meetingAgendaEntityType: int("meeting_agenda_entity_type").notNull(),
+    meetingAgendaContentId: int("meeting_agenda_content_id"),
+    meetingAgendaVoteId: int("meeting_agenda_vote_id"),
+    meetingAgendaEntityPosition: int(
+      "meeting_agenda_entity_position",
+    ).autoincrement(),
+  },
+  table => ({
+    meetingMeetingMappingIdFk: foreignKey({
+      name: "meeting_meeting_mapping_id_fk",
+      columns: [table.meetingId],
+      foreignColumns: [Meeting.id],
+    }),
+    meetingAgendaMeetingMappingIdFk: foreignKey({
+      name: "meeting_agenda_meeting_mapping_id_fk",
+      columns: [table.meetingAgendaId],
+      foreignColumns: [MeetingAgenda.id],
+    }),
+    meetingAgendaContentMeetingMappingIdFk: foreignKey({
+      name: "meeting_agenda_content_meeting_mapping_id_fk",
+      columns: [table.meetingAgendaContentId],
+      foreignColumns: [MeetingAgendaContent.id],
+    }),
+    meetingAgendaVoteMeetingMappingIdFk: foreignKey({
+      name: "meeting_agenda_vote_meeting_mapping_id_fk",
+      columns: [table.meetingAgendaVoteId],
+      foreignColumns: [MeetingAgendaVote.id],
+    }),
+  }),
+);

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -1,7 +1,7 @@
 import {
   boolean,
   datetime,
-  foreignKey,
+  // foreignKey,
   int,
   mysqlTable,
   text,
@@ -12,22 +12,6 @@ import {
 import { Club } from "./club.schema";
 import { Division } from "./division.schema";
 import { User } from "./user.schema";
-
-export const MeetingAgendaEnum = mysqlTable("meeting_agenda_enum", {
-  id: int("id").primaryKey(),
-  name: varchar("name", { length: 30 }).notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
-
-export const MeetingEnum = mysqlTable("meeting_enum", {
-  id: int("id").primaryKey(),
-  name: varchar("name", { length: 30 }).notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
-  deletedAt: timestamp("deleted_at"),
-});
 
 export const MeetingRoleEnum = mysqlTable("meeting_role_enum", {
   id: int("id").primaryKey(),
@@ -48,51 +32,40 @@ export const MeetingAnnouncement = mysqlTable("meeting_announcement", {
 
 export const Meeting = mysqlTable("meeting", {
   id: int("id").autoincrement().primaryKey(),
-  announcementId: int("meeting_announcement_id")
-    .references(() => MeetingAnnouncement.id)
-    .notNull(),
-  meetingEnumId: int("meeting_type_enum"),
+  announcementId: int("meeting_announcement_id").references(
+    () => MeetingAnnouncement.id,
+  ),
+  meetingEnumId: int("meeting_type_enum").notNull(),
   isRegular: boolean("is_regular_meeting").notNull(),
   location: varchar("location_kr", { length: 255 }),
   locationEn: varchar("location_en", { length: 255 }),
   startDate: datetime("start_datetime").notNull(),
   endDate: datetime("end_datetime"),
   tag: varchar("meeting_group_tag", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
   deletedAt: timestamp("deleted_at"),
 });
 
-export const MeetingAgenda = mysqlTable(
-  "meeting_agenda",
-  {
-    id: int("id").autoincrement().primaryKey(),
-    meetingId: int("meeting_id")
-      .references(() => Meeting.id)
-      .notNull(),
-    MeetingAgendaEnum: int("meeting_agenda_enum").notNull(),
-    title: varchar("title", { length: 255 }).notNull(),
-    createdBy: int("created_by").references(() => User.id),
-    createdAt: timestamp("created_at").defaultNow(),
-    updatedAt: timestamp("updated_at"),
-    deletedAt: timestamp("deleted_at"),
-  },
-  table => ({
-    meetingAgendaEnumForeignKey: foreignKey({
-      name: "meeting_agenda_enum_foreign_key",
-      columns: [table.MeetingAgendaEnum],
-      foreignColumns: [MeetingAgendaEnum.id],
-    }),
-  }),
-);
+export const MeetingAgenda = mysqlTable("meeting_agenda", {
+  id: int("id").autoincrement().primaryKey(),
+  MeetingAgendaEnum: int("enum").notNull(),
+  title: varchar("title", { length: 255 }).notNull(),
+  description: text("description").notNull(),
+  isEditableDivisionPresident: boolean(
+    "is_editable_divisionPresident",
+  ).notNull(),
+  isEditableRepresentative: boolean("is_editable_representative").notNull(),
+  isEditableSelf: boolean("is_editable_self").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
+  deletedAt: timestamp("deleted_at"),
+});
 
 export const MeetingAgendaContent = mysqlTable("meeting_agenda_content", {
   id: int("id").autoincrement().primaryKey(),
-  agendaId: int("agenda_id")
-    .references(() => MeetingAgenda.id)
-    .notNull(),
-  content: text("content"),
-  createdAt: timestamp("created_at").defaultNow(),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -107,7 +80,7 @@ export const MeetingAttendanceDay = mysqlTable("meeting_attendance_day", {
     .notNull(),
   whichClubId: int("which_club_id").references(() => Club.id),
   whichDivisionId: int("which_division_id").references(() => Division.id),
-  createdAt: timestamp("created_at").defaultNow(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -122,17 +95,16 @@ export const MeetingAttendanceTimeT = mysqlTable("meeting_attendance_time_t", {
     .notNull(),
   startTerm: datetime("start_term").notNull(),
   endTerm: datetime("end_term"),
-  createdAt: timestamp("created_at").defaultNow(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
 
 export const MeetingAgendaVote = mysqlTable("meeting_agenda_vote", {
   id: int("id").autoincrement().primaryKey(),
-  agendaId: int("agenda_id")
-    .references(() => MeetingAgenda.id)
-    .notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+  title: varchar("title", { length: 255 }).notNull(),
+  description: text("description").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -142,21 +114,45 @@ export const MeetingVoteChoice = mysqlTable("meeting_vote_choice", {
   voteId: int("vote_id")
     .references(() => MeetingAgendaVote.id)
     .notNull(),
-  choice: text("choice").notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+  choice: varchar("choice", { length: 255 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
 
 export const MeetingVoteResult = mysqlTable("meeting_vote_result", {
   id: int("id").autoincrement().primaryKey(),
+  voteId: int("vote_id")
+    .references(() => MeetingAgendaVote.id)
+    .notNull(),
   userId: int("user_id")
     .references(() => User.id)
     .notNull(),
   choiceId: int("choice_id")
     .references(() => MeetingVoteChoice.id)
     .notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
+});
+
+export const MeetingMapping = mysqlTable("meeting_mapping", {
+  id: int("id").autoincrement().primaryKey(),
+  meetingId: int("meeting_id")
+    .references(() => Meeting.id)
+    .notNull(),
+  meetingAgendaId: int("meeting_agenda_id")
+    .references(() => MeetingAgenda.id)
+    .notNull(),
+  meetingAgendaPosition: int("meeting_agenda_position").autoincrement(),
+  meetingAgendaEntityType: int("meeting_agenda_entity_type").notNull(),
+  meetingAgendaContentId: int("meeting_agenda_content_id").references(
+    () => MeetingAgendaContent.id,
+  ),
+  meetingAgendaVoteId: int("meeting_agenda_vote_id").references(
+    () => MeetingAgendaVote.id,
+  ),
+  meetingAgendaEntityPosition: int(
+    "meeting_agenda_entity_position",
+  ).autoincrement(),
 });

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -42,8 +42,8 @@ export const Meeting = mysqlTable("meeting", {
   startDate: datetime("start_datetime").notNull(),
   endDate: datetime("end_datetime"),
   tag: varchar("meeting_group_tag", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
 

--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -57,15 +57,15 @@ export const MeetingAgenda = mysqlTable("meeting_agenda", {
   ).notNull(),
   isEditableRepresentative: boolean("is_editable_representative").notNull(),
   isEditableSelf: boolean("is_editable_self").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
 
 export const MeetingAgendaContent = mysqlTable("meeting_agenda_content", {
   id: int("id").autoincrement().primaryKey(),
   content: text("content").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -80,7 +80,7 @@ export const MeetingAttendanceDay = mysqlTable("meeting_attendance_day", {
     .notNull(),
   whichClubId: int("which_club_id").references(() => Club.id),
   whichDivisionId: int("which_division_id").references(() => Division.id),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -95,7 +95,7 @@ export const MeetingAttendanceTimeT = mysqlTable("meeting_attendance_time_t", {
     .notNull(),
   startTerm: datetime("start_term").notNull(),
   endTerm: datetime("end_term"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -104,7 +104,7 @@ export const MeetingAgendaVote = mysqlTable("meeting_agenda_vote", {
   id: int("id").autoincrement().primaryKey(),
   title: varchar("title", { length: 255 }).notNull(),
   description: text("description").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -115,7 +115,7 @@ export const MeetingVoteChoice = mysqlTable("meeting_vote_choice", {
     .references(() => MeetingAgendaVote.id)
     .notNull(),
   choice: varchar("choice", { length: 255 }).notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });
@@ -131,7 +131,7 @@ export const MeetingVoteResult = mysqlTable("meeting_vote_result", {
   choiceId: int("choice_id")
     .references(() => MeetingVoteChoice.id)
     .notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at"),
   deletedAt: timestamp("deleted_at"),
 });

--- a/packages/api/src/feature/meeting/meeting.repository.ts
+++ b/packages/api/src/feature/meeting/meeting.repository.ts
@@ -45,8 +45,9 @@ export class MeetingRepository {
     return result;
   }
 
-  async vote(choiceId: number, userId: number) {
+  async vote(choiceId: number, userId: number, voteId: number) {
     const result = await this.db.insert(MeetingVoteResult).values({
+      voteId,
       choiceId,
       userId,
     });

--- a/packages/api/src/feature/meeting/meeting.service.ts
+++ b/packages/api/src/feature/meeting/meeting.service.ts
@@ -29,8 +29,8 @@ export class MeetingService {
     return result;
   }
 
-  async vote(choiceId: number, userId: number) {
-    const result = await this.meetingRepository.vote(choiceId, userId);
+  async vote(choiceId: number, userId: number, voteId: number) {
+    const result = await this.meetingRepository.vote(choiceId, userId, voteId);
     if (!result) {
       throw new WsException("Failed to exit meeting");
     }


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1187
- 시트를 보면서 meeting schema 전반을 수정
    - 안 쓰는 Enum table 삭제
    - 사소하게 constraint 빠져있는 거 추가
- MeetingMapping 테이블 추가

<h3>질문</h3>

**updatedAt에 notNull을 붙여야 하는가에 대하여** 

- 시트 안의 다수 테이블`(Meeting, MeetingAnnouncement, MeetingAgenda 등)`의 createdAt, updatedAt column이 notNull로 설정 되어 있습니다. 그래서 notNull을 코드에 추가해보니 `meeting.repository.ts의 postExecutiveMeetingAnnouncement에서` 왜 updatedAt은 notNull인데 안 넣어줬어! 하는 식으로 에러가 떴습니다.
- 그래서 우선 코드에서 createdAt, updatedAt에서 notNull 조건을 뺐습니다.
- 기존 Meeting 테이블의 createdAt이 시트에서 notNull이지만 코드에서 defaultNow 값을 넣어주기 때문에 notNull constraint를 안 붙이신 것 같다고 보이는데, `그렇다면 updatedAt이 시트에서 notNull이라고해서 코드에서 defaultNow를 추가해야하나?` 수정도 안 했는데 meeting 테이블에 row 하나 생성하자마자 수정일이 들어가는 건 이상해 보입니다. 
- 따라서 이후 Task로 시트에서 다수 테이블의 updatedAt에서 notNull을 빼야 하지 않을까 하는 고민이 됩니다.
- (애초에 시트 고칠 때부터 고민했어야 하는데 그 때는 생각하지 못했던 게, 에러를 마주하면서 생각이 나는 것 같습니다. 죄송합니다..!)

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
