### PR TITLE
fix: reset file input using ref to allow re-selection of the same file

### DIFF
--- a/packages/web/src/common/components/FileUpload.tsx
+++ b/packages/web/src/common/components/FileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 
 import { ApiFil001RequestBody } from "@sparcs-clubs/interface/api/file/apiFil001";
 import { overlay } from "overlay-kit";
@@ -116,6 +116,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
   const { mutate: putFileS3Mutation } = usePutFileS3();
 
   const [files, setFiles] = useState<FileDetail[]>(initialFiles);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const updateFiles = (_files: FileDetail[]) => {
     setFiles(_files);
@@ -126,7 +127,6 @@ const FileUpload: React.FC<FileUploadProps> = ({
     const newFiles = _files.filter(file => !files.find(f => f.id === file.id));
     const updatedFiles = multiple ? [...files, ...newFiles] : newFiles;
     updateFiles(updatedFiles);
-    onChange(updatedFiles);
   };
   const removeFile = (_file: FileDetail) => {
     const updatedFiles = files.filter(file => file.id !== _file.id);
@@ -208,6 +208,10 @@ const FileUpload: React.FC<FileUploadProps> = ({
       file => ({ file, previewUrl: URL.createObjectURL(file) }),
     );
     onSubmit(newFiles);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
   };
 
   const handleClick = () => {
@@ -243,6 +247,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
           <Icon type="file_upload_outlined" size={20} color="white" />
         </UploadIcon>
         <HiddenInput
+          ref={fileInputRef}
           type="file"
           accept={allowedTypes.join(",")}
           multiple={multiple}


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1404 

지원금 파일 업로드 되지 않는 이슈 발생
- 재현해보니 랜덤으로 가끔 파일이 업로드 되지 않음
- 특히 파일 추가 > 삭제 > 동일한 파일 다시 추가 했을 때에 조금 더 자주 파일 업로드 되지 않는 이슈가 생김

같은 파일 추가 시 onChange 함수가 제대로 트리거 되지 않아 발생할 수 있다고 생각되여 인풋 초기화하는 로직 추가함

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
