### PR TITLE
Remove autoincrement from positions in meeting mapping

### DIFF
--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -198,13 +198,11 @@ export const MeetingMapping = mysqlTable(
     id: int("id").autoincrement().primaryKey(),
     meetingId: int("meeting_id").notNull(),
     meetingAgendaId: int("meeting_agenda_id").notNull(),
-    meetingAgendaPosition: int("meeting_agenda_position").autoincrement(),
+    meetingAgendaPosition: int("meeting_agenda_position"),
     meetingAgendaEntityType: int("meeting_agenda_entity_type").notNull(),
     meetingAgendaContentId: int("meeting_agenda_content_id"),
     meetingAgendaVoteId: int("meeting_agenda_vote_id"),
-    meetingAgendaEntityPosition: int(
-      "meeting_agenda_entity_position",
-    ).autoincrement(),
+    meetingAgendaEntityPosition: int("meeting_agenda_entity_position"),
   },
   table => ({
     meetingMeetingMappingIdFk: foreignKey({


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->
Meeting mapping에서 PK 안 붙은 auto increment들 삭제합니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
