### PR TITLE
과거 활보 수정, 삭제, 승인 버튼 안 보이도록 변경

### DIFF
--- a/packages/web/src/features/activity-report/components/PastActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/PastActivityReportTable.tsx
@@ -82,7 +82,6 @@ const PastActivityReportTable: React.FC<PastActivityReportTableProps> = ({
         <Table
           table={table}
           onClick={row => {
-            localStorage.setItem("isPastActivity", "true");
             router.push(`/manage-club/activity-report/${row.id}`);
           }}
           count={data.length}

--- a/packages/web/src/features/activity-report/components/PastActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/PastActivityReportTable.tsx
@@ -81,7 +81,10 @@ const PastActivityReportTable: React.FC<PastActivityReportTableProps> = ({
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <Table
           table={table}
-          onClick={row => router.push(`/manage-club/activity-report/${row.id}`)}
+          onClick={row => {
+            localStorage.setItem("isPastActivity", "true");
+            router.push(`/manage-club/activity-report/${row.id}`);
+          }}
           count={data.length}
         />
       </AsyncBoundary>

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -196,8 +196,16 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
       return false;
     }
 
+    const maxEndTermDuration = data.durations.reduce(
+      (maxDuration, currentDuration) =>
+        new Date(currentDuration.endTerm) > new Date(maxDuration.endTerm)
+          ? currentDuration
+          : maxDuration,
+      data.durations[0],
+    );
+
     return (
-      new Date(data.durations[data.durations.length - 1].endTerm) <
+      new Date(maxEndTermDuration.endTerm) <
       new Date(activityDeadline.targetTerm.startTerm)
     );
   }, [activityDeadline, data.durations]);

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ReactNode, useCallback } from "react";
+import React, { ReactNode, useCallback, useEffect, useState } from "react";
 
 import { useParams, useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
@@ -113,6 +113,16 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
 }) => {
   const router = useRouter();
   const { id } = useParams<{ id: string }>();
+
+  const [isPastActivity, setIsPastActivity] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const storedValue = localStorage.getItem("isPastActivity");
+    if (storedValue !== null) {
+      setIsPastActivity(storedValue === "true");
+      localStorage.removeItem("isPastActivity");
+    }
+  }, []);
 
   const { data, isLoading, isError } = useGetActivityReportDetail(Number(id));
   const { mutate: deleteActivityReport } = useDeleteActivityReport();
@@ -343,7 +353,7 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
               목록으로 돌아가기
             </Button>
 
-            {additionalButtons()}
+            {isPastActivity ? null : additionalButtons()}
           </FlexWrapper>
         </FlexWrapper>
       </AsyncBoundary>

--- a/packages/web/src/features/activity-report/services/useGetActivityDeadline.ts
+++ b/packages/web/src/features/activity-report/services/useGetActivityDeadline.ts
@@ -1,0 +1,44 @@
+import apiAct018, {
+  ApiAct018ResponseOk,
+} from "@sparcs-clubs/interface/api/activity/endpoint/apiAct018";
+import { ActivityDeadlineEnum } from "@sparcs-clubs/interface/common/enum/activity.enum";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetActivityDeadline = () =>
+  useQuery<ApiAct018ResponseOk, Error>({
+    queryKey: [apiAct018.url()],
+    queryFn: async (): Promise<ApiAct018ResponseOk> => {
+      const { data } = await axiosClientWithAuth.get(apiAct018.url(), {});
+
+      return apiAct018.responseBodyMap[200].parse(data);
+    },
+  });
+
+export default useGetActivityDeadline;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiAct018.url()).reply(() => [
+    200,
+    {
+      targetTerm: {
+        id: 1,
+        year: 2023,
+        name: "여름가을",
+        startTerm: new Date("2024-07-01"),
+        endTerm: new Date("2024-12-30"),
+      },
+      deadline: {
+        activityDeadlineEnum: ActivityDeadlineEnum.Upload,
+        duration: {
+          startTerm: new Date("2024-08-01"),
+          endTerm: new Date("2024-08-31"),
+        },
+      },
+    },
+  ]);
+});


### PR DESCRIPTION
# 요약 \*


It closes #1324 

- 원래 react의 router push에 state로 데이터 전송하려 했는데 nextjs에서는 그게 안되는 것 같아서 로컬 스토리지로 틀었음
- 지도교수 화면은 계정이 없어서 확인 못함 아마 똑같은 로직이라 잘 될거 같긴 함

# 스크린샷

https://github.com/user-attachments/assets/8ffdb354-e9c5-4447-a676-e48349c4e0a4


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
