### PR TITLE
create story for radio and checkbox

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -75,6 +75,7 @@
     "@storybook/addon-links": "^8.4.5",
     "@storybook/blocks": "^8.4.5",
     "@storybook/nextjs": "^8.4.5",
+    "@storybook/preview-api": "^8.4.6",
     "@storybook/react": "^8.4.5",
     "@tanstack/react-query-devtools": "^5.28.4",
     "@types/node": "^20",

--- a/packages/web/src/stories/Checkbox.stories.tsx
+++ b/packages/web/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,39 @@
+import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/preview-api";
+
+import CheckboxOption from "../common/components/CheckboxOption";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof CheckboxOption> = {
+  component: CheckboxOption,
+  parameters: {
+    layout: "centered",
+    docs: {
+      autodocs: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CheckboxOption>;
+
+export const Primary: Story = {
+  args: {
+    optionText: "CheckboxOption",
+    checked: false,
+  },
+  argTypes: {
+    optionText: { control: "text" },
+    checked: { control: "boolean" },
+  },
+  render: function Render(args) {
+    const [{ checked }, updateArgs] = useArgs<{ checked: boolean }>();
+    const handleClick = () => {
+      updateArgs({ checked: !checked });
+      action("checkbox-click")(!checked);
+    };
+    return <CheckboxOption {...args} onClick={handleClick} />;
+  },
+};

--- a/packages/web/src/stories/Checkbox.stories.tsx
+++ b/packages/web/src/stories/Checkbox.stories.tsx
@@ -9,9 +9,6 @@ const meta: Meta<typeof CheckboxOption> = {
   component: CheckboxOption,
   parameters: {
     layout: "centered",
-    docs: {
-      autodocs: false,
-    },
   },
 };
 

--- a/packages/web/src/stories/Radio.stories.tsx
+++ b/packages/web/src/stories/Radio.stories.tsx
@@ -1,0 +1,46 @@
+import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/preview-api";
+
+import Radio from "../common/components/Radio";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Radio> = {
+  component: Radio,
+  title: "Radio",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Radio>;
+
+export const Primary: Story = {
+  args: {
+    label: "Radio",
+    value: "option1",
+    direction: "column",
+    gap: "12px",
+  },
+  argTypes: {
+    label: { control: "text" },
+    value: { control: "radio", options: ["option1", "option2"] },
+    direction: { control: "radio", options: ["row", "column"] },
+    gap: { control: "text" },
+  },
+  render: function Render(args) {
+    const [{ value }, updateArgs] = useArgs<{ value: string }>();
+    const handleChange = (newValue: string) => {
+      updateArgs({ value: newValue });
+      action("radio-change")(newValue);
+    };
+    return (
+      <Radio {...args} value={value} onChange={handleChange}>
+        <Radio.Option value="option1">Option 1</Radio.Option>
+        <Radio.Option value="option2">Option 2</Radio.Option>
+      </Radio>
+    );
+  },
+};

--- a/packages/web/src/stories/Radio.stories.tsx
+++ b/packages/web/src/stories/Radio.stories.tsx
@@ -7,7 +7,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Radio> = {
   component: Radio,
-  title: "Radio",
   parameters: {
     layout: "centered",
   },

--- a/packages/web/src/stories/RadioOption.stories.tsx
+++ b/packages/web/src/stories/RadioOption.stories.tsx
@@ -1,0 +1,36 @@
+import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/preview-api";
+
+import { Meta, StoryObj } from "@storybook/react";
+
+import RadioOption from "../common/components/Radio/RadioOption";
+
+const meta: Meta<typeof RadioOption> = {
+  component: RadioOption,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RadioOption>;
+
+export const Primary: Story = {
+  args: {
+    children: "RadioOption",
+    checked: false,
+  },
+  argTypes: {
+    children: { control: "text" },
+    checked: { control: "boolean" },
+  },
+  render: function Render(args) {
+    const [{ checked }, updateArgs] = useArgs<{ checked: boolean }>();
+    const handleClick = () => {
+      updateArgs({ checked: !checked });
+      action("radio-click")(!checked);
+    };
+    return <RadioOption {...args} onClick={handleClick} />;
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       '@storybook/nextjs':
         specifier: ^8.4.5
         version: 8.4.5(esbuild@0.19.12)(next@14.1.3)(react-dom@18.2.0)(react@18.2.0)(sass@1.79.3)(storybook@8.4.5)(typescript@5.4.2)(webpack@5.91.0)
+      '@storybook/preview-api':
+        specifier: ^8.4.6
+        version: 8.4.6(storybook@8.4.5)
       '@storybook/react':
         specifier: ^8.4.5
         version: 8.4.5(@storybook/test@8.4.5)(react-dom@18.2.0)(react@18.2.0)(storybook@8.4.5)(typescript@5.4.2)
@@ -5558,6 +5561,14 @@ packages:
 
   /@storybook/preview-api@8.4.5(storybook@8.4.5):
     resolution: {integrity: sha512-MKIZ2jQO/3cUdsT57eq8jRgB6inALo9BxrQ88f7mqzltOkMvADvTAY6y8JZqTUoDzWTH/ny/8SGGdtpqlxRuiQ==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+    dependencies:
+      storybook: 8.4.5(prettier@3.2.5)
+    dev: true
+
+  /@storybook/preview-api@8.4.6(storybook@8.4.5):
+    resolution: {integrity: sha512-LbD+lR1FGvWaJBXteVx5xdgs1x1D7tyidBg2CsW2ex+cP0iJ176JgjPfutZxlWOfQnhfRYNnJ3WKoCIfxFOTKA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1246 

Radio, CheckboxOption, RadioOption에 대한 storybook 구현
#1245 를 보고 storybook/preview-api의 useArgs를 사용했습니다

# 스크린샷

https://github.com/user-attachments/assets/f9efcf90-b62d-400d-a513-18c59ba3e329


<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
