### PR TITLE
Verify NotNull in MeetingMapping position attributes

### DIFF
--- a/packages/api/src/drizzle/schema/meeting.schema.ts
+++ b/packages/api/src/drizzle/schema/meeting.schema.ts
@@ -198,7 +198,7 @@ export const MeetingMapping = mysqlTable(
     id: int("id").autoincrement().primaryKey(),
     meetingId: int("meeting_id").notNull(),
     meetingAgendaId: int("meeting_agenda_id").notNull(),
-    meetingAgendaPosition: int("meeting_agenda_position"),
+    meetingAgendaPosition: int("meeting_agenda_position").notNull(),
     meetingAgendaEntityType: int("meeting_agenda_entity_type").notNull(),
     meetingAgendaContentId: int("meeting_agenda_content_id"),
     meetingAgendaVoteId: int("meeting_agenda_vote_id"),


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->
MeetingMapping Table에 Content, vote와 같은 entity의 position은 nullable 해야 합니다.
왜냐하면 MeetingMapping Table row에 meeting과 meeting agenda의 관계만 나타낼 때도 있기 때문입니다.
그래서 스프레드 시트를 변경하게 되었습니다.

코드도 싱크 맞추려고 확인해보니,
오히려 entity position에는 notnull이 없어서 괜찮은데 Agenda Position은 notnull이 필요해서 요 부분을 수정했습니다.
pnpm generate도 문제가 없었고, 덤프는 따로 따지 않았습니다!

[스키마 스프레드시트](https://docs.google.com/spreadsheets/d/1REbeZHX53U3h_blcIkXra6rY3I4MDpg3LM7h80NqSH4/edit?gid=886338294#gid=886338294)

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
