### PR TITLE
add a validation logic to funding expenditure date field

### DIFF
--- a/packages/web/src/utils/Date/getKSTDate.ts
+++ b/packages/web/src/utils/Date/getKSTDate.ts
@@ -1,13 +1,17 @@
+// date를 입력했을 때 시간을 제외한 년, 월, 일만 남기고 Date 타입으로 반환, 즉 시간을 00:00:00 으로 치환하기
+export const getLocalDateOnly = (date: Date) =>
+  new Date(
+    new Date(date).getFullYear(),
+    new Date(date).getMonth(),
+    new Date(date).getDate(),
+  );
+
 // 시간을 제외한 날짜만 KST로 변경
 // 예시: 입력 date가 2024-10-18 15:00 일 경우 getKSTDate 씌워서 api 요청 보내면
 // 2024.10.18 00:00 으로 요청 보내짐 (백에서도 그대로 받아서 그대로 프론트에 데이터 보냄)
 // 즉 항상 시간은 00:00 이게 됨
 export function getKSTDate(date: Date): Date {
-  const localDateOnly = new Date(
-    new Date(date).getFullYear(),
-    new Date(date).getMonth(),
-    new Date(date).getDate(),
-  );
+  const localDateOnly = getLocalDateOnly(date);
 
   const kstOffset = 9 * 60; // KST: UTC+9
   return new Date(localDateOnly.getTime() + kstOffset * 60 * 1000);


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1406 

동연측 요청사항:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/3c2810cf-4f4e-4284-aa3e-e776e56b6075" />


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="424" alt="image" src="https://github.com/user-attachments/assets/9644799c-b27b-45e1-8483-18351fca0b23" />


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
