### PR TITLE
feat: add List component

### DIFF
--- a/packages/web/src/common/components/List/ListItem.tsx
+++ b/packages/web/src/common/components/List/ListItem.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode } from "react";
+
+import styled from "styled-components";
+
+import Typography, {
+  ThemeColors,
+} from "@sparcs-clubs/web/common/components/Typography";
+import { Theme } from "@sparcs-clubs/web/styles/themes";
+
+const FlexTypography = styled(Typography)`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+interface ListItemProps {
+  children: string | ReactNode;
+  index: number;
+  fs?: number;
+  lh?: number;
+  fw?: keyof Theme["fonts"]["WEIGHT"];
+  ff?: keyof Theme["fonts"]["FAMILY"];
+  color?: ThemeColors;
+}
+
+// ActivityReportDetailFrame의 ActivityDetail 구현에서 따왔습니다.
+const ListItem: React.FC<ListItemProps> = ({
+  children = "",
+  index = -1,
+  fs = 16,
+  fw = "REGULAR",
+  lh = 20,
+  ff = "PRETENDARD",
+  color = "BLACK",
+}) => {
+  const isString: boolean = typeof children === "string";
+  return (
+    <FlexTypography fw={fw} fs={fs} lh={lh} ff={ff} color={color}>
+      {isString ? `${index === -1 ? "•" : `${index}.`} ${children}` : children}
+    </FlexTypography>
+  );
+};
+
+export default ListItem;

--- a/packages/web/src/common/components/List/index.tsx
+++ b/packages/web/src/common/components/List/index.tsx
@@ -1,0 +1,92 @@
+import React, { ReactNode } from "react";
+
+import styled from "styled-components";
+
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Typography, {
+  ThemeColors,
+} from "@sparcs-clubs/web/common/components/Typography";
+import { Theme } from "@sparcs-clubs/web/styles/themes";
+
+const FlexTypography = styled(Typography)`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+interface ListProps {
+  dataList: Array<string | ReactNode>;
+  listType: "bullet" | "number";
+  startIndex?: number;
+  gap: number;
+  // Typography의 props
+  fs?: number;
+  lh?: number;
+  fw?: keyof Theme["fonts"]["WEIGHT"];
+  ff?: keyof Theme["fonts"]["FAMILY"];
+  color?: ThemeColors;
+}
+
+interface ListItemProps {
+  children: string | ReactNode;
+  index: number;
+  fs?: number;
+  lh?: number;
+  fw?: keyof Theme["fonts"]["WEIGHT"];
+  ff?: keyof Theme["fonts"]["FAMILY"];
+  color?: ThemeColors;
+}
+
+// ActivityReportDetailFrame의 ActivityDetail 구현에서 따왔습니다.
+const ListItem: React.FC<ListItemProps> = ({
+  children = "",
+  index = -1,
+  fs = 16,
+  fw = "REGULAR",
+  lh = 20,
+  ff = "PRETENDARD",
+  color = "BLACK",
+}) => {
+  const isString: boolean = typeof children === "string";
+  return (
+    <FlexTypography fw={fw} fs={fs} lh={lh} ff={ff} color={color}>
+      {isString ? `${index === -1 ? "•" : `${index}.`} ${children}` : children}
+    </FlexTypography>
+  );
+};
+
+const List: React.FC<ListProps> = ({
+  dataList = [""],
+  listType = "bullet",
+  startIndex = 1,
+  gap = 16,
+  fs = 16,
+  fw = "REGULAR",
+  lh = 20,
+  ff = "PRETENDARD",
+  color = "BLACK",
+}) => (
+  <FlexWrapper
+    direction="column"
+    gap={gap}
+    style={{ alignItems: "flex-start", alignSelf: "stretch" }}
+  >
+    {dataList.map((data, index) => (
+      <ListItem
+        key={`${(index + startIndex).toString()}`}
+        index={listType === "number" ? index + startIndex : -1}
+        fs={fs}
+        fw={fw}
+        lh={lh}
+        ff={ff}
+        color={color}
+      >
+        {data}
+      </ListItem>
+    ))}
+  </FlexWrapper>
+);
+
+export default List;

--- a/packages/web/src/common/components/List/index.tsx
+++ b/packages/web/src/common/components/List/index.tsx
@@ -1,20 +1,9 @@
 import React, { ReactNode } from "react";
 
-import styled from "styled-components";
-
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
-import Typography, {
-  ThemeColors,
-} from "@sparcs-clubs/web/common/components/Typography";
+import ListItem from "@sparcs-clubs/web/common/components/List/ListItem";
+import { ThemeColors } from "@sparcs-clubs/web/common/components/Typography";
 import { Theme } from "@sparcs-clubs/web/styles/themes";
