### PR TITLE
[TU-24] add temporary storage to register club

### DIFF
--- a/packages/web/src/common/components/Modal/RestoreDraftModal.tsx
+++ b/packages/web/src/common/components/Modal/RestoreDraftModal.tsx
@@ -6,12 +6,14 @@ import CancellableModalContent from "./CancellableModalContent";
 
 interface RestoreDraftModalProps {
   isOpen: boolean;
+  mainText?: string;
   onConfirm: () => void;
   onClose: () => void;
 }
 
 const RestoreDraftModal: React.FC<RestoreDraftModalProps> = ({
   isOpen,
+  mainText = undefined,
   onConfirm,
   onClose,
 }) => (
@@ -22,7 +24,7 @@ const RestoreDraftModal: React.FC<RestoreDraftModalProps> = ({
       onConfirm={onConfirm}
       onClose={onClose}
     >
-      임시 저장된 데이터가 있습니다. 불러오시겠습니까?
+      {mainText ?? `임시 저장된 데이터가 있습니다. 불러오시겠습니까?`}
       <Typography color="GRAY.600" fs={12} lh={16} fw="REGULAR">
         ‘새로 작성하기’를 선택하면 기존 임시 저장된 데이터가 삭제됩니다.
       </Typography>

--- a/packages/web/src/common/components/Modal/RestoreDraftModal.tsx
+++ b/packages/web/src/common/components/Modal/RestoreDraftModal.tsx
@@ -26,7 +26,8 @@ const RestoreDraftModal: React.FC<RestoreDraftModalProps> = ({
     >
       {mainText ?? `임시 저장된 데이터가 있습니다. 불러오시겠습니까?`}
       <Typography color="GRAY.600" fs={12} lh={16} fw="REGULAR">
-        ‘새로 작성하기’를 선택하면 기존 임시 저장된 데이터가 삭제됩니다.
+        ‘새로 작성하기’를 선택하면 기존 임시 저장된 데이터가 삭제됩니다. 임시
+        저장 된 데이터는 24시간 후 자동 삭제됩니다.
       </Typography>
     </CancellableModalContent>
   </Modal>

--- a/packages/web/src/constants/localStorage.ts
+++ b/packages/web/src/constants/localStorage.ts
@@ -1,4 +1,5 @@
 export const LOCAL_STORAGE_KEY = {
   ACTIVITY_REPORT: "activity-report",
   REGISTER_CLUB: "register-club",
+  REGISTER_CLUB_ACTIVITY_REPORT_MODAL: "register-club-activity-report-modal",
 } as const;

--- a/packages/web/src/constants/localStorage.ts
+++ b/packages/web/src/constants/localStorage.ts
@@ -1,3 +1,4 @@
 export const LOCAL_STORAGE_KEY = {
   ACTIVITY_REPORT: "activity-report",
+  REGISTER_CLUB: "register-club",
 } as const;

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
@@ -37,6 +37,7 @@ const ButtonWrapper = styled.div`
   justify-content: space-between;
 `;
 
+// TODO. (refactor) RegisterClubForm 사용
 const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
   applyId,
   initialData,

--- a/packages/web/src/features/register-club/components/RegisterClubForm.tsx
+++ b/packages/web/src/features/register-club/components/RegisterClubForm.tsx
@@ -1,0 +1,245 @@
+import { useRouter } from "next/navigation";
+import { overlay } from "overlay-kit";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import styled from "styled-components";
+
+import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import Button from "@sparcs-clubs/web/common/components/Button";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useGetUserProfile from "@sparcs-clubs/web/common/services/getUserProfile";
+import LocalStorageUtil from "@sparcs-clubs/web/common/services/localStorageUtil";
+import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
+import { isObjectEmpty } from "@sparcs-clubs/web/utils";
+
+import useRegisterClub from "../services/useRegisterClub";
+import { RegisterClubModel } from "../types/registerClub";
+import computeErrorMessage from "../utils/computeErrorMessage";
+import ActivityReportFrame from "./activity-report/ActivityReportFrame";
+import AdvancedInformFrame from "./advanced-info/AdvancedInformFrame";
+import BasicInformFrame from "./basic-info/BasicInformFrame";
+import ProvisionalBasicInformFrame from "./basic-info/ProvisionalBasicInformFrame";
+import ClubRulesFrame from "./compliance/ClubRulesFrame";
+
+interface RegisterClubFormProps {
+  type: RegistrationTypeEnum;
+  initialData?: RegisterClubModel;
+}
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const RegisterClubForm: React.FC<RegisterClubFormProps> = ({
+  type,
+  initialData = undefined,
+}) => {
+  const router = useRouter();
+  const [isAgreed, setIsAgreed] = useState(false);
+
+  const {
+    data: profile,
+    isLoading: isLoadingProfile,
+    isError: isErrorProfile,
+  } = useGetUserProfile();
+
+  const formCtx = useForm<RegisterClubModel>({
+    mode: "all",
+    defaultValues: {
+      ...initialData,
+      registrationTypeEnumId: initialData?.registrationTypeEnumId ?? type,
+      phoneNumber: initialData?.phoneNumber ?? profile?.phoneNumber,
+    },
+  });
+
+  const {
+    watch,
+    handleSubmit,
+    formState: { isValid },
+  } = formCtx;
+
+  const formData = watch();
+
+  const clubId = watch("clubId");
+  const registrationTypeEnumId = watch("registrationTypeEnumId");
+  const foundedAt = watch("foundedAt");
+  const divisionId = watch("divisionId");
+
+  const isFormValid =
+    registrationTypeEnumId !== undefined &&
+    foundedAt !== undefined &&
+    divisionId !== undefined &&
+    isValid;
+
+  const errorMessage = useMemo(
+    () =>
+      computeErrorMessage({
+        ...formData,
+        isAgreed,
+      }),
+    [formData, isAgreed],
+  );
+
+  const {
+    data: registrationData,
+    mutate: registerClubApi,
+    isSuccess,
+    isError,
+  } = useRegisterClub();
+
+  const isProvisionalClub =
+    type === RegistrationTypeEnum.NewProvisional ||
+    type === RegistrationTypeEnum.ReProvisional;
+
+  const submitHandler = useCallback(
+    (data: RegisterClubModel) => {
+      // logger.debug("submit", data);
+      registerClubApi({
+        body: {
+          ...data,
+          clubRuleFileId: data.clubRuleFile?.id,
+          activityPlanFileId: data.activityPlanFile?.id,
+          externalInstructionFileId: data.externalInstructionFile?.id,
+        },
+      });
+    },
+    [registrationData, isSuccess, isError],
+  );
+
+  useEffect(() => {
+    if (!isObjectEmpty(formData)) {
+      LocalStorageUtil.save(LOCAL_STORAGE_KEY.REGISTER_CLUB, formData);
+    }
+  }, [formData]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      overlay.open(({ isOpen, close }) => (
+        <Modal isOpen={isOpen}>
+          <ConfirmModalContent
+            onConfirm={() => {
+              close();
+              router.push(`/my/register-club/${registrationData.id}`);
+              LocalStorageUtil.remove(LOCAL_STORAGE_KEY.REGISTER_CLUB);
+            }}
+          >
+            신청이 완료되었습니다.
+            <br />
+            확인을 누르면 신청 내역 화면으로 이동합니다.
+          </ConfirmModalContent>
+        </Modal>
+      ));
+      return;
+    }
+    if (isError) {
+      /* 
+        TODO: (@dora)
+        원래 useGetClubDetail()을 통해 clubName을 가져와서 
+        "{clubName} 동아리 등록 신청이 이미 존재하여 등록 신청을 할 수 없습니다."라고 표시해주었는데,
+        해당 API 호출에 이슈가 있어서 clubName에 대한 부분을 임시로 빼둔 상태
+        그리고 에러 케이스가 다양해지면서 그냥 문구를 퉁쳐버림...
+      */
+      overlay.open(({ isOpen, close }) => (
+        <Modal isOpen={isOpen}>
+          <ConfirmModalContent
+            onConfirm={() => {
+              close();
+            }}
+          >
+            해당 동아리에 대한 등록 신청이 이미 존재하거나,
+            <br />
+            이미 등록 신청 기록이 있거나,
+            <br />
+            지도교수를 입력하지 않아
+            <br />
+            등록 신청을 할 수 없습니다.
+          </ConfirmModalContent>
+        </Modal>
+      ));
+    }
+  }, [isSuccess, isError]);
+
+  return (
+    <FormProvider {...formCtx}>
+      <form onSubmit={handleSubmit(submitHandler)}>
+        <FlexWrapper direction="column" gap={60}>
+          <AsyncBoundary isLoading={isLoadingProfile} isError={isErrorProfile}>
+            {isProvisionalClub ? (
+              <ProvisionalBasicInformFrame
+                profile={
+                  profile
+                    ? { name: profile.name, phoneNumber: profile.phoneNumber }
+                    : undefined
+                }
+              />
+            ) : (
+              <BasicInformFrame
+                type={type}
+                profile={
+                  profile
+                    ? { name: profile.name, phoneNumber: profile.phoneNumber }
+                    : undefined
+                }
+              />
+            )}
+          </AsyncBoundary>
+          <AdvancedInformFrame
+            type={type}
+            files={{
+              activityPlanFile: initialData?.activityPlanFile,
+              clubRuleFile: initialData?.clubRuleFile,
+              externalInstructionFile: initialData?.externalInstructionFile,
+            }}
+          />
+          {type === RegistrationTypeEnum.Promotional && clubId && (
+            <ActivityReportFrame clubId={clubId} />
+          )}
+          <ClubRulesFrame
+            isNewProvisional={type === RegistrationTypeEnum.NewProvisional}
+            isAgreed={isAgreed}
+            setIsAgreed={setIsAgreed}
+          />
+
+          <ButtonWrapper>
+            <Button
+              type="outlined"
+              onClick={() => router.replace("/register-club")}
+            >
+              취소
+            </Button>
+
+            <FlexWrapper
+              direction="row"
+              gap={16}
+              style={{ alignItems: "center" }}
+            >
+              {errorMessage && (
+                <Typography color="RED.600" fs={12} lh={16}>
+                  {errorMessage}
+                </Typography>
+              )}
+              <Button
+                buttonType="submit"
+                type={
+                  isFormValid && isAgreed && errorMessage === ""
+                    ? "default"
+                    : "disabled"
+                }
+              >
+                신청
+              </Button>
+            </FlexWrapper>
+          </ButtonWrapper>
+        </FlexWrapper>
+      </form>
+    </FormProvider>
+  );
+};
+
+export default RegisterClubForm;

--- a/packages/web/src/features/register-club/components/activity-report/CreateActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/CreateActivityReportModal.tsx
@@ -5,6 +5,10 @@ import apiAct011 from "@sparcs-clubs/interface/api/activity/endpoint/apiAct011";
 
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
+import RestoreDraftModal from "@sparcs-clubs/web/common/components/Modal/RestoreDraftModal";
+import useTemporaryStorage from "@sparcs-clubs/web/common/hooks/useTemporaryStorage";
+import LocalStorageUtil from "@sparcs-clubs/web/common/services/localStorageUtil";
+import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
 import { ActivityReportFormData } from "@sparcs-clubs/web/features/activity-report/types/form";
 import usePostActivityReportForNewClub from "@sparcs-clubs/web/features/register-club/services/usePostActivityReportForNewClub";
 
@@ -23,6 +27,11 @@ const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
   close,
 }) => {
   const queryClient = useQueryClient();
+
+  const { savedData, isModalOpen, handleConfirm, handleClose } =
+    useTemporaryStorage<ActivityReportFormData>(
+      LOCAL_STORAGE_KEY.REGISTER_CLUB_ACTIVITY_REPORT_MODAL,
+    );
 
   const { mutate } = usePostActivityReportForNewClub();
 
@@ -44,6 +53,9 @@ const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
         },
         {
           onSuccess: () => {
+            LocalStorageUtil.remove(
+              LOCAL_STORAGE_KEY.REGISTER_CLUB_ACTIVITY_REPORT_MODAL,
+            );
             queryClient.invalidateQueries({ queryKey: [apiAct011.url()] });
             close();
           },
@@ -58,10 +70,22 @@ const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
     close();
   };
 
+  if (isModalOpen) {
+    return (
+      <RestoreDraftModal
+        isOpen={isModalOpen}
+        mainText="작성하시던 활동 보고서 내역이 있습니다. 불러오시겠습니까?"
+        onConfirm={handleConfirm}
+        onClose={handleClose}
+      />
+    );
+  }
+
   return (
     <Modal isOpen={isOpen} width="full">
       <ActivityReportForm
         clubId={clubId}
+        initialData={savedData}
         onCancel={handleCancel}
         onSubmit={submitHandler}
       />

--- a/packages/web/src/features/register-club/components/activity-report/_atomic/ActivityReportForm.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/_atomic/ActivityReportForm.tsx
@@ -11,9 +11,12 @@ import FormController from "@sparcs-clubs/web/common/components/FormController";
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
 import Select from "@sparcs-clubs/web/common/components/Select";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import LocalStorageUtil from "@sparcs-clubs/web/common/services/localStorageUtil";
+import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
 import SelectParticipant from "@sparcs-clubs/web/features/activity-report/components/SelectParticipant";
 import useGetParticipants from "@sparcs-clubs/web/features/activity-report/services/useGetParticipants";
 import { ActivityReportFormData } from "@sparcs-clubs/web/features/activity-report/types/form";
+import { isObjectEmpty } from "@sparcs-clubs/web/utils";
 
 import SelectActivityTerm from "./SelectActivityTerm";
 
@@ -42,6 +45,8 @@ const ActivityReportForm: React.FC<ActivityReportFormProps> = ({
     setValue,
     formState: { isValid },
   } = formCtx;
+
+  const formData = watch();
 
   const durations = watch("durations");
   const evidenceFiles = watch("evidenceFiles");
@@ -79,6 +84,15 @@ const ActivityReportForm: React.FC<ActivityReportFormProps> = ({
     () => isValid && durations && participants.length > 0 && evidenceFiles,
     [durations, participants, evidenceFiles, isValid],
   );
+
+  useEffect(() => {
+    if (!isObjectEmpty(formData)) {
+      LocalStorageUtil.save(
+        LOCAL_STORAGE_KEY.REGISTER_CLUB_ACTIVITY_REPORT_MODAL,
+        formData,
+      );
+    }
+  }, [formData]);
 
   return (
     <FormProvider {...formCtx}>

--- a/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubMainFrame.tsx
@@ -1,8 +1,4 @@
-import { useRouter } from "next/navigation";
-import { overlay } from "overlay-kit";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
-import styled from "styled-components";
+import React from "react";
 
 import {
   getDisplayNameRegistration,
@@ -10,91 +6,29 @@ import {
 } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
-import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Info from "@sparcs-clubs/web/common/components/Info";
-import Modal from "@sparcs-clubs/web/common/components/Modal";
-import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
+import RestoreDraftModal from "@sparcs-clubs/web/common/components/Modal/RestoreDraftModal";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
-import Typography from "@sparcs-clubs/web/common/components/Typography";
-import useGetUserProfile from "@sparcs-clubs/web/common/services/getUserProfile";
+import useTemporaryStorage from "@sparcs-clubs/web/common/hooks/useTemporaryStorage";
+import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
 import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
-import ActivityReportFrame from "../components/activity-report/ActivityReportFrame";
-import AdvancedInformFrame from "../components/advanced-info/AdvancedInformFrame";
-import BasicInformFrame from "../components/basic-info/BasicInformFrame";
-import ProvisionalBasicInformFrame from "../components/basic-info/ProvisionalBasicInformFrame";
-import ClubRulesFrame from "../components/compliance/ClubRulesFrame";
+import RegisterClubForm from "../components/RegisterClubForm";
 import { registerClubDeadlineInfoText } from "../constants";
-import useRegisterClub from "../services/useRegisterClub";
 import { RegisterClubModel } from "../types/registerClub";
-import computeErrorMessage from "../utils/computeErrorMessage";
 
 interface RegisterClubMainFrameProps {
   type: RegistrationTypeEnum;
   deadline: Date | null;
 }
 
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
 const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
   type,
   deadline = undefined,
 }) => {
-  const router = useRouter();
-  const [isAgreed, setIsAgreed] = useState(false);
-
-  const {
-    data: profile,
-    isLoading: isLoadingProfile,
-    isError: isErrorProfile,
-  } = useGetUserProfile();
-
-  const formCtx = useForm<RegisterClubModel>({
-    mode: "all",
-    defaultValues: {
-      registrationTypeEnumId: type,
-      phoneNumber: profile?.phoneNumber,
-    },
-  });
-
-  const {
-    watch,
-    handleSubmit,
-    formState: { isValid },
-  } = formCtx;
-
-  const formData = watch();
-
-  const clubId = watch("clubId");
-  const registrationTypeEnumId = watch("registrationTypeEnumId");
-  const foundedAt = watch("foundedAt");
-  const divisionId = watch("divisionId");
-
-  const isFormValid =
-    registrationTypeEnumId !== undefined &&
-    foundedAt !== undefined &&
-    divisionId !== undefined &&
-    isValid;
-
-  const errorMessage = useMemo(
-    () =>
-      computeErrorMessage({
-        ...formData,
-        isAgreed,
-      }),
-    [formData, isAgreed],
-  );
-
-  const {
-    data: registrationData,
-    mutate: registerClubApi,
-    isSuccess,
-    isError,
-  } = useRegisterClub();
+  const { savedData, isModalOpen, handleConfirm, handleClose } =
+    useTemporaryStorage<RegisterClubModel>(LOCAL_STORAGE_KEY.REGISTER_CLUB);
 
   const {
     semester: semesterInfo,
@@ -102,157 +36,36 @@ const RegisterClubMainFrame: React.FC<RegisterClubMainFrameProps> = ({
     isError: semesterError,
   } = useGetSemesterNow();
 
-  const isProvisionalClub =
-    type === RegistrationTypeEnum.NewProvisional ||
-    type === RegistrationTypeEnum.ReProvisional;
-
-  const submitHandler = useCallback(
-    (data: RegisterClubModel) => {
-      // logger.debug("submit", data);
-      registerClubApi({
-        body: {
-          ...data,
-          clubRuleFileId: data.clubRuleFile?.id,
-          activityPlanFileId: data.activityPlanFile?.id,
-          externalInstructionFileId: data.externalInstructionFile?.id,
-        },
-      });
-    },
-    [registrationData, isSuccess, isError],
-  );
-
-  useEffect(() => {
-    if (isSuccess) {
-      overlay.open(({ isOpen, close }) => (
-        <Modal isOpen={isOpen}>
-          <ConfirmModalContent
-            onConfirm={() => {
-              close();
-              router.push(`/my/register-club/${registrationData.id}`);
-            }}
-          >
-            신청이 완료되었습니다.
-            <br />
-            확인을 누르면 신청 내역 화면으로 이동합니다.
-          </ConfirmModalContent>
-        </Modal>
-      ));
-      return;
-    }
-    if (isError) {
-      /* 
-        TODO: (@dora)
-        원래 useGetClubDetail()을 통해 clubName을 가져와서 
-        "{clubName} 동아리 등록 신청이 이미 존재하여 등록 신청을 할 수 없습니다."라고 표시해주었는데,
-        해당 API 호출에 이슈가 있어서 clubName에 대한 부분을 임시로 빼둔 상태
-        그리고 에러 케이스가 다양해지면서 그냥 문구를 퉁쳐버림...
-      */
-      overlay.open(({ isOpen, close }) => (
-        <Modal isOpen={isOpen}>
-          <ConfirmModalContent
-            onConfirm={() => {
-              close();
-            }}
-          >
-            해당 동아리에 대한 등록 신청이 이미 존재하거나,
-            <br />
-            이미 등록 신청 기록이 있거나,
-            <br />
-            지도교수를 입력하지 않아
-            <br />
-            등록 신청을 할 수 없습니다.
-          </ConfirmModalContent>
-        </Modal>
-      ));
-    }
-  }, [isSuccess, isError]);
-
   return (
-    <FormProvider {...formCtx}>
-      <form onSubmit={handleSubmit(submitHandler)}>
-        <FlexWrapper direction="column" gap={60}>
-          <PageHead
-            items={[
-              {
-                name: `동아리 등록`,
-                path: `/register-club`,
-              },
-            ]}
-            title={`동아리 ${getDisplayNameRegistration(type)} 신청`}
-            enableLast
-          />
-          <AsyncBoundary isLoading={semesterLoading} isError={semesterError}>
-            {deadline ? (
-              <Info
-                text={registerClubDeadlineInfoText(deadline, semesterInfo)}
-              />
-            ) : (
-              <Info text="현재는 동아리 등록 기간이 아닙니다" />
-            )}
-          </AsyncBoundary>
-          <AsyncBoundary isLoading={isLoadingProfile} isError={isErrorProfile}>
-            {isProvisionalClub ? (
-              <ProvisionalBasicInformFrame
-                profile={
-                  profile
-                    ? { name: profile.name, phoneNumber: profile.phoneNumber }
-                    : undefined
-                }
-              />
-            ) : (
-              <BasicInformFrame
-                type={type}
-                profile={
-                  profile
-                    ? { name: profile.name, phoneNumber: profile.phoneNumber }
-                    : undefined
-                }
-              />
-            )}
-          </AsyncBoundary>
-          <AdvancedInformFrame type={type} />
-          {type === RegistrationTypeEnum.Promotional && clubId && (
-            <ActivityReportFrame clubId={clubId} />
-          )}
-          <ClubRulesFrame
-            isNewProvisional={type === RegistrationTypeEnum.NewProvisional}
-            isAgreed={isAgreed}
-            setIsAgreed={setIsAgreed}
-          />
-
-          <ButtonWrapper>
-            <Button
-              type="outlined"
-              onClick={() => router.replace("/register-club")}
-            >
-              취소
-            </Button>
-
-            <FlexWrapper
-              direction="row"
-              gap={16}
-              style={{ alignItems: "center" }}
-            >
-              {errorMessage && (
-                <Typography color="RED.600" fs={12} lh={16}>
-                  {errorMessage}
-                </Typography>
-              )}
-              <Button
-                buttonType="submit"
-                type={
-                  isFormValid && isAgreed && errorMessage === ""
-                    ? "default"
-                    : "disabled"
-                }
-              >
-                신청
-              </Button>
-            </FlexWrapper>
-          </ButtonWrapper>
-        </FlexWrapper>
-      </form>
-    </FormProvider>
+    <FlexWrapper direction="column" gap={60}>
+      <PageHead
+        items={[
+          {
+            name: `동아리 등록`,
+            path: `/register-club`,
+          },
+        ]}
+        title={`동아리 ${getDisplayNameRegistration(type)} 신청`}
+        enableLast
+      />
+      <AsyncBoundary isLoading={semesterLoading} isError={semesterError}>
+        {deadline ? (
+          <Info text={registerClubDeadlineInfoText(deadline, semesterInfo)} />
+        ) : (
+          <Info text="현재는 동아리 등록 기간이 아닙니다" />
+        )}
+      </AsyncBoundary>
+      {isModalOpen ? (
+        <RestoreDraftModal
+          isOpen={isModalOpen}
+          mainText="선택한 타입의 등록, 혹은 다른 타입의 동아리 등록 신청에서 작성하시던 내역이 있습니다. 불러오시겠습니까?"
+          onConfirm={handleConfirm}
+          onClose={handleClose}
+        />
+      ) : (
+        <RegisterClubForm type={type} initialData={savedData} />
+      )}
+    </FlexWrapper>
   );
 };
 


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 동아리 등록 신청페이지에 임시저장 기능 추가
- 동아리 신규등록 > 활보 작성 모달에도 임시저장 기능 추가

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 지금 동아리등록이 폼이 하나라 그냥 하나의 객체에 임시저장 했는데 그래서 데이터가 가등록, 재등록, 신규등록 사이에 공유됨. 혹시 이게 문제가 된다면 객체 3개 만들어서 따로 임시저장 하겠음 @wjeongchoi 

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: 2월 22일 (토요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 등록 페이지: http://localhost:3000/register-club/promotional 
2. 활보 작성 모달
