### PR TITLE
connect apiAct005, apiAct006

### DIFF
--- a/packages/api/src/feature/activity/controller/activity.activity-term.controller.ts
+++ b/packages/api/src/feature/activity/controller/activity.activity-term.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, UsePipes } from "@nestjs/common";
+import { Controller, Get, Param, Query, UsePipes } from "@nestjs/common";
 
 import apiAct006 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct006";
 import apiAct009 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct009";
@@ -12,12 +12,12 @@ import { GetStudent } from "@sparcs-clubs/api/common/util/decorators/param-decor
 import ActivityActivityTermService from "../service/activity.activity-term.service";
 
 import type {
-  ApiAct006RequestBody,
   ApiAct006RequestParam,
+  ApiAct006RequestQuery,
   ApiAct006ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct006";
 import type {
-  ApiAct009RequestBody,
+  ApiAct009RequestQuery,
   ApiAct009ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct009";
 
@@ -32,11 +32,11 @@ export default class ActivityActivityTermController {
   @UsePipes(new ZodPipe(apiAct009))
   async getStudentActivitiesActivityTerms(
     @GetStudent() user: GetStudent,
-    @Body() body: ApiAct009RequestBody,
+    @Query() query: ApiAct009RequestQuery,
   ): Promise<ApiAct009ResponseOk> {
     const result =
       await this.activityActivityTermService.getStudentActivitiesActivityTerms(
-        body,
+        query,
         user.studentId,
       );
     return result;
@@ -48,12 +48,12 @@ export default class ActivityActivityTermController {
   async getStudentActivitiesActivityTerm(
     @GetStudent() user: GetStudent,
     @Param() param: ApiAct006RequestParam,
-    @Body() body: ApiAct006RequestBody,
+    @Query() query: ApiAct006RequestQuery,
   ): Promise<ApiAct006ResponseOk> {
     const result =
       await this.activityActivityTermService.getStudentActivitiesActivityTerm(
         param,
-        body,
+        query,
         user.studentId,
       );
     return result;

--- a/packages/api/src/feature/activity/controller/activity.controller.ts
+++ b/packages/api/src/feature/activity/controller/activity.controller.ts
@@ -66,7 +66,7 @@ import type {
   ApiAct004ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct004";
 import type {
-  ApiAct005RequestBody,
+  ApiAct005RequestQuery,
   ApiAct005ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct005";
 import type {
@@ -129,10 +129,10 @@ export default class ActivityController {
   @UsePipes(new ZodPipe(apiAct005))
   async getStudentActivities(
     @GetStudent() user: GetStudent,
-    @Body() body: ApiAct005RequestBody,
+    @Query() query: ApiAct005RequestQuery,
   ): Promise<ApiAct005ResponseOk> {
     const result = await this.activityService.getStudentActivities(
-      body.clubId,
+      query.clubId,
       user.studentId,
     );
     return result;

--- a/packages/api/src/feature/activity/service/activity.activity-term.service.ts
+++ b/packages/api/src/feature/activity/service/activity.activity-term.service.ts
@@ -9,10 +9,11 @@ import ActivityRepository from "../repository/activity.repository";
 
 import type {
   ApiAct006RequestParam,
+  ApiAct006RequestQuery,
   ApiAct006ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct006";
 import type {
-  ApiAct009RequestBody,
+  ApiAct009RequestQuery,
   ApiAct009ResponseOk,
 } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct009";
 
@@ -72,14 +73,14 @@ export default class ActivityActivityTermService {
 
   async getStudentActivitiesActivityTerm(
     param: ApiAct006RequestParam,
-    body: ApiAct009RequestBody,
+    query: ApiAct006RequestQuery,
     studentId: number,
   ): Promise<ApiAct006ResponseOk> {
     // 요청한 학생이 동아리의 대표자인지 확인합니다.
-    await this.checkIsStudentDelegate({ studentId, clubId: body.clubId });
+    await this.checkIsStudentDelegate({ studentId, clubId: query.clubId });
     const activities =
       await this.activityRepository.selectActivityByClubIdAndActivityDId(
-        body.clubId,
+        query.clubId,
         param.activityTermId,
       );
     const result = await Promise.all(
@@ -107,15 +108,16 @@ export default class ActivityActivityTermService {
   }
 
   async getStudentActivitiesActivityTerms(
-    body: ApiAct009RequestBody,
+    query: ApiAct009RequestQuery,
     studentId: number,
   ): Promise<ApiAct009ResponseOk> {
     // 요청한 학생이 동아리의 대표자인지 확인합니다.
-    await this.checkIsStudentDelegate({ studentId, clubId: body.clubId });
+    await this.checkIsStudentDelegate({ studentId, clubId: query.clubId });
     // 해당 동아리가 등록되었던 학기 정보를 가져오고, startTerm과 endTerm에 대응되는 활동기간을 조회합니다.
     const semesters = await this.clubPublicService.getClubsExistedSemesters({
-      clubId: body.clubId,
+      clubId: query.clubId,
     });
+    console.log("asdfAsdf", semesters);
     const activityTerms: ApiAct009ResponseOk["terms"] = [];
     await Promise.all(
       semesters.map(async semester => {

--- a/packages/interface/src/api/activity/endpoint/apiAct005.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct005.ts
@@ -16,11 +16,11 @@ const method = "GET";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({});
-
-const requestBody = z.object({
+const requestQuery = z.object({
   clubId: z.coerce.number().int().min(1),
 });
+
+const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z
@@ -55,8 +55,8 @@ type ApiAct005ResponseOk = z.infer<(typeof apiAct005.responseBodyMap)[200]>;
 export default apiAct005;
 
 export type {
+  ApiAct005RequestBody,
   ApiAct005RequestParam,
   ApiAct005RequestQuery,
-  ApiAct005RequestBody,
   ApiAct005ResponseOk,
 };

--- a/packages/interface/src/api/activity/endpoint/apiAct006.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct006.ts
@@ -17,11 +17,11 @@ const requestParam = z.object({
   activityTermId: z.coerce.number().int().min(1),
 });
 
-const requestQuery = z.object({});
-
-const requestBody = z.object({
+const requestQuery = z.object({
   clubId: z.coerce.number().int().min(1),
 });
+
+const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
@@ -57,8 +57,8 @@ type ApiAct006ResponseOk = z.infer<(typeof apiAct006.responseBodyMap)[200]>;
 export default apiAct006;
 
 export type {
+  ApiAct006RequestBody,
   ApiAct006RequestParam,
   ApiAct006RequestQuery,
-  ApiAct006RequestBody,
   ApiAct006ResponseOk,
 };

--- a/packages/interface/src/api/activity/endpoint/apiAct009.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct009.ts
@@ -12,11 +12,11 @@ const method = "GET";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({});
-
-const requestBody = z.object({
+const requestQuery = z.object({
   clubId: z.coerce.number().int().min(1),
 });
+
+const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
@@ -52,8 +52,8 @@ type ApiAct009ResponseOk = z.infer<(typeof apiAct009.responseBodyMap)[200]>;
 export default apiAct009;
 
 export type {
+  ApiAct009RequestBody,
   ApiAct009RequestParam,
   ApiAct009RequestQuery,
-  ApiAct009RequestBody,
   ApiAct009ResponseOk,
 };

--- a/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
@@ -8,94 +8,72 @@ import {
 import styled from "styled-components";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
-import Tag, { type TagColor } from "@sparcs-clubs/web/common/components/Tag";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import {
+  ActTypeTagList,
+  ApplyTagList,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 import { type NewActivityReport } from "../types/activityReport";
 
 interface ActivityReportListProps {
-  data: NewActivityReport[];
+  data?: NewActivityReport[];
 }
 
 const columnHelper = createColumnHelper<NewActivityReport>();
 
-const getStatusTagColor = (status: string): TagColor => {
-  switch (status) {
-    case "운위":
-      return "ORANGE";
-    case "신청":
-      return "BLUE";
-    case "반려":
-      return "RED";
-    case "승인":
-      return "GREEN";
-    default:
-      return "GRAY";
-  }
-};
-
-const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
-  switch (professorApproval) {
-    case "대기":
-      return "GRAY";
-    case "완료":
-      return "GREEN";
-    case "반려":
-      return "RED";
-    default:
-      return "GRAY";
-  }
-};
-
-const getCategoryTagColor = (category: string): TagColor => {
-  switch (category) {
-    case "동아리 성격에 합치하는 내부 활동":
-      return "ORANGE";
-    case "동아리 성격에 합치하는 외부 활동":
-      return "BLUE";
-    case "동아리 성격에 합치하지 않는 활동":
-      return "PURPLE";
-    default:
-      return "GRAY";
-  }
-};
+// const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
+//   switch (professorApproval) {
+//     case "대기":
+//       return "GRAY";
+//     case "완료":
+//       return "GREEN";
+//     case "반려":
+//       return "RED";
+//     default:
+//       return "GRAY";
+//   }
+// };
 
 const columns = [
-  columnHelper.accessor(row => row.status, {
-    id: "status",
+  columnHelper.accessor("activityStatusEnumId", {
     header: "상태",
-    cell: info => (
-      <Tag color={getStatusTagColor(info.getValue())}>{info.getValue()}</Tag>
-    ),
+    cell: info => {
+      const { color, text } = getTagDetail(info.getValue(), ApplyTagList);
+      return <Tag color={color}>{text}</Tag>;
+    },
     size: 0,
   }),
-  columnHelper.accessor("professorApproval", {
-    id: "professorApproval",
-    header: "지도교수",
-    cell: info => (
-      <Tag color={getProfessorApprovalTagColor(info.getValue())}>
-        {info.getValue()}
-      </Tag>
-    ),
-    size: 0,
-  }),
-  columnHelper.accessor("activity", {
+  // columnHelper.accessor("professorApproval", {
+  //   id: "professorApproval",
+  //   header: "지도교수",
+  //   cell: info => (
+  //     <Tag color={getProfessorApprovalTagColor(info.getValue())}>
+  //       {info.getValue()}
+  //     </Tag>
+  //   ),
+  //   size: 0,
+  // }),
+  columnHelper.accessor("name", {
     id: "activity",
     header: "활동명",
     cell: info => info.getValue(),
     size: 20,
   }),
-  columnHelper.accessor("category", {
-    id: "category",
+  columnHelper.accessor("activityTypeEnumId", {
     header: "활동 분류",
-    cell: info => (
-      <Tag color={getCategoryTagColor(info.getValue())}>{info.getValue()}</Tag>
-    ),
+    cell: info => {
+      const { color, text } = getTagDetail(info.getValue(), ActTypeTagList);
+      return <Tag color={color}>{text}</Tag>;
+    },
     size: 32,
   }),
   columnHelper.accessor(
-    row => `${formatDate(row.startDate)} ~ ${formatDate(row.endDate)}`,
+    row => `${formatDate(row.startTerm)} ~ ${formatDate(row.endTerm)}`,
     {
       id: "date-range",
       header: "활동 기간",
@@ -114,7 +92,9 @@ const TableOuter = styled.div`
   align-self: stretch;
 `;
 
-const NewActivityReportList: React.FC<ActivityReportListProps> = ({ data }) => {
+const NewActivityReportList: React.FC<ActivityReportListProps> = ({
+  data = [],
+}) => {
   const table = useReactTable({
     columns,
     data,

--- a/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/NewActivityReportList.tsx
@@ -5,17 +5,16 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
 import {
   ActTypeTagList,
   ApplyTagList,
 } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
-
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 import { type NewActivityReport } from "../types/activityReport";
@@ -25,7 +24,7 @@ interface ActivityReportListProps {
 }
 
 const columnHelper = createColumnHelper<NewActivityReport>();
-
+// TODO(ym). 지도교수 승인이 활보 정책 문서 보면 필요없을 것 같지만 혹시 몰라 동연측에 문의 중(결과 확인 후 삭제 예정)
 // const getProfessorApprovalTagColor = (professorApproval: string): TagColor => {
 //   switch (professorApproval) {
 //     case "대기":
@@ -48,6 +47,7 @@ const columns = [
     },
     size: 0,
   }),
+  // TODO(ym). 지도교수 승인이 활보 정책 문서 보면 필요없을 것 같지만 혹시 몰라 동연측에 문의 중(결과 확인 후 삭제 예정)
   // columnHelper.accessor("professorApproval", {
   //   id: "professorApproval",
   //   header: "지도교수",
@@ -95,6 +95,7 @@ const TableOuter = styled.div`
 const NewActivityReportList: React.FC<ActivityReportListProps> = ({
   data = [],
 }) => {
+  const router = useRouter();
   const table = useReactTable({
     columns,
     data,
@@ -103,10 +104,11 @@ const NewActivityReportList: React.FC<ActivityReportListProps> = ({
   });
   return (
     <TableOuter>
-      <Typography fs={14} fw="REGULAR" lh={20} ff="PRETENDARD" color="GRAY.600">
-        총 {data.length}개
-      </Typography>
-      <Table table={table} />
+      <Table
+        table={table}
+        count={data.length}
+        onClick={row => router.push(`/manage-club/activity-report/${row.id}`)}
+      />
     </TableOuter>
   );
 };

--- a/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
@@ -13,7 +13,6 @@ import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import { ActTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 
@@ -90,14 +89,12 @@ const PastActivityReportList: React.FC<ActivityReportListProps> = ({
         title={`${term.year}년 ${term.name}학기 (총 ${data?.activities.length}개)`}
       >
         <TableOuter>
-          <Typography fs={16} lh={20} color="GRAY.600">
-            총 {data?.activities.length}개
-          </Typography>
           <Table
             table={table}
             onClick={row =>
               router.push(`/manage-club/activity-report/${row.id}`)
             }
+            count={data?.activities.length}
           />
         </TableOuter>
       </FoldableSection>

--- a/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
@@ -1,71 +1,59 @@
 import React from "react";
 
-import { ApiAct011ResponseOk } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct011";
+import { ApiAct006ResponseOk } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct006";
 import {
   createColumnHelper,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { overlay } from "overlay-kit";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
-import { ActStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import PastActivityReportModal from "@sparcs-clubs/web/features/register-club/components/_atomic/PastActivityReportModal";
+import { ActTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 
-import {
-  getActivityTypeTagColor,
-  getActivityTypeTagLabel,
-} from "@sparcs-clubs/web/features/register-club/utils/activityType";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import { PastActivityReport } from "../_mock/mock";
+import useGetActivityReportListForATerm from "../services/useGetActivityReportListForATerm";
+import { ActivityTerm } from "../types/activityReport";
 
 interface ActivityReportListProps {
-  data: PastActivityReport[];
-  profile: string;
-  showItemCount?: boolean;
-  refetch?: () => void;
+  term: ActivityTerm;
+  clubId: number;
 }
 
 const columnHelper =
-  createColumnHelper<ApiAct011ResponseOk["activities"][number]>();
+  createColumnHelper<ApiAct006ResponseOk["activities"][number]>();
 
 const columns = [
-  columnHelper.accessor("activityStatusEnumId", {
-    id: "activityStatusEnumId",
-    header: "상태",
-    cell: info => {
-      const { color, text } = getTagDetail(info.getValue(), ActStatusTagList);
-      return <Tag color={color}>{text}</Tag>;
-    },
-    size: 64,
-  }),
   columnHelper.accessor("name", {
+    id: "activity",
     header: "활동명",
     cell: info => info.getValue(),
-    size: 128,
+    size: 20,
   }),
   columnHelper.accessor("activityTypeEnumId", {
     header: "활동 분류",
-    cell: info => (
-      <Tag color={getActivityTypeTagColor(info.getValue())}>
-        {getActivityTypeTagLabel(info.getValue())}
-      </Tag>
-    ),
-    size: 128,
+    cell: info => {
+      const { color, text } = getTagDetail(info.getValue(), ActTypeTagList);
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 32,
   }),
   columnHelper.accessor(
-    row =>
-      `${formatDate(row.durations[0].startTerm)} ~ ${formatDate(row.durations[0].endTerm)}${row.durations.length > 1 ? ` 외 ${row.durations.length - 1}개` : ""}`,
+    row => `${formatDate(row.startTerm)} ~ ${formatDate(row.endTerm)}`,
     {
+      id: "date-range",
       header: "활동 기간",
       cell: info => info.getValue(),
-      size: 255,
+      size: 48,
     },
   ),
 ];
@@ -80,50 +68,40 @@ const TableOuter = styled.div`
 `;
 
 const PastActivityReportList: React.FC<ActivityReportListProps> = ({
-  data,
-  profile,
-  showItemCount = true,
-  refetch = () => {},
+  term,
+  clubId,
 }) => {
+  const router = useRouter();
+  const { data, isLoading, isError } = useGetActivityReportListForATerm(
+    term.id,
+    { clubId },
+  );
   const table = useReactTable({
     columns,
-    data,
+    data: data?.activities ?? [],
     getCoreRowModel: getCoreRowModel(),
     enableSorting: false,
   });
 
-  const openPastActivityReportModal = (activityId: number) => {
-    overlay.open(({ isOpen, close }) => (
-      <PastActivityReportModal
-        profile={profile}
-        activityId={activityId}
-        isOpen={isOpen}
-        close={() => {
-          close();
-          refetch();
-        }}
-      />
-    ));
-  };
-
   return (
-    <TableOuter>
-      {showItemCount && (
-        <Typography
-          fs={14}
-          fw="REGULAR"
-          lh={20}
-          ff="PRETENDARD"
-          color="GRAY.600"
-        >
-          총 {data.length}개
-        </Typography>
-      )}
-      <Table
-        table={table}
-        onClick={row => openPastActivityReportModal(row.id)}
-      />
-    </TableOuter>
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <FoldableSection
+        key={term.id}
+        title={`${term.year}년 ${term.name}학기 (총 ${data?.activities.length}개)`}
+      >
+        <TableOuter>
+          <Typography fs={16} lh={20} color="GRAY.600">
+            총 {data?.activities.length}개
+          </Typography>
+          <Table
+            table={table}
+            onClick={row =>
+              router.push(`/manage-club/activity-report/${row.id}`)
+            }
+          />
+        </TableOuter>
+      </FoldableSection>
+    </AsyncBoundary>
   );
 };
 

--- a/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/components/PastActivityReportList.tsx
@@ -20,7 +20,7 @@ import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
 
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import useGetActivityReportListForATerm from "../services/useGetActivityReportListForATerm";
+import useGetPastActivityReportList from "../services/useGetPastActivityReportList";
 import { ActivityTerm } from "../types/activityReport";
 
 interface ActivityReportListProps {
@@ -71,10 +71,9 @@ const PastActivityReportList: React.FC<ActivityReportListProps> = ({
   clubId,
 }) => {
   const router = useRouter();
-  const { data, isLoading, isError } = useGetActivityReportListForATerm(
-    term.id,
-    { clubId },
-  );
+  const { data, isLoading, isError } = useGetPastActivityReportList(term.id, {
+    clubId,
+  });
   const table = useReactTable({
     columns,
     data: data?.activities ?? [],

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
@@ -5,15 +5,14 @@ import styled from "styled-components";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import IconButton from "@sparcs-clubs/web/common/components/Buttons/IconButton";
-import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
-import { mockPastActivityData } from "../_mock/mock";
 import NewActivityReportList from "../components/NewActivityReportList";
 import PastActivityReportList from "../components/PastActivityReportList";
+import useGetActivityTerms from "../services/useGetActivityTerms";
 import useGetNewActivityReportList from "../services/useGetNewActivityReportList";
 
 const ActivityReportMainFrameInner = styled.div`
@@ -48,74 +47,78 @@ const PastSectionInner = styled.div`
 
 const ActivityReportMainFrame: React.FC = () => {
   // TODO(ym). manage-club 페이지에서 라우팅 연결되면 clubId props로 받아오기!
+  const clubId = 117;
   const {
     data: newActivityReportList,
     isLoading: isLoadingNewActivityReport,
     isError: isErrorNewActivityReport,
   } = useGetNewActivityReportList({
-    clubId: 117,
+    clubId,
   });
 
-  const isLoading = isLoadingNewActivityReport;
-  const isError = isErrorNewActivityReport;
+  const {
+    data: activityTerms,
+    isLoading: isLoadingActivityTerms,
+    isError: isErrorActivityTerms,
+  } = useGetActivityTerms({ clubId });
+
+  const isLoading = isLoadingActivityTerms;
+  const isError = isErrorActivityTerms;
 
   return (
-    <AsyncBoundary isLoading={isLoading} isError={isError}>
-      <ActivityReportMainFrameInner>
-        <PageHead
-          items={[
-            { name: "대표 동아리 관리", path: "/manage-club" },
-            { name: "활동 보고서", path: "/manage-club/activity-report" },
-          ]}
-          title="활동 보고서"
-        />
-        <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
-          <SectionInner>
-            <Info text="현재는 2024년 봄학기 활동 보고서 작성 기간입니다 (작성 마감 : 2024년 3월 10일 23:59)" />
-            <OptionOuter>
-              <Typography
-                fs={14}
-                fw="REGULAR"
-                lh={20}
-                color="GRAY.300"
-                ff="PRETENDARD"
-              >
-                활동 보고서는 최대 20개까지 작성 가능합니다
-              </Typography>
-              <Link href="/manage-club/activity-report/create">
-                <IconButton type="default" icon="add" onClick={() => {}}>
-                  활동 보고서 작성
-                </IconButton>
-              </Link>
-            </OptionOuter>
+    <ActivityReportMainFrameInner>
+      <PageHead
+        items={[
+          { name: "대표 동아리 관리", path: "/manage-club" },
+          { name: "활동 보고서", path: "/manage-club/activity-report" },
+        ]}
+        title="활동 보고서"
+      />
+      <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
+        <SectionInner>
+          <Info text="현재는 2024년 봄학기 활동 보고서 작성 기간입니다 (작성 마감 : 2024년 3월 10일 23:59)" />
+          <OptionOuter>
+            <Typography
+              fs={14}
+              fw="REGULAR"
+              lh={20}
+              color="GRAY.300"
+              ff="PRETENDARD"
+            >
+              활동 보고서는 최대 20개까지 작성 가능합니다
+            </Typography>
+            <Link href="/manage-club/activity-report/create">
+              <IconButton type="default" icon="add" onClick={() => {}}>
+                활동 보고서 작성
+              </IconButton>
+            </Link>
+          </OptionOuter>
+          <AsyncBoundary
+            isLoading={isLoadingNewActivityReport}
+            isError={isError}
+          >
             <NewActivityReportList data={newActivityReportList} />
-          </SectionInner>
-        </FoldableSectionTitle>
-        {/* TODO: profile 설정 */}
-        <FoldableSectionTitle title="과거 활동 보고서">
-          <PastSectionInner>
-            <FoldableSection title="2023년 가을학기 (총 6개)">
+          </AsyncBoundary>
+        </SectionInner>
+      </FoldableSectionTitle>
+      {/* TODO: profile 설정 */}
+      <FoldableSectionTitle title="과거 활동 보고서">
+        <PastSectionInner>
+          <AsyncBoundary
+            isLoading={isLoading}
+            isError={isErrorNewActivityReport}
+          >
+            {activityTerms?.terms.map(term => (
               <PastActivityReportList
-                data={mockPastActivityData.activities}
-                profile="undergraduate"
+                key={term.id}
+                term={term}
+                clubId={clubId}
               />
-            </FoldableSection>
-            <FoldableSection title="2023년 봄학기 (총 6개)">
-              <PastActivityReportList
-                data={mockPastActivityData.activities}
-                profile="undergraduate"
-              />
-            </FoldableSection>
-            <FoldableSection title="2022년 가을학기 (총 6개)">
-              <PastActivityReportList
-                data={mockPastActivityData.activities}
-                profile="undergraduate"
-              />
-            </FoldableSection>
-          </PastSectionInner>
-        </FoldableSectionTitle>
-      </ActivityReportMainFrameInner>
-    </AsyncBoundary>
+            ))}
+          </AsyncBoundary>
+        </PastSectionInner>
+      </FoldableSectionTitle>
+    </ActivityReportMainFrameInner>
   );
 };
 

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Link from "next/link";
 import styled from "styled-components";
 
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import IconButton from "@sparcs-clubs/web/common/components/Buttons/IconButton";
 import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
@@ -10,9 +11,10 @@ import Info from "@sparcs-clubs/web/common/components/Info";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
-import { mockNewActivityData, mockPastActivityData } from "../_mock/mock";
+import { mockPastActivityData } from "../_mock/mock";
 import NewActivityReportList from "../components/NewActivityReportList";
 import PastActivityReportList from "../components/PastActivityReportList";
+import useGetNewActivityReportList from "../services/useGetNewActivityReportList";
 
 const ActivityReportMainFrameInner = styled.div`
   display: flex;
@@ -44,61 +46,77 @@ const PastSectionInner = styled.div`
   gap: 40px;
 `;
 
-const ActivityReportMainFrame: React.FC = () => (
-  <ActivityReportMainFrameInner>
-    <PageHead
-      items={[
-        { name: "대표 동아리 관리", path: "/manage-club" },
-        { name: "활동 보고서", path: "/manage-club/activity-report" },
-      ]}
-      title="활동 보고서"
-    />
-    <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
-      <SectionInner>
-        <Info text="현재는 2024년 봄학기 활동 보고서 작성 기간입니다 (작성 마감 : 2024년 3월 10일 23:59)" />
-        <OptionOuter>
-          <Typography
-            fs={14}
-            fw="REGULAR"
-            lh={20}
-            color="GRAY.300"
-            ff="PRETENDARD"
-          >
-            활동 보고서는 최대 20개까지 작성 가능합니다
-          </Typography>
-          <Link href="/manage-club/activity-report/create">
-            <IconButton type="default" icon="add" onClick={() => {}}>
-              활동 보고서 작성
-            </IconButton>
-          </Link>
-        </OptionOuter>
-        <NewActivityReportList data={mockNewActivityData} />
-      </SectionInner>
-    </FoldableSectionTitle>
-    {/* TODO: profile 설정 */}
-    <FoldableSectionTitle title="과거 활동 보고서">
-      <PastSectionInner>
-        <FoldableSection title="2023년 가을학기 (총 6개)">
-          <PastActivityReportList
-            data={mockPastActivityData.activities}
-            profile="undergraduate"
-          />
-        </FoldableSection>
-        <FoldableSection title="2023년 봄학기 (총 6개)">
-          <PastActivityReportList
-            data={mockPastActivityData.activities}
-            profile="undergraduate"
-          />
-        </FoldableSection>
-        <FoldableSection title="2022년 가을학기 (총 6개)">
-          <PastActivityReportList
-            data={mockPastActivityData.activities}
-            profile="undergraduate"
-          />
-        </FoldableSection>
-      </PastSectionInner>
-    </FoldableSectionTitle>
-  </ActivityReportMainFrameInner>
-);
+const ActivityReportMainFrame: React.FC = () => {
+  // TODO(ym). manage-club 페이지에서 라우팅 연결되면 clubId props로 받아오기!
+  const {
+    data: newActivityReportList,
+    isLoading: isLoadingNewActivityReport,
+    isError: isErrorNewActivityReport,
+  } = useGetNewActivityReportList({
+    clubId: 117,
+  });
+
+  const isLoading = isLoadingNewActivityReport;
+  const isError = isErrorNewActivityReport;
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <ActivityReportMainFrameInner>
+        <PageHead
+          items={[
+            { name: "대표 동아리 관리", path: "/manage-club" },
+            { name: "활동 보고서", path: "/manage-club/activity-report" },
+          ]}
+          title="활동 보고서"
+        />
+        <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
+          <SectionInner>
+            <Info text="현재는 2024년 봄학기 활동 보고서 작성 기간입니다 (작성 마감 : 2024년 3월 10일 23:59)" />
+            <OptionOuter>
+              <Typography
+                fs={14}
+                fw="REGULAR"
+                lh={20}
+                color="GRAY.300"
+                ff="PRETENDARD"
+              >
+                활동 보고서는 최대 20개까지 작성 가능합니다
+              </Typography>
+              <Link href="/manage-club/activity-report/create">
+                <IconButton type="default" icon="add" onClick={() => {}}>
+                  활동 보고서 작성
+                </IconButton>
+              </Link>
+            </OptionOuter>
+            <NewActivityReportList data={newActivityReportList} />
+          </SectionInner>
+        </FoldableSectionTitle>
+        {/* TODO: profile 설정 */}
+        <FoldableSectionTitle title="과거 활동 보고서">
+          <PastSectionInner>
+            <FoldableSection title="2023년 가을학기 (총 6개)">
+              <PastActivityReportList
+                data={mockPastActivityData.activities}
+                profile="undergraduate"
+              />
+            </FoldableSection>
+            <FoldableSection title="2023년 봄학기 (총 6개)">
+              <PastActivityReportList
+                data={mockPastActivityData.activities}
+                profile="undergraduate"
+              />
+            </FoldableSection>
+            <FoldableSection title="2022년 가을학기 (총 6개)">
+              <PastActivityReportList
+                data={mockPastActivityData.activities}
+                profile="undergraduate"
+              />
+            </FoldableSection>
+          </PastSectionInner>
+        </FoldableSectionTitle>
+      </ActivityReportMainFrameInner>
+    </AsyncBoundary>
+  );
+};
 
 export default ActivityReportMainFrame;

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
@@ -101,20 +101,21 @@ const ActivityReportMainFrame: React.FC = () => {
           </AsyncBoundary>
         </SectionInner>
       </FoldableSectionTitle>
-      {/* TODO: profile 설정 */}
       <FoldableSectionTitle title="과거 활동 보고서">
         <PastSectionInner>
           <AsyncBoundary
             isLoading={isLoading}
             isError={isErrorNewActivityReport}
           >
-            {activityTerms?.terms.map(term => (
-              <PastActivityReportList
-                key={term.id}
-                term={term}
-                clubId={clubId}
-              />
-            ))}
+            {activityTerms?.terms
+              .toReversed()
+              .map(term => (
+                <PastActivityReportList
+                  key={term.id}
+                  term={term}
+                  clubId={clubId}
+                />
+              ))}
           </AsyncBoundary>
         </PastSectionInner>
       </FoldableSectionTitle>

--- a/packages/web/src/features/manage-club/activity-report/services/useGetActivityReportListForATerm.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetActivityReportListForATerm.tsx
@@ -1,0 +1,49 @@
+import apiAct006, {
+  ApiAct006RequestQuery,
+  ApiAct006ResponseOk,
+} from "@sparcs-clubs/interface/api/activity/endpoint/apiAct006";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetActivityReportListForATerm = (
+  activityTermId: number,
+  query: ApiAct006RequestQuery,
+) =>
+  useQuery<ApiAct006ResponseOk, Error>({
+    queryKey: [apiAct006.url(activityTermId)],
+    queryFn: async (): Promise<ApiAct006ResponseOk> => {
+      const { data } = await axiosClientWithAuth.get(
+        apiAct006.url(activityTermId),
+        {
+          params: query,
+        },
+      );
+
+      return apiAct006.responseBodyMap[200].parse(data);
+    },
+  });
+
+export default useGetActivityReportListForATerm;
+
+const baseUrl = "/student/activities/activity-terms/activity-term/";
+
+defineAxiosMock(mock => {
+  mock.onGet(new RegExp(`^${baseUrl}\\d+$`)).reply(() => [
+    200,
+    {
+      activities: [
+        {
+          id: 111,
+          name: "개발개발한 어떠한 활동",
+          activityTypeEnumId: 2,
+          startTerm: "2024-12-06T02:58:38.000Z",
+          endTerm: "2024-12-17T02:58:49.000Z",
+        },
+      ],
+    },
+  ]);
+});

--- a/packages/web/src/features/manage-club/activity-report/services/useGetActivityTerms.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetActivityTerms.tsx
@@ -1,0 +1,55 @@
+import apiAct009, {
+  ApiAct009RequestQuery,
+  ApiAct009ResponseOk,
+} from "@sparcs-clubs/interface/api/activity/endpoint/apiAct009";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetActivityTerms = (query: ApiAct009RequestQuery) =>
+  useQuery<ApiAct009ResponseOk, Error>({
+    queryKey: [apiAct009.url()],
+    queryFn: async (): Promise<ApiAct009ResponseOk> => {
+      const { data } = await axiosClientWithAuth.get(apiAct009.url(), {
+        params: query,
+      });
+
+      return apiAct009.responseBodyMap[200].parse(data);
+    },
+  });
+
+export default useGetActivityTerms;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiAct009.url()).reply(() => [
+    200,
+    {
+      terms: [
+        {
+          id: 1,
+          year: 2023,
+          name: "가을",
+          startTerm: "2023-01-01T07:16:56.000Z",
+          endTerm: "2023-06-01T07:16:55.000Z",
+        },
+        {
+          id: 4,
+          year: 2023,
+          name: "봄",
+          startTerm: "2023-07-04T07:16:57.000Z",
+          endTerm: "2023-11-30T00:00:00.000Z",
+        },
+        {
+          id: 5,
+          year: 2022,
+          name: "가을",
+          startTerm: "2023-12-01T00:00:00.000Z",
+          endTerm: "2023-03-01T00:00:00.000Z",
+        },
+      ],
+    },
+  ]);
+});

--- a/packages/web/src/features/manage-club/activity-report/services/useGetNewActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetNewActivityReportList.tsx
@@ -1,0 +1,56 @@
+import apiAct005, {
+  ApiAct005RequestQuery,
+  ApiAct005ResponseOk,
+} from "@sparcs-clubs/interface/api/activity/endpoint/apiAct005";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetNewActivityReportList = (query: ApiAct005RequestQuery) =>
+  useQuery<ApiAct005ResponseOk, Error>({
+    queryKey: [apiAct005.url()],
+    queryFn: async (): Promise<ApiAct005ResponseOk> => {
+      const { data } = await axiosClientWithAuth.get(apiAct005.url(), {
+        params: query,
+      });
+
+      return apiAct005.responseBodyMap[200].parse(data);
+    },
+  });
+
+export default useGetNewActivityReportList;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiAct005.url()).reply(() => [
+    200,
+    [
+      {
+        id: 111,
+        activityStatusEnumId: 1,
+        name: "겨울학기 활동 테스트",
+        activityTypeEnumId: 2,
+        startTerm: "2024-12-06T02:58:38.000Z",
+        endTerm: "2024-12-17T02:58:49.000Z",
+      },
+      {
+        id: 112,
+        activityStatusEnumId: 2,
+        name: "겨울학기 활동 테스트",
+        activityTypeEnumId: 1,
+        startTerm: "2024-12-06T02:58:38.000Z",
+        endTerm: "2024-12-17T02:58:49.000Z",
+      },
+      {
+        id: 113,
+        activityStatusEnumId: 3,
+        name: "겨울학기 활동 테스트",
+        activityTypeEnumId: 3,
+        startTerm: "2024-12-06T02:58:38.000Z",
+        endTerm: "2024-12-17T02:58:49.000Z",
+      },
+    ],
+  ]);
+});

--- a/packages/web/src/features/manage-club/activity-report/services/useGetPastActivityReportList.tsx
+++ b/packages/web/src/features/manage-club/activity-report/services/useGetPastActivityReportList.tsx
@@ -9,7 +9,7 @@ import {
   defineAxiosMock,
 } from "@sparcs-clubs/web/lib/axios";
 
-const useGetActivityReportListForATerm = (
+const useGetPastActivityReportList = (
   activityTermId: number,
   query: ApiAct006RequestQuery,
 ) =>
@@ -27,7 +27,7 @@ const useGetActivityReportListForATerm = (
     },
   });
 
-export default useGetActivityReportListForATerm;
+export default useGetPastActivityReportList;
 
 const baseUrl = "/student/activities/activity-terms/activity-term/";
 

--- a/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
+++ b/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
@@ -1,13 +1,19 @@
+import {
+  ActivityStatusEnum,
+  ActivityTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/activity.enum";
+
 export interface PastActivityReport {
-  activity: string;
-  category: string;
-  startDate: Date;
-  endDate: Date;
+  id: number;
+  activityTypeEnumId: ActivityTypeEnum;
+  name: string;
+  startTerm: Date;
+  endTerm: Date;
 }
 
 export interface NewActivityReport extends PastActivityReport {
-  status: string;
-  professorApproval: string;
+  activityStatusEnumId: ActivityStatusEnum;
+  professorApproval?: string;
 }
 
 export interface Participant {

--- a/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
+++ b/packages/web/src/features/manage-club/activity-report/types/activityReport.ts
@@ -34,3 +34,11 @@ export interface ActivityReport {
   participants: Participant[];
   proof: string;
 }
+
+export interface ActivityTerm {
+  id: number;
+  name: string;
+  startTerm: Date;
+  endTerm: Date;
+  year: number;
+}

--- a/packages/web/src/features/register-club/components/ActivityReportFrame.tsx
+++ b/packages/web/src/features/register-club/components/ActivityReportFrame.tsx
@@ -11,11 +11,11 @@ import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
-import PastActivityReportList from "@sparcs-clubs/web/features/manage-club/activity-report/components/PastActivityReportList";
 
 import { useGetActivityReportsForPromotional } from "../services/useGetActivityReportsForPromotional";
 
 import CreateActivityReportModal from "./_atomic/CreateActivityReportModal";
+import ActivityReportList from "./ActivityReportList";
 
 interface ActivityReportFrameProps {
   clubId: number;
@@ -82,7 +82,7 @@ const ActivityReportFrame: React.FC<ActivityReportFrameProps> = ({
               활동 보고서 작성
             </IconButton>
           </OptionOuter>
-          <PastActivityReportList
+          <ActivityReportList
             data={data?.activities ?? []}
             profile={profile?.type ?? ""}
             refetch={refetch}

--- a/packages/web/src/features/register-club/components/ActivityReportList.tsx
+++ b/packages/web/src/features/register-club/components/ActivityReportList.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+
+import { ApiAct011ResponseOk } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct011";
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { overlay } from "overlay-kit";
+import styled from "styled-components";
+
+import Table from "@sparcs-clubs/web/common/components/Table";
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+
+import { ActStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import PastActivityReportModal from "@sparcs-clubs/web/features/register-club/components/_atomic/PastActivityReportModal";
+
+import {
+  getActivityTypeTagColor,
+  getActivityTypeTagLabel,
+} from "@sparcs-clubs/web/features/register-club/utils/activityType";
+import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+import { ActivityReport } from "../types/registerClub";
+
+interface ActivityReportListProps {
+  data: ActivityReport[];
+  profile: string;
+  showItemCount?: boolean;
+  refetch?: () => void;
+}
+
+const columnHelper =
+  createColumnHelper<ApiAct011ResponseOk["activities"][number]>();
+
+const columns = [
+  columnHelper.accessor("activityStatusEnumId", {
+    id: "activityStatusEnumId",
+    header: "상태",
+    cell: info => {
+      const { color, text } = getTagDetail(info.getValue(), ActStatusTagList);
+      return <Tag color={color}>{text}</Tag>;
+    },
+    size: 64,
+  }),
+  columnHelper.accessor("name", {
+    header: "활동명",
+    cell: info => info.getValue(),
+    size: 128,
+  }),
+  columnHelper.accessor("activityTypeEnumId", {
+    header: "활동 분류",
+    cell: info => (
+      <Tag color={getActivityTypeTagColor(info.getValue())}>
+        {getActivityTypeTagLabel(info.getValue())}
+      </Tag>
+    ),
+    size: 128,
+  }),
+  columnHelper.accessor(
+    row =>
+      `${formatDate(row.durations[0].startTerm)} ~ ${formatDate(row.durations[0].endTerm)}${row.durations.length > 1 ? ` 외 ${row.durations.length - 1}개` : ""}`,
+    {
+      header: "활동 기간",
+      cell: info => info.getValue(),
+      size: 255,
+    },
+  ),
+];
+
+const TableOuter = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 8px;
+  align-self: stretch;
+`;
+
+const ActivityReportList: React.FC<ActivityReportListProps> = ({
+  data,
+  profile,
+  showItemCount = true,
+  refetch = () => {},
+}) => {
+  const table = useReactTable({
+    columns,
+    data,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  const openPastActivityReportModal = (activityId: number) => {
+    overlay.open(({ isOpen, close }) => (
+      <PastActivityReportModal
+        profile={profile}
+        activityId={activityId}
+        isOpen={isOpen}
+        close={() => {
+          close();
+          refetch();
+        }}
+      />
+    ));
+  };
+
+  return (
+    <TableOuter>
+      {showItemCount && (
+        <Typography
+          fs={14}
+          fw="REGULAR"
+          lh={20}
+          ff="PRETENDARD"
+          color="GRAY.600"
+        >
+          총 {data.length}개
+        </Typography>
+      )}
+      <Table
+        table={table}
+        onClick={row => openPastActivityReportModal(row.id)}
+      />
+    </TableOuter>
+  );
+};
+
+export default ActivityReportList;

--- a/packages/web/src/features/register-club/components/ActivityReportList.tsx
+++ b/packages/web/src/features/register-club/components/ActivityReportList.tsx
@@ -11,7 +11,6 @@ import styled from "styled-components";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import { ActStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import PastActivityReportModal from "@sparcs-clubs/web/features/register-club/components/_atomic/PastActivityReportModal";
@@ -28,7 +27,6 @@ import { ActivityReport } from "../types/registerClub";
 interface ActivityReportListProps {
   data: ActivityReport[];
   profile: string;
-  showItemCount?: boolean;
   refetch?: () => void;
 }
 
@@ -82,7 +80,6 @@ const TableOuter = styled.div`
 const ActivityReportList: React.FC<ActivityReportListProps> = ({
   data,
   profile,
-  showItemCount = true,
   refetch = () => {},
 }) => {
   const table = useReactTable({
@@ -108,19 +105,9 @@ const ActivityReportList: React.FC<ActivityReportListProps> = ({
 
   return (
     <TableOuter>
-      {showItemCount && (
-        <Typography
-          fs={14}
-          fw="REGULAR"
-          lh={20}
-          ff="PRETENDARD"
-          color="GRAY.600"
-        >
-          총 {data.length}개
-        </Typography>
-      )}
       <Table
         table={table}
+        count={data.length}
         onClick={row => openPastActivityReportModal(row.id)}
       />
     </TableOuter>

--- a/packages/web/src/features/register-club/types/registerClub.ts
+++ b/packages/web/src/features/register-club/types/registerClub.ts
@@ -1,4 +1,5 @@
 import { ApiReg001RequestBody } from "@sparcs-clubs/interface/api/registration/endpoint/apiReg001";
+import { ActivityStatusEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
 import { ProfessorEnum } from "@sparcs-clubs/interface/common/enum/user.enum";
 
 export interface RegisterClubInterface extends ApiReg001RequestBody {
@@ -24,3 +25,11 @@ export interface Duration {
   startTerm: Date;
   endTerm: Date;
 }
+
+export type ActivityReport = {
+  id: number;
+  name: string;
+  activityTypeEnumId: number;
+  activityStatusEnumId: ActivityStatusEnum;
+  durations: Duration[];
+};


### PR DESCRIPTION
# 요약 \*

apiAct005 (신규 활동보고서 목록 조회)
- 테스트 시 백엔드 코드 일부 수정해야 함
- 1. apiAct005 파일에서 requestBody 다음 부분을 requestQuery 내부로 이동 `clubId: z.coerce.number().int().min(1),`
- 2. activity.controller.ts 에서 다음과 같이 변경
  - <img width="600" alt="image" src="https://github.com/user-attachments/assets/3bba0cde-a9ed-484b-9d03-49092db1e526" />

apiAct006 (과거 활동보고서 목록 조회)
- 테스트 시 백엔드 코드 수정해야 함
  - 위와 같음 (apiAct006, apiAct009, activity.activity-term.controller, activity.activity-term.service 수정 필요)
- apiAct009가 과거 활동 기간 목록이 맞는지 모르겠음.. 일단 넣긴 했는데 데브에서 테스트했을 때 신규 활동보고서와 같은 기간이 밑에 추가됨 
- apiAct009에서의 year, name을 이런식으로 사용하는 것이 맞는지 모르겠음 `${term.year}년 ${term.name}학기` (name이 정확히 뭘 말하는건지 모르겠음)

It closes #1254

# 스크린샷 
# http://localhost:3000/manage-club/activity-report
- 신규 활동 보고서
![image](https://github.com/user-attachments/assets/5b8b8c89-ff46-4855-9aa8-07997b1b176e)
- 과거 활동 보고서
![image](https://github.com/user-attachments/assets/5853feb9-7fa6-4181-9f4c-7613e4759dba)




# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
