### PR TITLE
fix funding detail layout

### DIFF
--- a/packages/web/src/common/components/Toast/index.tsx
+++ b/packages/web/src/common/components/Toast/index.tsx
@@ -45,7 +45,7 @@ const ApproveReasonToastInner = styled.div<{ color: ToastColorType }>`
 
   .ApproveReasonToast-title {
     padding: 12px 16px 0 16px;
-
+    width: 100%;
     position: sticky;
     top: 0;
     display: flex;

--- a/packages/web/src/features/manage-club/funding/detail/components/ExecutiveFundingReviewSection.tsx
+++ b/packages/web/src/features/manage-club/funding/detail/components/ExecutiveFundingReviewSection.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "next/navigation";
 import { overlay } from "overlay-kit";
 import React, { useState } from "react";
+import styled from "styled-components";
 
 import { IFundingCommentResponse } from "@sparcs-clubs/interface/api/funding/type/funding.comment.type";
 import { IFundingResponse } from "@sparcs-clubs/interface/api/funding/type/funding.type";
@@ -19,6 +20,18 @@ import { FundingTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import useExecutiveReviewFunding from "@sparcs-clubs/web/features/manage-club/funding/services/useExecutiveReviewFunding";
 import { formatSlashDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+const FundingInputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  width: 100%;
+
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.lg}) {
+    flex-direction: column;
+    gap: 20px;
+  }
+`;
 
 const ExecutiveFundingReviewSection: React.FC<{
   funding: IFundingResponse;
@@ -175,45 +188,56 @@ const ExecutiveFundingReviewSection: React.FC<{
         placeholder="내용"
         area
       />
-
-      <FlexWrapper direction="row" gap={16} style={{ height: "36px" }}>
-        <Typography
-          fs={16}
-          lh={36}
-          fw="MEDIUM"
-          style={{ whiteSpace: "nowrap" }}
+      <FundingInputWrapper>
+        <FlexWrapper
+          direction="row"
+          gap={16}
+          style={{ height: "36px", flex: 1 }}
         >
-          승인 금액
-        </Typography>
-        <UnitInput
-          value={approveAmount}
-          handleChange={setApproveAmount}
-          unit={`/ ${funding.expenditureAmount}원`}
-          placeholder="금액을 입력해주세요"
-          required={false}
-          unitOnClick={() =>
-            setApproveAmount(funding.expenditureAmount.toString())
-          }
-        />
-        <Button
-          type={availableToApprove() ? "default" : "disabled"}
-          onClick={handleApprove}
+          <Typography
+            fs={16}
+            lh={36}
+            fw="MEDIUM"
+            style={{ whiteSpace: "nowrap" }}
+          >
+            승인 금액
+          </Typography>
+          <UnitInput
+            value={approveAmount}
+            handleChange={setApproveAmount}
+            unit={`/ ${funding.expenditureAmount}원`}
+            placeholder="금액을 입력해주세요"
+            required={false}
+            unitOnClick={() =>
+              setApproveAmount(funding.expenditureAmount.toString())
+            }
+          />
+        </FlexWrapper>
+        <FlexWrapper
+          direction="row"
+          gap={16}
+          style={{ height: "36px", justifyContent: "flex-end" }}
         >
-          신청 승인
-        </Button>
-        <Button
-          onClick={handleReject}
-          type={reviewDetail === "" ? "disabled" : "default"}
-        >
-          신청 반려
-        </Button>
-        <Button
-          type={availableToApprove() ? "default" : "disabled"}
-          onClick={handleCommittee}
-        >
-          운위 상정
-        </Button>
-      </FlexWrapper>
+          <Button
+            type={availableToApprove() ? "default" : "disabled"}
+            onClick={handleApprove}
+          >
+            신청 승인
+          </Button>
+          <Button
+            onClick={handleReject}
+            type={reviewDetail === "" ? "disabled" : "default"}
+          >
+            신청 반려
+          </Button>
+          <Button
+            type={availableToApprove() ? "default" : "disabled"}
+            onClick={handleCommittee}
+          >
+            운위 상정
+          </Button>
+        </FlexWrapper>
+      </FundingInputWrapper>
     </Card>
   );
 };


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #1446 

- Toast 스크롤 할 때 contents가 제목 옆으로 보이지 않게 수정
- ExecutiveFundingReviewSection에서 화면 너비 좁아질 때 버튼 레이아웃 수정

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 집행부원 지원금 상세 페이지: http://localhost:3000/executive/funding/623
<img width="537" alt="스크린샷 2025-02-10 오전 12 39 03" src="https://github.com/user-attachments/assets/6259db32-ab76-4c0e-8ab1-b040340a894a" />


https://github.com/user-attachments/assets/abd40cce-d4e8-4fe5-9764-68f586501c2e



