### PR TITLE
fix: reg005 club member registration startterm to clubts one

### DIFF
--- a/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-student-t.repository.ts
@@ -15,7 +15,7 @@ import {
 import { MySql2Database } from "drizzle-orm/mysql2";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
-import { getKSTDate, takeUnique } from "@sparcs-clubs/api/common/util/util";
+import { takeUnique } from "@sparcs-clubs/api/common/util/util";
 import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 
 import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
@@ -155,15 +155,15 @@ export default class ClubStudentTRepository {
     studentId: number,
     clubId: number,
     semesterId: number,
+    startTerm: Date,
   ): Promise<void> {
-    const cur = getKSTDate();
     await this.db
       .insert(ClubStudentT)
       .values({
         studentId,
         clubId,
         semesterId,
-        startTerm: cur,
+        startTerm,
       })
       .execute();
   }

--- a/packages/api/src/feature/club/repository/club.club-t.repository.ts
+++ b/packages/api/src/feature/club/repository/club.club-t.repository.ts
@@ -120,4 +120,18 @@ export default class ClubTRepository {
       .where(and(eq(ClubT.semesterId, semesterId), isNull(ClubT.deletedAt)))
       .then(result => result);
   }
+
+  async findByClubIdAndSemesterId(clubId: number, semesterId: number) {
+    return this.db
+      .select()
+      .from(ClubT)
+      .where(
+        and(
+          eq(ClubT.clubId, clubId),
+          eq(ClubT.semesterId, semesterId),
+          isNull(ClubT.deletedAt),
+        ),
+      )
+      .then(takeUnique);
+  }
 }

--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -238,11 +238,23 @@ export default class ClubPublicService {
       );
     }
 
+    const clubT = await this.clubTRepository.findByClubIdAndSemesterId(
+      clubId,
+      semesterId,
+    );
+    if (!semesterId) {
+      throw new HttpException(
+        "The club is not found at that semester.",
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
     // 신입 부원 추가
     await this.clubStudentTRepository.addStudentToClub(
       studentId,
       clubId,
       semesterId,
+      clubT.startTerm,
     );
   }
 


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1302 



# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

addStudentToClub할 때 현재 시간 기준으로 추가하던 것을 semester 기준으로 변경합니다.
그 과정에서 semester랑 club으로 clubT를 구하는 게 없어서 추가했습니다.

아 근데 REG 005 가 아니라 007 이네요 ㅎ(대표자가 인원 승인할 때)

CHANGED:

![image](https://github.com/user-attachments/assets/d71370ad-4d94-43c7-9e25-87ac73a13383)

![image](https://github.com/user-attachments/assets/5e17e9e8-3bb7-4857-9bb9-6412e1ac2ff7)


ADDED:
![image](https://github.com/user-attachments/assets/d21f4835-433c-4b19-970d-176e4ceb6ee0)


# 이후 Task 

- 없음

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
