### PR TITLE
[TU-25] feat: manage registration and deadline with semester id

### DIFF
--- a/packages/api/src/drizzle/schema/registration.schema.ts
+++ b/packages/api/src/drizzle/schema/registration.schema.ts
@@ -8,7 +8,7 @@ import {
   varchar,
 } from "drizzle-orm/mysql-core";
 
-import { Club } from "./club.schema";
+import { Club, SemesterD } from "./club.schema";
 import { Division } from "./division.schema";
 import { File } from "./file.schema";
 import { Executive, Professor, Student } from "./user.schema";
@@ -33,6 +33,7 @@ export const Registration = mysqlTable(
   {
     id: int("id").autoincrement().primaryKey(),
     clubId: int("club_id").references(() => Club.id),
+    semesterId: int("semester_d_id").references(() => SemesterD.id),
     registrationApplicationTypeEnumId: int(
       "registration_application_type_enum_id",
     ).notNull(),
@@ -75,6 +76,11 @@ export const Registration = mysqlTable(
     deletedAt: timestamp("deleted_at"),
   },
   table => ({
+    semesterIdFk: foreignKey({
+      name: "registration_semester_d_id_fk",
+      columns: [table.semesterId],
+      foreignColumns: [SemesterD.id],
+    }),
     registrationApplicationTypeEnumIdFk: foreignKey({
       name: "registration_registration_type_enum_id_fk",
       columns: [table.registrationApplicationTypeEnumId],
@@ -176,6 +182,7 @@ export const RegistrationDeadlineD = mysqlTable(
   "registration_deadline_d",
   {
     id: int("id").autoincrement().primaryKey(),
+    semesterId: int("semester_d_id").references(() => SemesterD.id),
     registrationDeadlineEnumId: int("registration_deadline_enum_id").notNull(),
     startDate: date("start_date"),
     endDate: date("end_date"),

--- a/packages/api/src/feature/registration/club-registration/repository/club-registration.repository.ts
+++ b/packages/api/src/feature/registration/club-registration/repository/club-registration.repository.ts
@@ -79,33 +79,38 @@ export class ClubRegistrationRepository {
     return result;
   }
 
-  async findByClubId(clubId: number) {
-    const clubs = await this.db
+  async findByClubAndSemesterId(clubId: number, semesterId: number) {
+    const registration = await this.db
       .select()
       .from(Registration)
       .where(
-        and(eq(Registration.clubId, clubId), isNull(Registration.deletedAt)),
+        and(
+          eq(Registration.clubId, clubId),
+          eq(Registration.semesterId, semesterId),
+          isNull(Registration.deletedAt),
+        ),
       );
-
-    return clubs;
+    return registration;
   }
 
-  async findByStudentId(studentId: number) {
-    const clubs = await this.db
+  async findByStudentAndSemesterId(studentId: number, semesterId: number) {
+    const registration = await this.db
       .select()
       .from(Registration)
       .where(
         and(
           eq(Registration.studentId, studentId),
+          eq(Registration.semesterId, semesterId),
           isNull(Registration.deletedAt),
         ),
       );
 
-    return clubs;
+    return registration;
   }
 
   async createRegistration(
     studentId: number,
+    semesterId: number,
     body: ApiReg001RequestBody,
   ): Promise<ApiReg001ResponseCreated> {
     const cur = getKSTDate();
@@ -186,6 +191,7 @@ export class ClubRegistrationRepository {
       const [registrationInsertResult] = await tx.insert(Registration).values({
         clubId: body.clubId,
         registrationApplicationTypeEnumId: body.registrationTypeEnumId,
+        semesterId,
         clubNameKr: body.clubNameKr,
         clubNameEn: body.clubNameEn,
         studentId,
@@ -536,6 +542,7 @@ export class ClubRegistrationRepository {
 
   async getStudentRegistrationsClubRegistrationsMy(
     studentId: number,
+    semesterId: number,
   ): Promise<ApiReg012ResponseOk> {
     const result = await this.db
       .select({
@@ -547,6 +554,7 @@ export class ClubRegistrationRepository {
         newClubNameKr: Registration.clubNameKr,
         newClubNameEn: Registration.clubNameEn,
         clubId: Registration.clubId,
+        semesterId: Registration.semesterId,
         activityFieldKr: Registration.activityFieldKr,
         activityFieldEn: Registration.activityFieldEn,
         professorName: Professor.name,
@@ -575,6 +583,7 @@ export class ClubRegistrationRepository {
       .where(
         and(
           eq(Registration.studentId, studentId),
+          eq(Registration.semesterId, semesterId),
           isNull(Registration.deletedAt),
         ),
       );


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

https://sparcs.slack.com/archives/C06LN70UX3L/p1739894981922079



It closes #issue_number

- 작업요약1: Registration 이 semesterId 기반으로 관리되도록 post(Reg001)와 get(Reg012)를 수정하였습니다.
- 작업요약2

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/register-club
