### PR TITLE
Fix refetch problem with activity report

### DIFF
--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportCreateFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportCreateFrame.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ApiAct001RequestBody } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct001";
 import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
 
-import { useRouter } from "next/navigation";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 
@@ -56,8 +55,6 @@ const ActivityReportCreateFrame: React.FC<ActivityReportCreateFrameProps> = ({
 }) => {
   const formCtx = useForm<ActivityReportForm>({ mode: "all" });
 
-  const router = useRouter();
-
   const { mutate } = usePostActivityReport();
 
   const submitHandler = useCallback(
@@ -80,12 +77,12 @@ const ActivityReportCreateFrame: React.FC<ActivityReportCreateFrameProps> = ({
         },
         {
           onSuccess: () => {
-            router.push("/manage-club/activity-report");
+            window.location.href = "/manage-club/activity-report";
           },
         },
       );
     },
-    [],
+    [clubId, mutate],
   );
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -138,7 +138,7 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
               {
                 onSuccess: () => {
                   close();
-                  router.push("/manage-club/activity-report");
+                  router.replace("/manage-club/activity-report");
                 },
               },
             );

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -138,7 +138,7 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
               {
                 onSuccess: () => {
                   close();
-                  router.replace("/manage-club/activity-report");
+                  window.location.href = "/manage-club/activity-report";
                 },
               },
             );

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportEditFrame.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ApiAct003RequestBody } from "@sparcs-clubs/interface/api/activity/endpoint/apiAct003";
 
 import { ActivityTypeEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
-import { useRouter } from "next/navigation";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 
@@ -64,8 +63,6 @@ const ActivityReportEditFrame: React.FC<ActivityReportEditFrameProps> = ({
     Number(id),
   );
 
-  const router = useRouter();
-
   useEffect(() => {
     if (data) {
       /* NOTE: (@dora) request body of put should not include clubId */
@@ -106,12 +103,12 @@ const ActivityReportEditFrame: React.FC<ActivityReportEditFrameProps> = ({
         },
         {
           onSuccess: () => {
-            router.push(`/manage-club/activity-report/${id}`);
+            window.location.href = `/manage-club/activity-report/${id}`;
           },
         },
       );
     },
-    [id, router, mutate],
+    [id, mutate],
   );
 
   const handleSubmit = (e: React.BaseSyntheticEvent) => {
@@ -194,8 +191,6 @@ const ActivityReportEditFrame: React.FC<ActivityReportEditFrameProps> = ({
   const [selectedParticipants, setSelectedParticipants] = useState<
     Participant[]
   >([]);
-
-  console.log(selectedParticipants, initialParticipants, participantData);
 
   useEffect(() => {
     if (initialParticipants && participantData) {
@@ -374,7 +369,6 @@ const ActivityReportEditFrame: React.FC<ActivityReportEditFrameProps> = ({
                         const participantIds = v.map(_data => ({
                           studentId: +_data.id,
                         }));
-                        console.log("participantIds", participantIds);
                         formCtx.setValue("participants", participantIds);
                         formCtx.trigger("participants");
                       }}

--- a/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
+++ b/packages/web/src/features/manage-club/activity-report/frames/ActivityReportMainFrame.tsx
@@ -85,7 +85,7 @@ const ActivityReportMainFrame: React.FC<ActivityReportMainFrameProps> = ({
       />
       <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
         <SectionInner>
-          <Info text="현재는 2024년 여름-가을학기 활동 보고서 작성 기간입니다 (작성 마감 : 2024년 1월 7일 23:59)" />
+          <Info text="현재는 2024년 여름-가을학기 활동 보고서 작성 기간입니다 (작성 마감 : 2025년 1월 7일 23:59)" />
           <AsyncBoundary
             isLoading={isLoadingNewActivityReport}
             isError={isErrorNewActivityReport}


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1270 

- 생성, 수정, 삭제 후 데이터 업데이트 안 되는 문제 수정 (delete는 router.replace로 해결, 생성, 수정은 window location href 이용해서 강제 새로고침) -> 혹시 더 좋은 방법이 있다면 알려주세요
- 눈에 보이는 console log 삭제
- 하드코딩된 텍스트 2024->2025 수정
# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
