### PR TITLE
fix: update delegate service response status to FORBIDDEN for empty results

### DIFF
--- a/packages/api/src/feature/club/delegate/delegate.service.ts
+++ b/packages/api/src/feature/club/delegate/delegate.service.ts
@@ -472,7 +472,7 @@ export default class ClubDelegateService {
 
     if (result.length === 0)
       return {
-        status: HttpStatus.NO_CONTENT,
+        status: HttpStatus.FORBIDDEN,
         data: {},
       };
     if (result.length > 1)


### PR DESCRIPTION
# 요약 \*
대의원 아닌 사람이 manage-club/funding 같은 페이지에 아예 접속 자체가 안되도록 수정

It closes #issue_number

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
