### PR TITLE
1364 fix funding api bugs

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -9,10 +9,10 @@ import { ActivityCertificateModule } from "./feature/activity-certificate/activi
 
 import { AuthModule } from "./feature/auth/auth.module";
 import { JwtAccessGuard } from "./feature/auth/guard/jwt-access.guard";
-import { ClubModule } from "./feature/club/club.module";
+import ClubModule from "./feature/club/club.module";
 import { CommonSpaceModule } from "./feature/common-space/common-space.module";
 import DivisionModule from "./feature/division/division.module";
-import { FileModule } from "./feature/file/file.module";
+import FileModule from "./feature/file/file.module";
 import FundingModule from "./feature/funding/funding.module";
 import { MeetingModule } from "./feature/meeting/meeting.module";
 import { NoticeModule } from "./feature/notice/notice.module";

--- a/packages/api/src/drizzle/schema/funding.schema.ts
+++ b/packages/api/src/drizzle/schema/funding.schema.ts
@@ -46,7 +46,6 @@ export const Funding = mysqlTable(
     origin: varchar("origin", { length: 255 }),
     destination: varchar("destination", { length: 255 }),
     purposeOfTransportation: text("purpose_of_transportation"),
-    placeValidity: text("place_validity"),
     isNonCorporateTransaction: boolean(
       "is_non_corporate_transaction",
     ).notNull(),

--- a/packages/api/src/feature/activity-certificate/activity-certificate.module.ts
+++ b/packages/api/src/feature/activity-certificate/activity-certificate.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
 
-import { ClubModule } from "@sparcs-clubs/api/feature/club/club.module";
+import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 

--- a/packages/api/src/feature/activity/activity.module.ts
+++ b/packages/api/src/feature/activity/activity.module.ts
@@ -2,10 +2,10 @@ import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "src/drizzle/drizzle.module";
 
-import { ClubModule } from "../club/club.module";
+import ClubModule from "../club/club.module";
 import ClubTRepository from "../club/repository/club.club-t.repository";
 import DivisionModule from "../division/division.module";
-import { FileModule } from "../file/file.module";
+import FileModule from "../file/file.module";
 import { ClubRegistrationModule } from "../registration/club-registration/club-registration.module";
 import UserModule from "../user/user.module";
 

--- a/packages/api/src/feature/activity/repository/activity.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity.repository.ts
@@ -711,9 +711,7 @@ export default class ActivityRepository {
     return result;
   }
 
-  async fetchActivitySummaries(
-    activityIds: number[],
-  ): Promise<IActivitySummary[]> {
+  async fetchSummaries(activityIds: number[]): Promise<IActivitySummary[]> {
     if (activityIds.length === 0) {
       return [];
     }
@@ -736,7 +734,7 @@ export default class ActivityRepository {
    * 선택가능한 활동이란, 승인되거나 운위로 넘겨진 경우를 의미합니다.
    */
 
-  async fetchAvailableActivitySummaries(
+  async fetchAvailableSummaries(
     clubId: number,
     activityDId: number,
   ): Promise<IActivitySummary[]> {
@@ -760,7 +758,7 @@ export default class ActivityRepository {
     return result;
   }
 
-  async fetchParticipantStudentSummaries(
+  async fetchParticipantSummaries(
     activityId: number,
   ): Promise<VStudentSummary[]> {
     const result = await this.db

--- a/packages/api/src/feature/activity/repository/activity.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity.repository.ts
@@ -714,6 +714,9 @@ export default class ActivityRepository {
   async fetchActivitySummaries(
     activityIds: number[],
   ): Promise<IActivitySummary[]> {
+    if (activityIds.length === 0) {
+      return [];
+    }
     const result = await this.db
       .select({
         id: Activity.id,

--- a/packages/api/src/feature/activity/repository/activity.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity.repository.ts
@@ -27,8 +27,6 @@ import {
   Student,
 } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
-import { VStudentSummary } from "@sparcs-clubs/api/feature/user/model/student.summary.model";
-
 @Injectable()
 export default class ActivityRepository {
   constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
@@ -758,18 +756,12 @@ export default class ActivityRepository {
     return result;
   }
 
-  async fetchParticipantSummaries(
-    activityId: number,
-  ): Promise<VStudentSummary[]> {
+  async fetchParticipantIds(activityId: number): Promise<number[]> {
     const result = await this.db
       .select({
         id: ActivityParticipant.studentId,
-        userId: Student.userId,
-        studentNumber: Student.number,
-        name: Student.name,
       })
       .from(ActivityParticipant)
-      .leftJoin(Student, eq(ActivityParticipant.studentId, Student.id))
       .where(
         and(
           eq(ActivityParticipant.activityId, activityId),
@@ -777,12 +769,6 @@ export default class ActivityRepository {
         ),
       );
 
-    return result.map(
-      participant =>
-        new VStudentSummary({
-          ...participant,
-          studentNumber: participant.studentNumber.toString(), // TODO: studentNumber가 string으로 바뀌면 삭제
-        }),
-    );
+    return result.map(participant => participant.id);
   }
 }

--- a/packages/api/src/feature/activity/service/activity.public.service.ts
+++ b/packages/api/src/feature/activity/service/activity.public.service.ts
@@ -1,7 +1,9 @@
-import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 
 import { IActivitySummary } from "@sparcs-clubs/interface/api/activity/type/activity.type";
 import { IStudentSummary } from "@sparcs-clubs/interface/api/user/type/user.type";
+
+import UserPublicService from "@sparcs-clubs/api/feature/user/service/user.public.service";
 
 import ActivityRepository from "../repository/activity.repository";
 
@@ -12,6 +14,7 @@ export default class ActivityPublicService {
   constructor(
     private activityRepository: ActivityRepository,
     private activityService: ActivityService,
+    private userPublicService: UserPublicService,
   ) {}
 
   /**
@@ -51,15 +54,8 @@ export default class ActivityPublicService {
   async fetchParticipantSummaries(
     activityId: number,
   ): Promise<IStudentSummary[]> {
-    const participants =
-      await this.activityRepository.fetchParticipantSummaries(activityId);
-
-    if (participants.length === 0) {
-      throw new HttpException(
-        `Participants not found for activity ${activityId}`,
-        HttpStatus.NOT_FOUND,
-      );
-    }
-    return participants;
+    const participantIds =
+      await this.activityRepository.fetchParticipantIds(activityId);
+    return this.userPublicService.fetchStudentSummaries(participantIds);
   }
 }

--- a/packages/api/src/feature/activity/service/activity.public.service.ts
+++ b/packages/api/src/feature/activity/service/activity.public.service.ts
@@ -26,42 +26,33 @@ export default class ActivityPublicService {
     return this.activityRepository.selectActivityById(id);
   }
 
-  async fetchActivitySummaries(
-    activityIds: number[],
-  ): Promise<IActivitySummary[]> {
-    return this.activityRepository.fetchActivitySummaries(activityIds);
+  async fetchSummaries(activityIds: number[]): Promise<IActivitySummary[]> {
+    return this.activityRepository.fetchSummaries(activityIds);
   }
 
   // API Fnd 007
-  async fetchAvailableActivitySummaries(
-    clubId: number,
-  ): Promise<IActivitySummary[]>;
-  async fetchAvailableActivitySummaries(
+  async fetchAvailableSummaries(clubId: number): Promise<IActivitySummary[]>;
+  async fetchAvailableSummaries(
     clubId: number,
     activityDId: number,
   ): Promise<IActivitySummary[]>;
-  async fetchAvailableActivitySummaries(
+  async fetchAvailableSummaries(
     arg1: number,
     arg2?: number,
   ): Promise<IActivitySummary[]> {
     if (arg2 === undefined) {
       const activityDId = (await this.activityService.getLastActivityD()).id;
-      return this.activityRepository.fetchAvailableActivitySummaries(
-        arg1,
-        activityDId,
-      );
+      return this.activityRepository.fetchAvailableSummaries(arg1, activityDId);
     }
-    return this.activityRepository.fetchAvailableActivitySummaries(arg1, arg2);
+    return this.activityRepository.fetchAvailableSummaries(arg1, arg2);
   }
 
   // API Fnd 008
-  async fetchParticipantStudentSummaries(
+  async fetchParticipantSummaries(
     activityId: number,
   ): Promise<IStudentSummary[]> {
     const participants =
-      await this.activityRepository.fetchParticipantStudentSummaries(
-        activityId,
-      );
+      await this.activityRepository.fetchParticipantSummaries(activityId);
 
     if (participants.length === 0) {
       throw new HttpException(

--- a/packages/api/src/feature/club/club.module.ts
+++ b/packages/api/src/feature/club/club.module.ts
@@ -39,4 +39,4 @@ import { ClubService } from "./service/club.service";
   ],
   exports: [ClubPublicService],
 })
-export class ClubModule {}
+export default class ClubModule {}

--- a/packages/api/src/feature/club/delegate/delegate.module.ts
+++ b/packages/api/src/feature/club/delegate/delegate.module.ts
@@ -4,7 +4,7 @@ import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 // eslint-disable-next-line import/no-cycle
-import { ClubModule } from "../club.module";
+import ClubModule from "../club.module";
 
 import { ClubDelegateDRepository } from "./club.club-delegate-d.repository";
 

--- a/packages/api/src/feature/common-space/common-space.module.ts
+++ b/packages/api/src/feature/common-space/common-space.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
-import { ClubModule } from "@sparcs-clubs/api/feature/club/club.module";
+import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 import ClubStudentTRepository from "@sparcs-clubs/api/feature/club/repository/club.club-student-t.repository";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 

--- a/packages/api/src/feature/file/file.module.ts
+++ b/packages/api/src/feature/file/file.module.ts
@@ -3,7 +3,7 @@ import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "src/drizzle/drizzle.module";
 
-import { ClubModule } from "../club/club.module";
+import ClubModule from "../club/club.module";
 
 import { FileController } from "./controller/file.controller";
 import { FileRepository } from "./repository/file.repository";
@@ -31,4 +31,4 @@ import { FileService } from "./service/file.service";
   ],
   exports: [FilePublicService],
 })
-export class FileModule {}
+export default class FileModule {}

--- a/packages/api/src/feature/funding/funding.module.ts
+++ b/packages/api/src/feature/funding/funding.module.ts
@@ -3,12 +3,8 @@ import { Module } from "@nestjs/common";
 import { DrizzleModule } from "src/drizzle/drizzle.module";
 
 import ActivityModule from "../activity/activity.module";
-import { ClubModule } from "../club/club.module";
-import { FileModule } from "../file/file.module";
-import ExecutiveRepository from "../user/repository/executive.repository";
-import ProfessorRepository from "../user/repository/professor.repository";
-import { StudentRepository } from "../user/repository/student.repository";
-import UserPublicService from "../user/service/user.public.service";
+import ClubModule from "../club/club.module";
+import FileModule from "../file/file.module";
 import UserModule from "../user/user.module";
 
 import FundingController from "./controller/funding.controller";
@@ -19,15 +15,7 @@ import FundingService from "./service/funding.service";
 @Module({
   imports: [DrizzleModule, UserModule, ClubModule, ActivityModule, FileModule],
   controllers: [FundingController],
-  providers: [
-    FundingRepository,
-    FundingService,
-    StudentRepository,
-    ExecutiveRepository,
-    ProfessorRepository,
-    UserPublicService,
-    FundingCommentRepository,
-  ],
+  providers: [FundingRepository, FundingService, FundingCommentRepository],
   exports: [],
 })
 export default class FundingModule {}

--- a/packages/api/src/feature/funding/model/funding.model.ts
+++ b/packages/api/src/feature/funding/model/funding.model.ts
@@ -60,7 +60,6 @@ export type FundingDBResult = {
     origin: string;
     destination: string;
     purposeOfTransportation: string;
-    placeValidity: string;
   };
   fundingFeedback?: {
     feedback?: string;
@@ -241,7 +240,6 @@ export class MFunding implements IFunding {
             origin: result.funding.origin,
             destination: result.funding.destination,
             purpose: result.funding.purposeOfTransportation,
-            placeValidity: result.funding.placeValidity,
             passengers: result.transportationPassengers.map(passenger => ({
               id: passenger.id,
             })),

--- a/packages/api/src/feature/funding/repository/funding.comment.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.comment.repository.ts
@@ -10,7 +10,7 @@ import { MFundingComment } from "@sparcs-clubs/api/feature/funding/model/funding
 export default class FundingCommentRepository {
   constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
 
-  async fetchComments(fundingId: number): Promise<MFundingComment[]> {
+  async fetchAll(fundingId: number): Promise<MFundingComment[]> {
     const result = await this.db
       .select()
       .from(FundingFeedback)

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -197,7 +197,12 @@ export default class FundingRepository {
           name: Student.name,
         })
         .from(FundingTransportationPassenger)
-        .where(and(isNull(FundingTransportationPassenger.deletedAt)))
+        .where(
+          and(
+            eq(FundingTransportationPassenger.fundingId, id),
+            isNull(FundingTransportationPassenger.deletedAt),
+          ),
+        )
         .innerJoin(
           Student,
           eq(Student.id, FundingTransportationPassenger.studentId),

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -336,7 +336,6 @@ export default class FundingRepository {
         origin: funding.transportation?.origin,
         destination: funding.transportation?.destination,
         purposeOfTransportation: funding.transportation?.purpose,
-        placeValidity: funding.transportation?.placeValidity,
         // Trader fields
         traderName: funding.nonCorporateTransaction?.traderName,
         traderAccountNumber:
@@ -619,7 +618,6 @@ export default class FundingRepository {
           origin: funding.transportation?.origin,
           destination: funding.transportation?.destination,
           purposeOfTransportation: funding.transportation?.purpose,
-          placeValidity: funding.transportation?.placeValidity,
           // Trader fields
           traderName: funding.nonCorporateTransaction?.traderName,
           traderAccountNumber:

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -259,18 +259,18 @@ export default class FundingRepository {
     });
   }
 
-  async selectAll(
+  async fetchFundingSummaries(
     clubId: number,
     semesterId: number,
   ): Promise<IFundingSummary[]> {
-    const fundingOrders = await this.db
+    const fundings = await this.db
       .select({
         id: Funding.id,
         name: Funding.name,
         expenditureAmount: Funding.expenditureAmount,
         approvedAmount: Funding.approvedAmount,
         fundingStatusEnum: Funding.fundingStatusEnum,
-        purposeActivity: Funding.purposeActivityId,
+        purposeActivityId: Funding.purposeActivityId,
       })
       .from(Funding)
       .where(
@@ -281,14 +281,14 @@ export default class FundingRepository {
         ),
       );
 
-    if (fundingOrders.length === 0) {
+    if (fundings.length === 0) {
       return [];
     }
 
-    return fundingOrders.map(fundingOrder => ({
-      ...fundingOrder,
+    return fundings.map(funding => ({
+      ...funding,
       purposeActivity: {
-        id: fundingOrder.purposeActivity,
+        id: funding.purposeActivityId,
       },
     }));
   }

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -259,7 +259,7 @@ export default class FundingRepository {
     });
   }
 
-  async fetchFundingSummaries(
+  async fetchSummaries(
     clubId: number,
     semesterId: number,
   ): Promise<IFundingSummary[]> {

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -218,7 +218,7 @@ export default class FundingService {
       );
     }
 
-    const comments = (await this.fundingCommentRepository.fetchComments(
+    const comments = (await this.fundingCommentRepository.fetchAll(
       funding.id,
     )) as IFundingCommentResponse[];
 
@@ -290,12 +290,12 @@ export default class FundingService {
     const now = getKSTDate();
     const thisSemester = await this.clubPublicService.dateToSemesterId(now);
 
-    const fundings = await this.fundingRepository.fetchFundingSummaries(
+    const fundings = await this.fundingRepository.fetchSummaries(
       query.clubId,
       thisSemester,
     );
 
-    const activities = await this.activityPublicService.fetchActivitySummaries(
+    const activities = await this.activityPublicService.fetchSummaries(
       fundings.map(funding => funding.purposeActivity.id),
     );
 
@@ -323,12 +323,12 @@ export default class FundingService {
       throw new HttpException("Student not found", HttpStatus.NOT_FOUND);
     }
 
-    const fundings = await this.fundingRepository.fetchFundingSummaries(
+    const fundings = await this.fundingRepository.fetchSummaries(
       body.clubId,
       param.semesterId,
     );
 
-    const activities = await this.activityPublicService.fetchActivitySummaries(
+    const activities = await this.activityPublicService.fetchSummaries(
       fundings.map(funding => funding.purposeActivity.id),
     );
 
@@ -361,7 +361,7 @@ export default class FundingService {
     }
 
     const activities =
-      await this.activityPublicService.fetchAvailableActivitySummaries(clubId);
+      await this.activityPublicService.fetchAvailableSummaries(clubId);
 
     return {
       activities,
@@ -372,9 +372,7 @@ export default class FundingService {
     activityId: number,
   ): Promise<ApiFnd008ResponseOk> {
     const participants =
-      await this.activityPublicService.fetchParticipantStudentSummaries(
-        activityId,
-      );
+      await this.activityPublicService.fetchParticipantSummaries(activityId);
     return {
       participants,
     };

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -290,7 +290,7 @@ export default class FundingService {
     const now = getKSTDate();
     const thisSemester = await this.clubPublicService.dateToSemesterId(now);
 
-    const fundings = await this.fundingRepository.selectAll(
+    const fundings = await this.fundingRepository.fetchFundingSummaries(
       query.clubId,
       thisSemester,
     );
@@ -323,7 +323,7 @@ export default class FundingService {
       throw new HttpException("Student not found", HttpStatus.NOT_FOUND);
     }
 
-    const fundings = await this.fundingRepository.selectAll(
+    const fundings = await this.fundingRepository.fetchFundingSummaries(
       body.clubId,
       param.semesterId,
     );

--- a/packages/api/src/feature/promotional-printing/promotional-printing.module.ts
+++ b/packages/api/src/feature/promotional-printing/promotional-printing.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
 
-import { ClubModule } from "@sparcs-clubs/api/feature/club/club.module";
+import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 import { DrizzleModule } from "src/drizzle/drizzle.module";
 
 import { PromotionalPrintingController } from "./controller/promotional-printing.controller";

--- a/packages/api/src/feature/registration/club-registration/club-registration.module.ts
+++ b/packages/api/src/feature/registration/club-registration/club-registration.module.ts
@@ -2,10 +2,10 @@ import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
-import { ClubModule } from "@sparcs-clubs/api/feature/club/club.module";
+import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 
 import DivisionModule from "@sparcs-clubs/api/feature/division/division.module";
-import { FileModule } from "@sparcs-clubs/api/feature/file/file.module";
+import FileModule from "@sparcs-clubs/api/feature/file/file.module";
 
 import { ClubRegistrationController } from "./controller/club-registration.controller";
 import { ClubRegistrationRepository } from "./repository/club-registration.repository";

--- a/packages/api/src/feature/registration/member-registration/member-registration.module.ts
+++ b/packages/api/src/feature/registration/member-registration/member-registration.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
-import { ClubModule } from "@sparcs-clubs/api/feature/club/club.module";
+import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 import { MemberRegistrationController } from "./controller/member-registration.controller";

--- a/packages/api/src/feature/user/repository/student.repository.ts
+++ b/packages/api/src/feature/user/repository/student.repository.ts
@@ -11,8 +11,6 @@ import {
   StudentT,
 } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
-import { MStudent } from "../model/student.model";
-
 @Injectable()
 export class StudentRepository {
   constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
@@ -95,20 +93,12 @@ export class StudentRepository {
     return isUpdateSucceed;
   }
 
-  async selectStudentsByIds(studentIds: number[]): Promise<MStudent[]> {
-    const students = await this.db
-      .select()
-      .from(Student)
-      .where(and(inArray(Student.id, studentIds), isNull(Student.deletedAt)));
-    return students.map(
-      student =>
-        new MStudent({ ...student, studentNumber: student.number.toString() }),
-    );
-  }
-
   async fetchStudentSummaries(
     studentIds: number[],
   ): Promise<IStudentSummary[]> {
+    if (studentIds.length === 0) {
+      return [];
+    }
     const students = await this.db
       .select()
       .from(Student)

--- a/packages/api/src/feature/user/repository/student.repository.ts
+++ b/packages/api/src/feature/user/repository/student.repository.ts
@@ -12,7 +12,7 @@ import {
 } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 @Injectable()
-export class StudentRepository {
+export default class StudentRepository {
   constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
 
   async selectStudentById(id: number) {

--- a/packages/api/src/feature/user/service/user.public.service.ts
+++ b/packages/api/src/feature/user/service/user.public.service.ts
@@ -8,7 +8,6 @@ import {
 import logger from "@sparcs-clubs/api/common/util/logger";
 import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
 
-import { MStudent } from "../model/student.model";
 import ExecutiveRepository from "../repository/executive.repository";
 import ProfessorRepository from "../repository/professor.repository";
 import { StudentRepository } from "../repository/student.repository";
@@ -164,18 +163,6 @@ export default class UserPublicService {
 
   async updateStudentPhoneNumber(userId: number, phoneNumber: string) {
     await this.studentRepository.updateStudentPhoneNumber(userId, phoneNumber);
-  }
-
-  /**
-   * 학생의 studentID Array를 통해 학생 정보를 반환합니다.
-   * */
-  async getStudentsByIds(studentIds: number[]): Promise<MStudent[]> {
-    const students =
-      await this.studentRepository.selectStudentsByIds(studentIds);
-    if (students.length === 0) {
-      throw new HttpException("Student Doesn't exist", HttpStatus.NOT_FOUND);
-    }
-    return students;
   }
 
   /**

--- a/packages/api/src/feature/user/service/user.public.service.ts
+++ b/packages/api/src/feature/user/service/user.public.service.ts
@@ -10,7 +10,7 @@ import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
 
 import ExecutiveRepository from "../repository/executive.repository";
 import ProfessorRepository from "../repository/professor.repository";
-import { StudentRepository } from "../repository/student.repository";
+import StudentRepository from "../repository/student.repository";
 
 @Injectable()
 export default class UserPublicService {

--- a/packages/api/src/feature/user/service/user.service.ts
+++ b/packages/api/src/feature/user/service/user.service.ts
@@ -7,7 +7,7 @@ import UserRepository from "@sparcs-clubs/api/feature/user/repository/user.repos
 
 import ExecutiveRepository from "../repository/executive.repository";
 import ProfessorRepository from "../repository/professor.repository";
-import { StudentRepository } from "../repository/student.repository";
+import StudentRepository from "../repository/student.repository";
 
 @Injectable()
 export class UserService {

--- a/packages/api/src/feature/user/user.module.ts
+++ b/packages/api/src/feature/user/user.module.ts
@@ -9,7 +9,7 @@ import { UserController } from "./controller/user.controller";
 import PrivacyPolicyModule from "./privacy-policy/privacy-policy.module";
 import ExecutiveRepository from "./repository/executive.repository";
 import ProfessorRepository from "./repository/professor.repository";
-import { StudentRepository } from "./repository/student.repository";
+import StudentRepository from "./repository/student.repository";
 import UserPublicService from "./service/user.public.service";
 import { UserService } from "./service/user.service";
 

--- a/packages/interface/src/api/funding/type/funding.type.ts
+++ b/packages/interface/src/api/funding/type/funding.type.ts
@@ -41,7 +41,6 @@ export const zTransportation = z.object({
   origin: z.string().max(255).optional(),
   destination: z.string().max(255).optional(),
   purpose: z.string().optional(),
-  placeValidity: z.string().optional(),
   passengers: z.array(zStudentSummary.pick({ id: true })),
 });
 
@@ -188,20 +187,6 @@ export const zFundingRequest = zFundingRequestBase.superRefine((data, ctx) => {
         code: z.ZodIssueCode.custom,
         message: "transportation is required",
       });
-    }
-    if (
-      data.transportation?.enum === TransportationEnum.CallVan ||
-      data.transportation?.enum === TransportationEnum.Cargo ||
-      data.transportation?.enum === TransportationEnum.Airplane ||
-      data.transportation?.enum === TransportationEnum.Ship ||
-      data.transportation?.enum === TransportationEnum.Others
-    ) {
-      if (!data.transportation?.placeValidity) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "transportationPlaceValidity is required",
-        });
-      }
     }
   }
 

--- a/packages/web/src/features/manage-club/funding/hooks/useCreateFunding.ts
+++ b/packages/web/src/features/manage-club/funding/hooks/useCreateFunding.ts
@@ -112,7 +112,6 @@ export const useCreateFunding = (clubId: number) => {
                   origin: data.origin,
                   destination: data.destination,
                   purpose: data.purposeOfTransportation,
-                  placeValidity: data.placeValidity,
                   passengers: isParticipantsRequired(data.transportationEnum)
                     ? data.transportationPassengers.map(participant => ({
                         id: participant.id,

--- a/packages/web/src/features/manage-club/funding/hooks/useGetInitialFundingForm.ts
+++ b/packages/web/src/features/manage-club/funding/hooks/useGetInitialFundingForm.ts
@@ -61,7 +61,6 @@ const useGetInitialFundingFormData = (
       origin: funding.transportation?.origin,
       destination: funding.transportation?.destination,
       purposeOfTransportation: funding.transportation?.purpose,
-      placeValidity: funding.transportation?.placeValidity,
       transportationPassengers: funding.transportation?.passengers ?? [],
 
       // 비법인 거래 증빙

--- a/packages/web/src/features/manage-club/funding/hooks/useUpdateFunding.ts
+++ b/packages/web/src/features/manage-club/funding/hooks/useUpdateFunding.ts
@@ -113,7 +113,6 @@ const useUpdateFunding = (fundingId: number, clubId: number) => {
                   origin: data.origin,
                   destination: data.destination,
                   purpose: data.purposeOfTransportation,
-                  placeValidity: data.placeValidity,
                   passengers: isParticipantsRequired(data.transportationEnum)
                     ? data.transportationPassengers.map(participant => ({
                         id: participant.id,

--- a/packages/web/src/features/manage-club/funding/types/funding.ts
+++ b/packages/web/src/features/manage-club/funding/types/funding.ts
@@ -63,7 +63,6 @@ export interface AddEvidence {
   origin?: string;
   destination?: string;
   purposeOfTransportation?: string;
-  placeValidity?: string;
   transportationPassengers: IStudentSummary[];
   // 비법인 거래 증빙
   isNonCorporateTransaction: boolean;

--- a/packages/web/src/features/manage-club/services/_mock/mockFundingDetail.ts
+++ b/packages/web/src/features/manage-club/services/_mock/mockFundingDetail.ts
@@ -69,7 +69,6 @@ const mockFundingDetail = {
   origin: "서울역",
   destination: "대전역",
   purposeOfTransportation: "해커톤 장소 사전답사",
-  placeValidity: "",
   transportationPassengers: [
     { id: 1, studentNumber: "20240510", name: "스팍스" },
     { id: 2, studentNumber: "20200515", name: "이도라" },


### PR DESCRIPTION
# 요약 \*

현재 프론트에서는 택시, 전세버스, 콜밴, 비행기, 선박, 기타 의 경우에만 탑승자 명단 선택하도록 되어 있습니다. 신청할 때 철도를 선택하고 신청해서 탑승자가 없어야 하는데 상세조회에서 백에서 탑승자 명단을 보내줘서 백에서는 어떻게 돌아가고 있는지 궁금해요

교통비 증빙 관련 데이터 중 purpose 와 placeValidity가 각각 무엇을 말하는건지 궁금합니다. 프론트에선 하나의 필드로 되어 있는데 혹시 상황에 따라 다르게 데이터를 보내야 하는걸까요?

해당 계정에 지원금 신규 신청내역이 없는 경우 500 에러가 납니다

It closes #issue_number

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
