### PR TITLE
fix change representative

### DIFF
--- a/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
+++ b/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
@@ -7,6 +7,7 @@ import {
 import {
   and,
   count,
+  desc,
   eq,
   gte,
   isNotNull,
@@ -73,17 +74,25 @@ export class ClubDelegateDRepository {
   /**
    * @param clubId 변경 신청을 조회하고자 하는 동아리의 id
    * @returns 해당 동아리의 모든 대표자 변경 요청의 목록
+   * 3일 이내에 신청된 요청만을 조회합니다.
+   * 최근에 신청된 요청이 가장 위에 위치합니다.
    */
   async findDelegateChangeRequestByClubId(param: { clubId: number }) {
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
     const result = await this.db
       .select()
       .from(ClubDelegateChangeRequest)
       .where(
         and(
           eq(ClubDelegateChangeRequest.clubId, param.clubId),
+          gte(ClubDelegateChangeRequest.createdAt, threeDaysAgo),
           isNull(ClubDelegateChangeRequest.deletedAt),
         ),
-      );
+      )
+      .orderBy(desc(ClubDelegateChangeRequest.createdAt));
+
     return result;
   }
 
@@ -109,8 +118,12 @@ export class ClubDelegateDRepository {
   /**
    * @param studentId 변경의 대상이 된 학생의 id
    * @returns 해당 학생이 변경의 대상이 된 요청의 목록, 로직에 문제가 없다면 배열의 길이가 항상 1 이하여야 합니다.
+   * 3일 이내에 신청된 요청만을 조회합니다.
    */
   async findDelegateChangeRequestByStudentId(param: { studentId: number }) {
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
     const result = await this.db
       .select()
       .from(ClubDelegateChangeRequest)
@@ -121,6 +134,7 @@ export class ClubDelegateDRepository {
             ClubDelegateChangeRequestStatusEnum.Applied,
           ),
           eq(ClubDelegateChangeRequest.studentId, param.studentId),
+          gte(ClubDelegateChangeRequest.createdAt, threeDaysAgo),
           isNull(ClubDelegateChangeRequest.deletedAt),
         ),
       );

--- a/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
+++ b/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
@@ -77,6 +77,7 @@ export class ClubDelegateDRepository {
    * 3일 이내에 신청된 요청만을 조회합니다.
    * 최근에 신청된 요청이 가장 위에 위치합니다.
    */
+  // TODO: 만료 enum 추가
   async findDelegateChangeRequestByClubId(param: { clubId: number }) {
     const threeDaysAgo = new Date();
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);

--- a/packages/web/src/features/manage-club/components/ChangeRepresentativeCard.tsx
+++ b/packages/web/src/features/manage-club/components/ChangeRepresentativeCard.tsx
@@ -140,7 +140,8 @@ const ChangeRepresentativeCard: React.FC<{
         delegatesNow?.delegates
           .find(delegate => delegate.delegateEnumId === 2)
           ?.studentId?.toString() &&
-      type !== "Applied"
+      type !== "Applied" &&
+      delegate1 !== ""
     ) {
       updateClubDelegates(
         { clubId },
@@ -159,7 +160,8 @@ const ChangeRepresentativeCard: React.FC<{
         delegatesNow?.delegates
           .find(delegate => delegate.delegateEnumId === 3)
           ?.studentId?.toString() &&
-      type !== "Applied"
+      type !== "Applied" &&
+      delegate2 !== ""
     ) {
       updateClubDelegates(
         { clubId },
@@ -175,7 +177,6 @@ const ChangeRepresentativeCard: React.FC<{
   const cancelRequest = () => {
     setType("Canceled");
     deleteChangeDelegateRequest({ clubId });
-    refetch();
   };
 
   const changeDelegateRequest = async (
@@ -231,8 +232,28 @@ const ChangeRepresentativeCard: React.FC<{
           </Typography>
           <TextButton
             text="대의원1 삭제"
-            onClick={() => setDelegate1("")}
-            disabled={delegate1 === ""}
+            onClick={async () => {
+              setDelegateItems(prevItems =>
+                prevItems.map(item =>
+                  item.value === delegate1
+                    ? { ...item, selectable: true }
+                    : item,
+                ),
+              );
+              setRepresentativeItems(prevItems =>
+                prevItems.map(item =>
+                  item.value === delegate1
+                    ? { ...item, selectable: true }
+                    : item,
+                ),
+              );
+              setDelegate1("");
+              await updateClubDelegates(
+                { clubId },
+                { delegateEnumId: ClubDelegateEnum.Delegate1, studentId: 0 },
+              );
+            }}
+            disabled={delegate1 === "" || type === "Applied"}
           />
         </LabelWrapper>
         <Select
@@ -250,8 +271,28 @@ const ChangeRepresentativeCard: React.FC<{
           </Typography>
           <TextButton
             text="대의원2 삭제"
-            onClick={() => setDelegate2("")}
-            disabled={delegate2 === ""}
+            onClick={async () => {
+              setDelegateItems(prevItems =>
+                prevItems.map(item =>
+                  item.value === delegate2
+                    ? { ...item, selectable: true }
+                    : item,
+                ),
+              );
+              setRepresentativeItems(prevItems =>
+                prevItems.map(item =>
+                  item.value === delegate2
+                    ? { ...item, selectable: true }
+                    : item,
+                ),
+              );
+              setDelegate2("");
+              await updateClubDelegates(
+                { clubId },
+                { delegateEnumId: ClubDelegateEnum.Delegate2, studentId: 0 },
+              );
+            }}
+            disabled={delegate2 === "" || type === "Applied"}
           />
         </LabelWrapper>
         <Select

--- a/packages/web/src/features/my/components/ChangeRepresentativeModalContent.tsx
+++ b/packages/web/src/features/my/components/ChangeRepresentativeModalContent.tsx
@@ -19,7 +19,7 @@ interface ChangeRepresentativeModalContentProps {
   onClose: () => void;
   refetch: () => void;
   requestId: number;
-  setType: (type: "Requested" | "Finished") => void;
+  setType: (type: "Requested" | "Finished" | "Rejected") => void;
 }
 
 const ButtonWrapper = styled.div`
@@ -44,7 +44,6 @@ const ChangeRepresentativeModalContent: React.FC<
   const [errorPhone, setErrorPhone] = useState<boolean>(false);
   const [phone, setPhone] = useState<string>("");
 
-  // TODO: clb013 014 수정되면 반영
   const onConfirm = () => {
     patchMyDelegateRequest(
       { requestId },
@@ -67,6 +66,7 @@ const ChangeRepresentativeModalContent: React.FC<
           ClubDelegateChangeRequestStatusEnum.Rejected,
       },
     );
+    setType("Rejected");
     onClose();
   };
 

--- a/packages/web/src/features/my/components/MyChangeRepresentative.tsx
+++ b/packages/web/src/features/my/components/MyChangeRepresentative.tsx
@@ -81,10 +81,7 @@ const MyChangeRepresentative: React.FC<MyChangeRepresentativeProps> = ({
           clubName={clubName}
           prevRepresentative={prevRepresentative}
           newRepresentative={newRepresentative}
-          onClose={() => {
-            close();
-            setType("Rejected");
-          }}
+          onClose={close}
           refetch={refetch}
           requestId={requestId}
           setType={setType}


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1257 

BE 수정사항
- CLB011, 013:  3일 지난 요청 만료(get할 때 제외)되도록 수정 
-> 삭제는 하지 않고 제외만 되도록 했는데 삭제 필요한가요?
- CLB012: 승인/거절된 요청 남아있을 때 대표자 변경 신청->취소하면 이전 승인/거절 결과가 나타나는 문제 있어서 대표자 변경 취소할 때 이전에 남아있는 (3일 지나지 않은) 요청 삭제하도록 수정

추가된 조건 관련해서 API 문서에 파란색으로 수정해두었습니다. 리뷰할 때 같이 검토 부탁드립니다.

FE 수정사항
- 대의원 삭제할 때 Select 목록 업데이트 되지 않는 문제 수정
- 대표자 변경 요청 들어가있는 상태에서 대의원 삭제 버튼 disabled
- 대의원 비어있을 때 새로고침하면 계속 대의원 변경 api 호출되는 문제 수정
- 마이페이지에서 대표자 변경 승인/거절 모달 닫을 때 변경 요청 거절로 화면 바뀌는 문제 수정

나름 다양한 케이스에 대해 테스트하면서 오류 잡았는데 놓친 것이 있을 수 있으니 최대한 다양하게 테스트해주시면 감사하겠습니다

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
