### PR TITLE
apply sem001

### DIFF
--- a/packages/web/src/common/services/getSemesters.ts
+++ b/packages/web/src/common/services/getSemesters.ts
@@ -1,0 +1,21 @@
+import apiSem001, {
+  ApiSem001RequestQuery,
+  ApiSem001ResponseOK,
+} from "@sparcs-clubs/interface/api/semester/apiSem001";
+import { useQuery } from "@tanstack/react-query";
+
+import { axiosClientWithAuth } from "@sparcs-clubs/web/lib/axios";
+
+const useGetSemesters = (requestQuery: ApiSem001RequestQuery) =>
+  useQuery<ApiSem001ResponseOK, Error>({
+    queryKey: [apiSem001.url(), requestQuery],
+    queryFn: async (): Promise<ApiSem001ResponseOK> => {
+      const { data } = await axiosClientWithAuth.get(apiSem001.url(), {
+        params: requestQuery,
+      });
+
+      return data;
+    },
+  });
+
+export default useGetSemesters;

--- a/packages/web/src/features/clubDetails/components/RegisterInfo.tsx
+++ b/packages/web/src/features/clubDetails/components/RegisterInfo.tsx
@@ -11,6 +11,7 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 
 import { useRegisterClub } from "../services/registerClub";
 import { useUnregisterClub } from "../services/unregisterClub";
@@ -75,6 +76,11 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
     }
   `;
 
+  const { data: semesterInfo } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   const submitHandler = () => {
     overlay.open(({ isOpen, close }) => (
       <Modal isOpen={isOpen} onClose={close}>
@@ -85,7 +91,8 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
               ToggleUnregistered(close);
             }}
           >
-            2024학년도 봄학기
+            {semesterInfo?.semesters[0].year}년도{" "}
+            {semesterInfo?.semesters[0].name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의<br />
             회원 등록을 취소합니다.
@@ -97,7 +104,8 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
               ToggleRegistered(close);
             }}
           >
-            2024학년도 봄학기
+            {semesterInfo?.semesters[0].year}년도{" "}
+            {semesterInfo?.semesters[0].name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의<br />
             회원 등록 신청을 진행합니다.

--- a/packages/web/src/features/clubDetails/components/RegisterInfo.tsx
+++ b/packages/web/src/features/clubDetails/components/RegisterInfo.tsx
@@ -11,7 +11,8 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
+
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 import { useRegisterClub } from "../services/registerClub";
 import { useUnregisterClub } from "../services/unregisterClub";
@@ -76,10 +77,7 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
     }
   `;
 