-
-const FlexTypography = styled(Typography)`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: flex-start;
-  align-self: stretch;
-`;
 
 interface ListProps {
   dataList: Array<string | ReactNode>;
@@ -28,34 +17,6 @@ interface ListProps {
   ff?: keyof Theme["fonts"]["FAMILY"];
   color?: ThemeColors;
 }
-
-interface ListItemProps {
-  children: string | ReactNode;
-  index: number;
-  fs?: number;
-  lh?: number;
-  fw?: keyof Theme["fonts"]["WEIGHT"];
-  ff?: keyof Theme["fonts"]["FAMILY"];
-  color?: ThemeColors;
-}
-
-// ActivityReportDetailFrame의 ActivityDetail 구현에서 따왔습니다.
-const ListItem: React.FC<ListItemProps> = ({
-  children = "",
-  index = -1,
-  fs = 16,
-  fw = "REGULAR",
-  lh = 20,
-  ff = "PRETENDARD",
-  color = "BLACK",
-}) => {
-  const isString: boolean = typeof children === "string";
-  return (
-    <FlexTypography fw={fw} fs={fs} lh={lh} ff={ff} color={color}>
-      {isString ? `${index === -1 ? "•" : `${index}.`} ${children}` : children}
-    </FlexTypography>
-  );
-};
 
 const List: React.FC<ListProps> = ({
   dataList = [""],

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import { useParams, useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
@@ -13,6 +13,7 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import Card from "@sparcs-clubs/web/common/components/Card";
 import ThumbnailPreviewList from "@sparcs-clubs/web/common/components/File/ThumbnailPreviewList";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import List from "@sparcs-clubs/web/common/components/List";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
@@ -67,29 +68,8 @@ const ActivitySection: React.FC<ActivitySectionProps> = ({
   </FlexWrapper>
 );
 // ActivitySection은 활동 보고서에서 구분된 각 영역을 나타냅니다.
-// label prop으로 이름을 넣고, children으로 ActivityDetail들을 넣어 주세요.
-
-const FlexTypography = styled(Typography)`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: flex-start;
-  align-self: stretch;
-`;
-
-const ActivityDetail: React.FC<{ children: string | ReactNode }> = ({
-  children = "",
-}) => {
-  const isString: boolean = typeof children === "string";
-  return (
-    <FlexTypography fw="REGULAR" fs={16} lh={20}>
-      {isString ? `• ${children}` : children}
-    </FlexTypography>
-  );
-};
-// ActivityDetail은 세부 활동 내역을 나타냅니다.
-// string이면 bullet point가 자동으로 포함됩니다.
-// string이 아닌 경우는 FilePreview가 들어가는 경우입니다. padding이 포함됩니다.
+// label prop으로 이름을 넣고, children으로 List 컴포넌트 또는 기타 children을 넣어주세요.
+// 들여쓰기가 필요한 경우 FlexWrapper를 활용해 주세요.
 
 const FilePreviewContainerWrapper = styled(FlexWrapper)`
   padding-left: 24px;
@@ -294,11 +274,16 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
             )}
 
             <ActivitySection label="활동 정보">
-              <ActivityDetail>{`활동명: ${data.name}`}</ActivityDetail>
-              <ActivityDetail>
-                {`활동 분류: ${getActivityTypeLabel(data.activityTypeEnumId)}`}
-              </ActivityDetail>
-              <ActivityDetail>활동 기간:</ActivityDetail>
+              <List
+                dataList={[
+                  `활동명: ${data.name}`,
+                  `활동 분류: ${getActivityTypeLabel(data.activityTypeEnumId)}`,
+                  "활동 기간:",
+                ]}
+                listType="bullet"
+                gap={16}
+              />
+
               <FlexWrapper
                 direction="column"
                 gap={12}
@@ -310,28 +295,45 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
                   </Typography>
                 ))}
               </FlexWrapper>
-              <ActivityDetail>{`활동 장소: ${data.location}`}</ActivityDetail>
-              <ActivityDetail>{`활동 목적: ${data.purpose}`}</ActivityDetail>
-              <ActivityDetail>{`활동 내용: ${data.detail}`}</ActivityDetail>
+              <List
+                dataList={[
+                  `활동 장소: ${data.location}`,
+                  `활동 목적: ${data.purpose}`,
+                  `활동 내용: ${data.detail}`,
+                ]}
+                listType="bullet"
+                gap={16}
+              />
             </ActivitySection>
             <ActivitySection label={`활동 인원(${data.participants.length}명)`}>
-              {data.participants.map(participant => (
-                <ActivityDetail
-                  key={participant.id}
-                >{`${participant.studentNumber} ${participant.name}`}</ActivityDetail>
-              ))}
+              <List
+                dataList={data.participants.map(
+                  participant =>
+                    `${participant.studentNumber} ${participant.name}`,
+                )}
+                listType="bullet"
+                gap={16}
+                startIndex={0}
+                fw="REGULAR"
+                fs={16}
+                lh={20}
+              />
             </ActivitySection>
             <ActivitySection label="활동 증빙">
-              <ActivityDetail>첨부 파일</ActivityDetail>
-              <ActivityDetail>
-                <FilePreviewContainer>
-                  <ThumbnailPreviewList
-                    fileList={data.evidenceFiles}
-                    disabled
-                  />
-                </FilePreviewContainer>
-              </ActivityDetail>
-              <ActivityDetail>{`부가 설명: ${data.evidence}`}</ActivityDetail>
+              <List
+                dataList={[
+                  "첨부 파일",
+                  <FilePreviewContainer key="file-preview">
+                    <ThumbnailPreviewList
+                      fileList={data.evidenceFiles}
+                      disabled
+                    />
+                  </FilePreviewContainer>,
+                  `부가 설명: ${data.evidence}`,
+                ]}
+                listType="bullet"
+                gap={16}
+              />
             </ActivitySection>
             {data.professorApproval !== null && (
               <FlexWrapper


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1342 

기존에 여러 구현 방식으로 만들어져 있던 bullet list와 number list를 하나의 컴포넌트로 통일합니다.
아래는 적용 예시입니다.
```
<List listType="bullet" gap={16}>
  <ListItem>{`활동 장소: ${data.location}`}</ListItem>
  <ListItem>{`활동 목적: ${data.purpose}`}</ListItem>
  <ListItem>{`활동 내용: ${data.detail}`}</ListItem>
</List>
```
bullet point로도 사용할 수 있고, 시작 index (0 이상)를 정해서 number list로도 사용할 수 있습니다.
활동보고서 상세 보기 (packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx) 에 우선 적용해 두었으며, 추후 적용이 필요한 다른 페이지 리팩토링을 진행하고자 합니다.

## 이슈들
1. List와 ListItem을 같은 폴더의 다른 파일로 분리해 봤는데, 매번 2개씩 import해야 한다는 단점이 있군요.. 어떻게 생각하시나요?
2. 위와 같은 구조로 바꾸면서, bullet 또는 숫자 뒤에 임의로 0.5em 만큼의 margin을 주도록 했는데 어때 보이시나요?
3. 이상하게 ListItem의 children 속에, <br />이 들어가 있는 것이 잘 적용이 안됩니다. <></>으로 감싸도 안되고, <div></div>로 감싸면 줄바꿈이 됩니다. 이 문제에 대해 어떻게 생각하시나요?
4. bullet과 한 자리 숫자, 두 자리 숫자 각각 폭이 달라서 content가 시작하는 x좌표도 달라지는데 이것은 어떻게 생각하시는지 궁금합니다

# 스크린샷
## Current
- 활동 보고서에 적용한 예시
![image](https://github.com/user-attachments/assets/8a688b76-1294-41fa-a76a-4bf787148bbb)
- Number List
![image](https://github.com/user-attachments/assets/9f31b8b5-5582-470b-9005-b1121d6c312d)
- Storybook
![image](https://github.com/user-attachments/assets/bc15fee5-6f5e-4048-ab79-0e852a97bbe6)



---
## Outdated screenshots
- Bullet list
![image](https://github.com/user-attachments/assets/e37cc820-d0a9-430c-aeb9-669a3629e4a9)
- Number list
![image](https://github.com/user-attachments/assets/77207240-fba6-4434-bed2-5d020d8efb7a)

data로 string이랑 일반적인 ReactNode를 섞어 쓸 수 있게 허용하다 보니, number로 했을 때 이런 광경을 볼 수 있긴 합니다
![image](https://github.com/user-attachments/assets/58fa6692-f63a-4297-a53a-91c151f535e0)
List 여러 개로 쪼개고, 필요한 대로 startIndex 조절하면서 해결이 가능하나, 추후에 수정 필요가 있다면 numbering 로직을 바꾸겠습니다.


# 이후 Task \*

- 다른 페이지에 적용하기
- Storybook 문서화 (완료)