-  const { data: semesterInfo } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  const semester = useGetSemesterNow()?.semester;
 
   const submitHandler = () => {
     overlay.open(({ isOpen, close }) => (
@@ -91,8 +89,7 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
               ToggleUnregistered(close);
             }}
           >
-            {semesterInfo?.semesters[0].year}년도{" "}
-            {semesterInfo?.semesters[0].name}학기
+            {semester?.year}년도 {semester?.name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의<br />
             회원 등록을 취소합니다.
@@ -104,8 +101,7 @@ export const RegisterInfo: React.FC<RegisterInfoProps> = ({
               ToggleRegistered(close);
             }}
           >
-            {semesterInfo?.semesters[0].year}년도{" "}
-            {semesterInfo?.semesters[0].name}학기
+            {semester?.year}년도 {semester?.name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의<br />
             회원 등록 신청을 진행합니다.

--- a/packages/web/src/features/clubs/components/ClubRegistrationButton.tsx
+++ b/packages/web/src/features/clubs/components/ClubRegistrationButton.tsx
@@ -11,6 +11,7 @@ import styled from "styled-components";
 import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useRegisterClub } from "@sparcs-clubs/web/features/clubDetails/services/registerClub";
 import { useUnregisterClub } from "@sparcs-clubs/web/features/clubDetails/services/unregisterClub";
 
@@ -66,6 +67,11 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
     }
   `;
 
+  const { data: semesterInfo } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   const handleRegister = () => {
     overlay.open(({ isOpen, close }) => (
       <Modal isOpen={isOpen} onClose={close}>
@@ -76,7 +82,8 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
               ToggleUnregistered(close);
             }}
           >
-            2024학년도 봄학기
+            {semesterInfo?.semesters[0].year}년도{" "}
+            {semesterInfo?.semesters[0].name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의
             <br />
@@ -89,7 +96,8 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
               ToggleRegistered(close);
             }}
           >
-            2024학년도 봄학기
+            {semesterInfo?.semesters[0].year}년도{" "}
+            {semesterInfo?.semesters[0].name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의
             <br />

--- a/packages/web/src/features/clubs/components/ClubRegistrationButton.tsx
+++ b/packages/web/src/features/clubs/components/ClubRegistrationButton.tsx
@@ -11,9 +11,9 @@ import styled from "styled-components";
 import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useRegisterClub } from "@sparcs-clubs/web/features/clubDetails/services/registerClub";
 import { useUnregisterClub } from "@sparcs-clubs/web/features/clubDetails/services/unregisterClub";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 interface ClubRegistrationButtonProps {
   club: ApiClb001ResponseOK["divisions"][number]["clubs"][number];
@@ -67,10 +67,7 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
     }
   `;
 
-  const { data: semesterInfo } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  const { semester: semesterInfo } = useGetSemesterNow();
 
   const handleRegister = () => {
     overlay.open(({ isOpen, close }) => (
@@ -82,8 +79,7 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
               ToggleUnregistered(close);
             }}
           >
-            {semesterInfo?.semesters[0].year}년도{" "}
-            {semesterInfo?.semesters[0].name}학기
+            {semesterInfo?.year}년도 {semesterInfo?.name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의
             <br />
@@ -96,8 +92,7 @@ const ClubRegistrationButton: React.FC<ClubRegistrationButtonProps> = ({
               ToggleRegistered(close);
             }}
           >
-            {semesterInfo?.semesters[0].year}년도{" "}
-            {semesterInfo?.semesters[0].name}학기
+            {semesterInfo?.year}년도 {semesterInfo?.name}학기
             <ResponsiveBr /> {club.type === 1 ? "정동아리" : "가동아리"}{" "}
             {club.name_kr}의
             <br />

--- a/packages/web/src/features/clubs/frames/ClubsStudentFrame.tsx
+++ b/packages/web/src/features/clubs/frames/ClubsStudentFrame.tsx
@@ -6,10 +6,10 @@ import { RegistrationDeadlineEnum } from "@sparcs-clubs/interface/common/enum/re
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Info from "@sparcs-clubs/web/common/components/Info";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubsListFrame from "@sparcs-clubs/web/features/clubs/frames/ClubsListFrame";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 const ClubsStudentFrame: React.FC = () => {
   const {
@@ -47,13 +47,10 @@ const ClubsStudentFrame: React.FC = () => {
   }, [termData]);
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   return (
     <>
@@ -63,7 +60,7 @@ const ClubsStudentFrame: React.FC = () => {
       >
         {isRegistrationPeriod && (
           <Info
-            text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 신청 기간입니다 (신청 마감 : ${formatDateTime(memberRegistrationPeriodEnd)})`}
+            text={`현재는 ${semesterInfo?.year}년 ${semesterInfo?.name}학기 동아리 신청 기간입니다 (신청 마감 : ${formatDateTime(memberRegistrationPeriodEnd)})`}
           />
         )}
       </AsyncBoundary>

--- a/packages/web/src/features/clubs/frames/ClubsStudentFrame.tsx
+++ b/packages/web/src/features/clubs/frames/ClubsStudentFrame.tsx
@@ -6,6 +6,7 @@ import { RegistrationDeadlineEnum } from "@sparcs-clubs/interface/common/enum/re
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Info from "@sparcs-clubs/web/common/components/Info";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubsListFrame from "@sparcs-clubs/web/features/clubs/frames/ClubsListFrame";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
@@ -45,13 +46,24 @@ const ClubsStudentFrame: React.FC = () => {
     }
   }, [termData]);
 
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   return (
     <>
-      <AsyncBoundary isLoading={isLoadingTerm} isError={isErrorTerm}>
+      <AsyncBoundary
+        isLoading={isLoadingTerm || semesterLoading}
+        isError={isErrorTerm || semesterError}
+      >
         {isRegistrationPeriod && (
-          // TODO: 학기 동적처리
           <Info
-            text={`현재는 2024년 가을학기 동아리 신청 기간입니다 (신청 마감 : ${formatDateTime(memberRegistrationPeriodEnd)})`}
+            text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 신청 기간입니다 (신청 마감 : ${formatDateTime(memberRegistrationPeriodEnd)})`}
           />
         )}
       </AsyncBoundary>

--- a/packages/web/src/features/manage-club/components/MembersTable.tsx
+++ b/packages/web/src/features/manage-club/components/MembersTable.tsx
@@ -19,10 +19,9 @@ import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/Confi
 import Table from "@sparcs-clubs/web/common/components/Table";
 import TableButton from "@sparcs-clubs/web/common/components/Table/TableButton";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { MemTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
-
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 import { patchClubMemberRegistration } from "../members/services/patchClubMemberRegistration";
@@ -256,16 +255,13 @@ const MembersTable: React.FC<MembersTableProps> = ({
   refetch,
   delegates,
 }) => {
-  const { data: semesterInfo } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  const { semester: semesterInfo } = useGetSemesterNow();
 
   const columns = columnsFunction(
     clubName,
     clubId,
-    semesterInfo?.semesters[0].year ?? 0,
-    semesterInfo?.semesters[0].name ?? "",
+    semesterInfo?.year ?? 0,
+    semesterInfo?.name ?? "",
     refetch,
     delegates,
   );

--- a/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
@@ -15,11 +15,10 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Table from "@sparcs-clubs/web/common/components/Table";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
-
 import { useGetClubMembers } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMembers";
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 const columnHelper =
   createColumnHelper<ApiClb010ResponseOk["members"][number]>();
@@ -96,15 +95,12 @@ const MemberManageFrame: React.FC = () => {
   };
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
-  const title = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 (총 ${membersCount}명)`;
+  const title = `${semesterInfo?.year}년 ${semesterInfo?.name}학기 (총 ${membersCount}명)`;
 
   return (
     <FoldableSectionTitle title="회원 명단">

--- a/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
@@ -15,6 +15,7 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
 
 import { useGetClubMembers } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMembers";
@@ -94,14 +95,22 @@ const MemberManageFrame: React.FC = () => {
     isError: boolean;
   };
 
-  const title = `2024년 가을학기(총 ${membersCount}명)`;
-  // TODO: 학기 받아올 수 있도록 수정
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
+  const title = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 (총 ${membersCount}명)`;
 
   return (
     <FoldableSectionTitle title="회원 명단">
       <AsyncBoundary
-        isLoading={clubIsLoading || memberIsLoading}
-        isError={clubIsError || memberIsError}
+        isLoading={clubIsLoading || memberIsLoading || semesterLoading}
+        isError={clubIsError || memberIsError || semesterError}
       >
         {clubData && membersData && (
           <FlexWrapper direction="column" gap={16}>

--- a/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
@@ -13,6 +13,7 @@ import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
 import MembersTable from "@sparcs-clubs/web/features/manage-club/components/MembersTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMemberRegistration";
@@ -83,9 +84,17 @@ const RegistrationManageFrame: React.FC = () => {
     ).length;
   const totalCount = memberData && memberData.applies.length;
 
-  const title = `2024년 가을학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
-  const mobileTitle = `2024년 가을학기`;
-  // TODO: 학기 받아올 수 있도록 수정
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
+  const title = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
+  const mobileTitle = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`;
 
   const theme = useTheme();
   const [isMobileView, setIsMobileView] = useState(false);
@@ -106,8 +115,15 @@ const RegistrationManageFrame: React.FC = () => {
   return (
     <FoldableSectionTitle title="회원 명단">
       <AsyncBoundary
-        isLoading={memberIsLoading || clubIsLoading || delegatesIsLoading}
-        isError={memberIsError || clubIsError || delegatesIsError}
+        isLoading={
+          memberIsLoading ||
+          clubIsLoading ||
+          delegatesIsLoading ||
+          semesterLoading
+        }
+        isError={
+          memberIsError || clubIsError || delegatesIsError || semesterError
+        }
       >
         <FlexWrapper direction="column" gap={20}>
           {memberData && clubData && (

--- a/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/RegistrationManageFrame.tsx
@@ -13,12 +13,11 @@ import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubDetails/services/getClubDetail";
 import MembersTable from "@sparcs-clubs/web/features/manage-club/components/MembersTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/manage-club/members/services/getClubMemberRegistration";
-
 import { useGetMyManageClub } from "@sparcs-clubs/web/features/manage-club/services/getMyManageClub";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 import { useGetClubDelegate } from "../services/getClubDelegate";
 
@@ -85,16 +84,13 @@ const RegistrationManageFrame: React.FC = () => {
   const totalCount = memberData && memberData.applies.length;
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
-  const title = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
-  const mobileTitle = `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`;
+  const title = `${semesterInfo?.year}년 ${semesterInfo?.name}학기 (신청 ${appliedCount}명, 승인 ${approvedCount}명, 반려 ${rejectedCount}명 / 총 ${totalCount}명)`;
+  const mobileTitle = `${semesterInfo?.year}년 ${semesterInfo?.name}학기`;
 
   const theme = useTheme();
   const [isMobileView, setIsMobileView] = useState(false);

--- a/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
+++ b/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import Info from "@sparcs-clubs/web/common/components/Info";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { newMemberListSectionInfoText } from "@sparcs-clubs/web/constants/manageClubMembers";
 
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
@@ -52,17 +53,28 @@ const RegisterMemberListFrame = () => {
     }
   }, [termData]);
 
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   if (!isRegistrationPeriod) return null;
 
   return (
     <FoldableSectionTitle title="신청 회원 명단" childrenMargin="20px">
       <RegisterMemberListWrapper>
-        <AsyncBoundary isLoading={isLoadingTerm} isError={isErrorTerm}>
+        <AsyncBoundary
+          isLoading={isLoadingTerm || semesterLoading}
+          isError={isErrorTerm || semesterError}
+        >
           {isRegistrationPeriod && (
-            // TODO: 학기 동적처리
             <Info
               text={newMemberListSectionInfoText(
-                "2024년 가을",
+                `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}`,
                 memberRegistrationPeriodEnd,
               )}
             />

--- a/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
+++ b/packages/web/src/features/manage-club/members/frames/RegisterMemberListFrame.tsx
@@ -6,10 +6,9 @@ import styled from "styled-components";
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import Info from "@sparcs-clubs/web/common/components/Info";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { newMemberListSectionInfoText } from "@sparcs-clubs/web/constants/manageClubMembers";
-
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 import RegisterMemberList from "../components/RegisterMemberList";
 
@@ -54,13 +53,10 @@ const RegisterMemberListFrame = () => {
   }, [termData]);
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   if (!isRegistrationPeriod) return null;
 
@@ -74,7 +70,7 @@ const RegisterMemberListFrame = () => {
           {isRegistrationPeriod && (
             <Info
               text={newMemberListSectionInfoText(
-                `${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}`,
+                `${semesterInfo?.year}년 ${semesterInfo?.name}`,
                 memberRegistrationPeriodEnd,
               )}
             />

--- a/packages/web/src/features/my/frames/MyClubFrame.tsx
+++ b/packages/web/src/features/my/frames/MyClubFrame.tsx
@@ -5,23 +5,48 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubListGrid from "@sparcs-clubs/web/features/clubs/components/ClubListGrid";
 import useGetMyClub from "@sparcs-clubs/web/features/my/clubs/service/useGetMyClub";
 
 const MyClubFrame: React.FC = () => {
   const { data, isLoading, isError } = useGetMyClub();
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
 
   return (
     <FoldableSectionTitle title="나의 동아리">
-      <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <AsyncBoundary
+        isLoading={isLoading || semesterLoading}
+        isError={isError || semesterError}
+      >
+        {" "}
         <FlexWrapper direction="column" gap={20}>
           <MoreDetailTitle
-            title="2024년 봄학기"
+            title={`${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`}
             moreDetail="전체 보기"
             moreDetailPath="/my/clubs"
           />
-          {data && data.semesters.length > 0 ? (
-            <ClubListGrid clubList={data?.semesters[0].clubs ?? []} />
+          {data &&
+          data.semesters.length > 0 &&
+          (
+            data.semesters.find(
+              semester => semester.id === semesterInfo?.semesters[0].id,
+            )?.clubs ?? []
+          ).length > 0 ? (
+            <ClubListGrid
+              clubList={
+                data.semesters.find(
+                  semester => semester.id === semesterInfo?.semesters[0].id,
+                )?.clubs ?? []
+              }
+            />
           ) : (
             <Typography color="GRAY.300" fs={16} fw="MEDIUM">
               이번 학기 동아리가 없습니다

--- a/packages/web/src/features/my/frames/MyClubFrame.tsx
+++ b/packages/web/src/features/my/frames/MyClubFrame.tsx
@@ -5,20 +5,17 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubListGrid from "@sparcs-clubs/web/features/clubs/components/ClubListGrid";
 import useGetMyClub from "@sparcs-clubs/web/features/my/clubs/service/useGetMyClub";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 const MyClubFrame: React.FC = () => {
   const { data, isLoading, isError } = useGetMyClub();
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   return (
     <FoldableSectionTitle title="나의 동아리">
@@ -29,21 +26,20 @@ const MyClubFrame: React.FC = () => {
         {" "}
         <FlexWrapper direction="column" gap={20}>
           <MoreDetailTitle
-            title={`${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`}
+            title={`${semesterInfo?.year}년 ${semesterInfo?.name}학기`}
             moreDetail="전체 보기"
             moreDetailPath="/my/clubs"
           />
           {data &&
           data.semesters.length > 0 &&
           (
-            data.semesters.find(
-              semester => semester.id === semesterInfo?.semesters[0].id,
-            )?.clubs ?? []
+            data.semesters.find(semester => semester.id === semesterInfo?.id)
+              ?.clubs ?? []
           ).length > 0 ? (
             <ClubListGrid
               clubList={
                 data.semesters.find(
-                  semester => semester.id === semesterInfo?.semesters[0].id,
+                  semester => semester.id === semesterInfo?.id,
                 )?.clubs ?? []
               }
             />

--- a/packages/web/src/features/my/frames/ProfessorMyClubFrame.tsx
+++ b/packages/web/src/features/my/frames/ProfessorMyClubFrame.tsx
@@ -5,24 +5,48 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubListGrid from "@sparcs-clubs/web/features/clubs/components/ClubListGrid";
 
 import useGetMyClubProfessor from "../clubs/service/getMyClubProfessor";
 
 const ProfessorMyClubFrame: React.FC = () => {
   const { data, isLoading, isError } = useGetMyClubProfessor();
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
 
   return (
     <FoldableSectionTitle title="나의 동아리">
-      <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <AsyncBoundary
+        isLoading={isLoading || semesterLoading}
+        isError={isError || semesterError}
+      >
         <FlexWrapper direction="column" gap={20}>
           <MoreDetailTitle
-            title="2024년 봄학기"
+            title={`${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`}
             moreDetail="전체 보기"
             moreDetailPath="/my/clubs"
           />
-          {data && data.semesters.length > 0 ? (
-            <ClubListGrid clubList={data?.semesters[0].clubs ?? []} />
+          {data &&
+          data.semesters.length > 0 &&
+          (
+            data.semesters.find(
+              semester => semester.id === semesterInfo?.semesters[0].id,
+            )?.clubs ?? []
+          ).length > 0 ? (
+            <ClubListGrid
+              clubList={
+                data.semesters.find(
+                  semester => semester.id === semesterInfo?.semesters[0].id,
+                )?.clubs ?? []
+              }
+            />
           ) : (
             <Typography color="GRAY.300" fs={16} fw="MEDIUM">
               이번 학기 동아리가 없습니다

--- a/packages/web/src/features/my/frames/ProfessorMyClubFrame.tsx
+++ b/packages/web/src/features/my/frames/ProfessorMyClubFrame.tsx
@@ -5,21 +5,18 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import MoreDetailTitle from "@sparcs-clubs/web/common/components/MoreDetailTitle";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import ClubListGrid from "@sparcs-clubs/web/features/clubs/components/ClubListGrid";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 import useGetMyClubProfessor from "../clubs/service/getMyClubProfessor";
 
 const ProfessorMyClubFrame: React.FC = () => {
   const { data, isLoading, isError } = useGetMyClubProfessor();
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   return (
     <FoldableSectionTitle title="나의 동아리">
@@ -29,21 +26,20 @@ const ProfessorMyClubFrame: React.FC = () => {
       >
         <FlexWrapper direction="column" gap={20}>
           <MoreDetailTitle
-            title={`${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기`}
+            title={`${semesterInfo?.year}년 ${semesterInfo?.name}학기`}
             moreDetail="전체 보기"
             moreDetailPath="/my/clubs"
           />
           {data &&
           data.semesters.length > 0 &&
           (
-            data.semesters.find(
-              semester => semester.id === semesterInfo?.semesters[0].id,
-            )?.clubs ?? []
+            data.semesters.find(semester => semester.id === semesterInfo?.id)
+              ?.clubs ?? []
           ).length > 0 ? (
             <ClubListGrid
               clubList={
                 data.semesters.find(
-                  semester => semester.id === semesterInfo?.semesters[0].id,
+                  semester => semester.id === semesterInfo?.id,
                 )?.clubs ?? []
               }
             />

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
@@ -22,6 +22,7 @@ import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import WarningInfo from "@sparcs-clubs/web/common/components/WarningInfo";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import useGetClubRegistration from "@sparcs-clubs/web/features/my/services/useGetClubRegistration";
 import usePutClubRegistration from "@sparcs-clubs/web/features/my/services/usePutClubRegistration";
@@ -243,6 +244,15 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
     }
   }, [isSuccess, router, applyId, queryClient]);
 
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   if (!detail) return null;
 
   return (
@@ -265,10 +275,12 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
               enableLast
             />
             <FlexWrapper direction="column" gap={20}>
-              <AsyncBoundary isLoading={isLoadingTerm} isError={isErrorTerm}>
-                {/* TODO: 학기 동적처리  */}
+              <AsyncBoundary
+                isLoading={isLoadingTerm || semesterLoading}
+                isError={isErrorTerm || semesterError}
+              >
                 <Info
-                  text={`현재는 2024년 가을학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+                  text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
                 />
               </AsyncBoundary>
               <WarningInfo>

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
@@ -22,7 +22,6 @@ import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import WarningInfo from "@sparcs-clubs/web/common/components/WarningInfo";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import useGetClubRegistration from "@sparcs-clubs/web/features/my/services/useGetClubRegistration";
 import usePutClubRegistration from "@sparcs-clubs/web/features/my/services/usePutClubRegistration";
@@ -34,6 +33,7 @@ import ProvisionalBasicInformFrame from "@sparcs-clubs/web/features/register-clu
 import computeErrorMessage from "@sparcs-clubs/web/features/register-club/utils/computeErrorMessage";
 import { isProvisional } from "@sparcs-clubs/web/features/register-club/utils/registrationType";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 interface RegisterClubMainFrameProps {
   applyId: number;
@@ -245,13 +245,10 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
   }, [isSuccess, router, applyId, queryClient]);
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   if (!detail) return null;
 
@@ -280,7 +277,7 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
                 isError={isErrorTerm || semesterError}
               >
                 <Info
-                  text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+                  text={`현재는 ${semesterInfo?.year}년 ${semesterInfo?.name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
                 />
               </AsyncBoundary>
               <WarningInfo>

--- a/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
@@ -14,11 +14,11 @@ import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import WarningInfo from "@sparcs-clubs/web/common/components/WarningInfo";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { useGetMyClubRegistration } from "@sparcs-clubs/web/features/my/services/getMyClubRegistration";
 import ClubButton from "@sparcs-clubs/web/features/register-club/components/_atomic/ClubButton";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 const ClubButtonWrapper = styled.div`
   display: flex;
@@ -99,13 +99,10 @@ const RegisterClubFrame = () => {
   };
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>
@@ -135,7 +132,7 @@ const RegisterClubFrame = () => {
         >
           {isRegistrationPeriod ? (
             <Info
-              text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+              text={`현재는 ${semesterInfo?.year}년 ${semesterInfo?.name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
             />
           ) : (
             <Info text="현재는 동아리 등록 기간이 아닙니다" />

--- a/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
@@ -14,6 +14,7 @@ import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import WarningInfo from "@sparcs-clubs/web/common/components/WarningInfo";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { useGetMyClubRegistration } from "@sparcs-clubs/web/features/my/services/getMyClubRegistration";
 import ClubButton from "@sparcs-clubs/web/features/register-club/components/_atomic/ClubButton";
@@ -97,6 +98,15 @@ const RegisterClubFrame = () => {
       router.push(`register-club/provisional`);
   };
 
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>
       {/* TODO: (@dora) fix loading boundary to enhance ux */}
@@ -119,11 +129,13 @@ const RegisterClubFrame = () => {
             </Typography>
           </WarningInfo>
         )}
-        <AsyncBoundary isLoading={isLoadingTerm} isError={isErrorTerm}>
-          {/* TODO: 학기 동적처리  */}
+        <AsyncBoundary
+          isLoading={isLoadingTerm || semesterLoading}
+          isError={isErrorTerm || semesterError}
+        >
           {isRegistrationPeriod ? (
             <Info
-              text={`현재는 2024년 가을학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+              text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
             />
           ) : (
             <Info text="현재는 동아리 등록 기간이 아닙니다" />

--- a/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
@@ -20,6 +20,7 @@ import Modal from "@sparcs-clubs/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
 
@@ -185,6 +186,15 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
     isError,
   } = useRegisterClub();
 
+  const {
+    data: semesterInfo,
+    isLoading: semesterLoading,
+    isError: semesterError,
+  } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
   const title = useMemo(() => {
     formCtx.setValue("registrationTypeEnumId", type);
     return getDisplayNameRegistration(type);
@@ -264,10 +274,12 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
             title={`동아리 ${title} 신청`}
             enableLast
           />
-          <AsyncBoundary isLoading={isLoadingTerm} isError={isErrorTerm}>
-            {/* TODO: 학기 동적처리  */}
+          <AsyncBoundary
+            isLoading={isLoadingTerm || semesterLoading}
+            isError={isErrorTerm || semesterError}
+          >
             <Info
-              text={`현재는 2024년 가을학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+              text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
             />
           </AsyncBoundary>
           {isProvisionalClub ? (

--- a/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
@@ -20,9 +20,9 @@ import Modal from "@sparcs-clubs/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import { useGetRegistrationTerm } from "@sparcs-clubs/web/features/clubs/services/useGetRegistrationTerm";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
+import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
 import ActivityReportFrame from "../components/ActivityReportFrame";
 import AdvancedInformFrame from "../components/AdvancedInformFrame";
@@ -187,13 +187,10 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
   } = useRegisterClub();
 
   const {
-    data: semesterInfo,
+    semester: semesterInfo,
     isLoading: semesterLoading,
     isError: semesterError,
-  } = useGetSemesters({
-    pageOffset: 1,
-    itemCount: 1,
-  });
+  } = useGetSemesterNow();
 
   const title = useMemo(() => {
     formCtx.setValue("registrationTypeEnumId", type);
@@ -279,7 +276,7 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
             isError={isErrorTerm || semesterError}
           >
             <Info
-              text={`현재는 ${semesterInfo?.semesters[0].year}년 ${semesterInfo?.semesters[0].name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
+              text={`현재는 ${semesterInfo?.year}년 ${semesterInfo?.name}학기 동아리 등록 기간입니다 (신청 마감 : ${formatDateTime(clubRegistrationPeriodEnd)})`}
             />
           </AsyncBoundary>
           {isProvisionalClub ? (

--- a/packages/web/src/utils/getSemesterNow.ts
+++ b/packages/web/src/utils/getSemesterNow.ts
@@ -1,0 +1,12 @@
+import useGetSemesters from "../common/services/getSemesters";
+
+const useGetSemesterNow = () => {
+  const { data, isLoading, isError } = useGetSemesters({
+    pageOffset: 1,
+    itemCount: 1,
+  });
+
+  return { semester: data?.semesters[0], isLoading, isError };
+};
+
+export default useGetSemesterNow;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1225 

학기 정보 가져오는 현재 학기 정보를 보여줘야 하는 화면에 SEM001 적용

### 고민되는 부분
어떤 api를 호출할 때 param으로 semesterId를 넣어야 하는 경우가 간혹 있는데(예: MemberManageFrame에서 CLB010 사용), 한번에 호출해서 처리하려고 하면 문제가 생기는 것을 발견함 (같은 파일에서 clubId 다른 api 통해서 가져다 쓰는 건 잘 됨) 이를 어떻게 해결할지
생각해본 방법
- 백엔드에서 semesterId 비우면 현재 학기로 처리하도록 설정하기
- 전역변수로 semester 정보 관리
- frame depth 하나 더 들어가서 쓰도록 수정

현재 학기 정보를 사용하는 화면이 생각보다는 적었는데, provider 이용해서 전역변수로 관리해야할지도 고민

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- SEM001 적용 과정에서 ClubRegistrationButton과 RegisterInfo 코드가 매우 유사한 것을 발견함. 별도 이슈로 분리해서 수정해보면 좋을 것 같음.
