### PR TITLE
동아리 등록 페이지 신청내역 관련하여 버튼 활성화 여부 수정

### DIFF
--- a/packages/web/src/common/frames/HasClubRegistration.tsx
+++ b/packages/web/src/common/frames/HasClubRegistration.tsx
@@ -24,13 +24,16 @@ const ErrorMessage = styled.div`
   }
 `;
 
-const HasClubRegistration: React.FC<{ applyId: number }> = ({ applyId }) => {
+const HasClubRegistration: React.FC<{
+  applyId?: number;
+  errorMessage?: string;
+}> = ({ applyId = undefined, errorMessage = undefined }) => {
   const router = useRouter();
 
   const Message = (
-    <ErrorMessage>
-      동아리 등록 신청 내역이 이미 존재하여 <br />
-      추가로 신청할 수 없습니다
+    <ErrorMessage style={{ whiteSpace: "pre-line" }}>
+      {errorMessage ||
+        `동아리 등록 신청 내역이 이미 존재하여 \n 추가로 신청할 수 없습니다`}
     </ErrorMessage>
   );
 
@@ -41,13 +44,17 @@ const HasClubRegistration: React.FC<{ applyId: number }> = ({ applyId }) => {
   return (
     <ErrorPageTemplate
       message={Message}
-      buttons={[
-        { text: "메인 바로가기", onClick: goToMain },
-        {
-          text: "동아리 등록 신청 내역 바로가기",
-          onClick: () => router.push(`/my/register-club/${applyId}`),
-        },
-      ]}
+      buttons={
+        applyId
+          ? [
+              { text: "메인 바로가기", onClick: goToMain },
+              {
+                text: "동아리 등록 신청 내역 바로가기",
+                onClick: () => router.push(`/my/register-club/${applyId}`),
+              },
+            ]
+          : [{ text: "메인 바로가기", onClick: goToMain }]
+      }
     />
   );
 };

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubDetailFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubDetailFrame.tsx
@@ -36,6 +36,7 @@ import {
   RegistrationTypeTagList,
 } from "@sparcs-clubs/web/constants/tableTagList";
 import { deleteMyClubRegistration } from "@sparcs-clubs/web/features/my/services/deleteMyClubRegistration";
+import { useGetMyClubRegistration } from "@sparcs-clubs/web/features/my/services/getMyClubRegistration";
 import usePatchClubRegProfessorApprove from "@sparcs-clubs/web/features/my/services/usePatchClubRegProfessorApprove";
 import { getRegisterClubProgress } from "@sparcs-clubs/web/features/register-club/constants/registerClubProgress";
 import useGetClubRegistrationPeriod from "@sparcs-clubs/web/features/register-club/hooks/useGetClubRegistrationPeriod";
@@ -83,6 +84,12 @@ const MyRegisterClubDetailFrame: React.FC<{
   const queryClient = useQueryClient();
   const router = useRouter();
   const { id } = useParams();
+
+  const {
+    data: myClubRegistrationData,
+    isLoading: isLoadingMyClubRegistration,
+    isError: isErrorMyClubRegistration,
+  } = useGetMyClubRegistration();
 
   const {
     data: deadlineData,
@@ -370,7 +377,10 @@ const MyRegisterClubDetailFrame: React.FC<{
         >
           목록으로 돌아가기
         </Button>
-        <AsyncBoundary isLoading={isLoadingDeadline} isError={isErrorDeadline}>
+        <AsyncBoundary
+          isLoading={isLoadingDeadline || isLoadingMyClubRegistration}
+          isError={isErrorDeadline || isErrorMyClubRegistration}
+        >
           {deadlineData.isClubRegistrationPeriod &&
             (isProfessor ? (
               <FlexWrapper direction="row" gap={10}>
@@ -383,17 +393,23 @@ const MyRegisterClubDetailFrame: React.FC<{
                 </Button>
               </FlexWrapper>
             ) : (
-              <FlexWrapper direction="row" gap={10}>
-                <Button
-                  style={{ width: "max-content" }}
-                  onClick={deleteHandler}
-                >
-                  삭제
-                </Button>
-                <Button style={{ width: "max-content" }} onClick={editHandler}>
-                  수정
-                </Button>
-              </FlexWrapper>
+              myClubRegistrationData &&
+              myClubRegistrationData.registrations.length > 0 && (
+                <FlexWrapper direction="row" gap={10}>
+                  <Button
+                    style={{ width: "max-content" }}
+                    onClick={deleteHandler}
+                  >
+                    삭제
+                  </Button>
+                  <Button
+                    style={{ width: "max-content" }}
+                    onClick={editHandler}
+                  >
+                    수정
+                  </Button>
+                </FlexWrapper>
+              )
             ))}
         </AsyncBoundary>
       </ButtonWrapper>

--- a/packages/web/src/features/register-club/components/RegisterClubForm.tsx
+++ b/packages/web/src/features/register-club/components/RegisterClubForm.tsx
@@ -1,9 +1,12 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 
+import apiReg012 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg012";
+import apiReg025 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg025";
 import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
@@ -40,6 +43,8 @@ const RegisterClubForm: React.FC<RegisterClubFormProps> = ({
   type,
   initialData = undefined,
 }) => {
+  const queryClient = useQueryClient();
+
   const router = useRouter();
   const [isAgreed, setIsAgreed] = useState(false);
 
@@ -53,7 +58,7 @@ const RegisterClubForm: React.FC<RegisterClubFormProps> = ({
     mode: "all",
     defaultValues: {
       ...initialData,
-      registrationTypeEnumId: initialData?.registrationTypeEnumId ?? type,
+      registrationTypeEnumId: type,
       phoneNumber: initialData?.phoneNumber ?? profile?.phoneNumber,
     },
   });
@@ -124,6 +129,12 @@ const RegisterClubForm: React.FC<RegisterClubFormProps> = ({
         <Modal isOpen={isOpen}>
           <ConfirmModalContent
             onConfirm={() => {
+              queryClient.invalidateQueries({
+                queryKey: [apiReg012.url()],
+              });
+              queryClient.invalidateQueries({
+                queryKey: [apiReg025.url()],
+              });
               close();
               router.push(`/my/register-club/${registrationData.id}`);
               LocalStorageUtil.remove(LOCAL_STORAGE_KEY.REGISTER_CLUB);

--- a/packages/web/src/features/register-club/components/basic-info/ProvisionalBasicInformFrame.tsx
+++ b/packages/web/src/features/register-club/components/basic-info/ProvisionalBasicInformFrame.tsx
@@ -17,6 +17,7 @@ import {
   notAllowKrRegx,
   regxErrorMessage,
 } from "@sparcs-clubs/web/features/register-club/constants";
+import useGetAvailableRegistrationInfo from "@sparcs-clubs/web/features/register-club/hooks/useGetAvailableRegistrationInfo";
 import useGetClubsForReProvisional from "@sparcs-clubs/web/features/register-club/services/useGetClubsForReProvisional";
 
 import ClubNameField from "./_atomic/ClubNameField";
@@ -38,6 +39,11 @@ const ProvisionalBasicInformFrame: React.FC<
   const registrationType = watch("registrationTypeEnumId");
 
   const { data, isLoading, isError } = useGetClubsForReProvisional();
+  const {
+    data: availableRegistrationInfo,
+    isLoading: isLoadingAvailableRegistrationInfo,
+    isError: isErrorAvailableRegistrationInfo,
+  } = useGetAvailableRegistrationInfo();
 
   const [isCheckedProfessor, setIsCheckedProfessor] = useState(false);
 
@@ -53,6 +59,18 @@ const ProvisionalBasicInformFrame: React.FC<
 
   const buttonType = useCallback(
     (type: RegistrationTypeEnum) => {
+      if (type === RegistrationTypeEnum.ReProvisional) {
+        if (
+          !availableRegistrationInfo.haveAvailableRegistration ||
+          availableRegistrationInfo.noManageClub ||
+          !availableRegistrationInfo.availableRegistrations.includes(
+            RegistrationTypeEnum.ReProvisional,
+          )
+        ) {
+          return "disabled";
+        }
+      }
+
       if (type === registrationType) {
         return "default";
       }
@@ -65,7 +83,10 @@ const ProvisionalBasicInformFrame: React.FC<
   );
 
   return (
-    <AsyncBoundary isLoading={isLoading} isError={isError}>
+    <AsyncBoundary
+      isLoading={isLoading || isLoadingAvailableRegistrationInfo}
+      isError={isError || isErrorAvailableRegistrationInfo}
+    >
       <FlexWrapper direction="column" gap={40}>
         <SectionTitle>기본 정보</SectionTitle>
         <Card outline gap={32} style={{ marginLeft: 20 }}>

--- a/packages/web/src/features/register-club/constants/index.ts
+++ b/packages/web/src/features/register-club/constants/index.ts
@@ -1,7 +1,7 @@
+import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
 import { Semester } from "@sparcs-clubs/web/types/semester";
 import { formatDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
-
-import { RegistrationType } from "../types/registerClub";
 
 // 영문, 숫자, 특수문자, 공백이 허용되는 정규식(한글 안됨)
 export const notAllowKrRegx = /^[\x20-\x7E]+$/;
@@ -16,12 +16,12 @@ export const registerClubDeadlineInfoText = (
 
 export const registerClubOptions = [
   {
-    type: RegistrationType.Renewal,
+    type: RegistrationTypeEnum.Renewal,
     title: "재등록",
     buttonText: ["직전 학기에 정동아리 지위를 유지했던 동아리만 등록 가능"],
   },
   {
-    type: RegistrationType.Promotional,
+    type: RegistrationTypeEnum.Promotional,
     title: "신규 등록",
     buttonText: [
       "2개 정규학기 이상 가등록 지위를 유지한 동아리 등록 가능",
@@ -29,7 +29,7 @@ export const registerClubOptions = [
     ],
   },
   {
-    type: RegistrationType.Provisional,
+    type: RegistrationTypeEnum.NewProvisional,
     title: "가등록",
     buttonText: [
       "새로 동아리를 만드려는 학부 총학생회 정회원 등록 가능",

--- a/packages/web/src/features/register-club/frames/RegisterClubAuthFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubAuthFrame.tsx
@@ -10,6 +10,7 @@ import { useGetMyClubRegistration } from "@sparcs-clubs/web/features/my/services
 import RegisterClubMainFrame from "@sparcs-clubs/web/features/register-club/frames/RegisterClubMainFrame";
 import { useCheckManageClub } from "@sparcs-clubs/web/hooks/checkManageClub";
 
+import useGetAvailableRegistrationInfo from "../hooks/useGetAvailableRegistrationInfo";
 import useGetClubRegistrationPeriod from "../hooks/useGetClubRegistrationPeriod";
 
 const RegisterClubAuthFrame: React.FC<{
@@ -22,6 +23,12 @@ const RegisterClubAuthFrame: React.FC<{
     isLoading,
     isError,
   } = useGetMyClubRegistration();
+
+  const {
+    data: availableRegistrationInfo,
+    isLoading: isLoadingAvailableRegistrationInfo,
+    isError: isErrorAvailableRegistrationInfo,
+  } = useGetAvailableRegistrationInfo();
 
   const {
     data: deadlineData,
@@ -37,11 +44,21 @@ const RegisterClubAuthFrame: React.FC<{
     [myClubRegistrationData],
   );
 
-  if (isLoading || checkLoading || isLoadingDeadline) {
+  if (
+    isLoading ||
+    checkLoading ||
+    isLoadingDeadline ||
+    isLoadingAvailableRegistrationInfo
+  ) {
     return (
       <AsyncBoundary
-        isLoading={isLoading || checkLoading || isLoadingDeadline}
-        isError={isError || isErrorDeadline}
+        isLoading={
+          isLoading ||
+          checkLoading ||
+          isLoadingDeadline ||
+          isLoadingAvailableRegistrationInfo
+        }
+        isError={isError || isErrorDeadline || isErrorAvailableRegistrationInfo}
       />
     );
   }
@@ -54,6 +71,18 @@ const RegisterClubAuthFrame: React.FC<{
     return (
       <HasClubRegistration
         applyId={myClubRegistrationData!.registrations[0].id}
+      />
+    );
+  }
+
+  if (
+    availableRegistrationInfo &&
+    !availableRegistrationInfo.availableRegistrations.includes(type) &&
+    type !== RegistrationTypeEnum.NewProvisional
+  ) {
+    return (
+      <HasClubRegistration
+        errorMessage={`관리하고 있는 동아리의 동아리 신청 내역이 존재하거나 \n 동아리 등록 신청 조건에 만족하지 않아 신청할 수 없습니다.`}
       />
     );
   }

--- a/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubFrame.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import React, { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 
+import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
@@ -19,9 +21,8 @@ import {
 } from "@sparcs-clubs/web/features/register-club/constants";
 import useGetSemesterNow from "@sparcs-clubs/web/utils/getSemesterNow";
 
+import useGetAvailableRegistrationInfo from "../hooks/useGetAvailableRegistrationInfo";
 import useGetClubRegistrationPeriod from "../hooks/useGetClubRegistrationPeriod";
-import useGetRegistrationAvailableClubs from "../services/useGetRegistrationAvailableClubs";
-import { RegistrationType } from "../types/registerClub";
 
 const ClubButtonWrapper = styled.div`
   display: flex;
@@ -37,7 +38,7 @@ const ClubButtonWrapper = styled.div`
 const RegisterClubFrame: React.FC = () => {
   const router = useRouter();
 
-  const [selectedType, setSelectedType] = useState<RegistrationType | null>(
+  const [selectedType, setSelectedType] = useState<RegistrationTypeEnum | null>(
     null,
   );
 
@@ -48,10 +49,10 @@ const RegisterClubFrame: React.FC = () => {
   } = useGetMyClubRegistration();
 
   const {
-    data: availableClubRegistrationData,
+    data: availableRegistrationInfo,
     isLoading,
     isError,
-  } = useGetRegistrationAvailableClubs();
+  } = useGetAvailableRegistrationInfo();
 
   const {
     data: deadlineData,
@@ -65,28 +66,50 @@ const RegisterClubFrame: React.FC = () => {
     isError: semesterError,
   } = useGetSemesterNow();
 
+  const onClickRegisterClub = useCallback(() => {
+    if (selectedType === RegistrationTypeEnum.Renewal)
+      router.push(`register-club/renewal`);
+    else if (selectedType === RegistrationTypeEnum.Promotional)
+      router.push(`register-club/promotional`);
+    else {
+      router.push(`register-club/provisional`);
+    }
+  }, [selectedType]);
+
+  const showWarningInfoLinkedText = useMemo(
+    () =>
+      myClubRegistrationData && myClubRegistrationData.registrations.length > 0,
+    [myClubRegistrationData],
+  );
+
   const canRegisterClub = useMemo<boolean>(() => {
     // 대표자/대의원으로 관리하던 동아리가 있는 경우:
     // 1. 동아리 등록 신청 내역이 없으면 재등록, 신규등록, 가등록 모두 가능 2. 신청 내역 있으면 가등록(신규)만 가능 3. 내가 이미 신청했으면 셋 다 불가능
-    if (availableClubRegistrationData?.club) {
-      return (
-        availableClubRegistrationData?.club.availableRegistrationTypeEnums
-          .length > 0
-      );
+    if (availableRegistrationInfo && selectedType) {
+      if (
+        availableRegistrationInfo.availableRegistrations.includes(selectedType)
+      ) {
+        return true;
+      }
+
+      if (
+        selectedType === RegistrationTypeEnum.NewProvisional &&
+        availableRegistrationInfo.availableRegistrations.includes(
+          RegistrationTypeEnum.ReProvisional,
+        )
+      ) {
+        return true;
+      }
     }
 
-    // 관리하던 동아리 신청내역과는 상관없이 가등록(신규)의 경우 항상 가능
-    return selectedType === RegistrationType.Provisional;
-  }, [availableClubRegistrationData, selectedType]);
+    // 관리하는 동아리가 있고 나의 신청 내역에 데이터가 있으면 모든 타입 비활성화
+    if (!availableRegistrationInfo.noManageClub && showWarningInfoLinkedText) {
+      return false;
+    }
 
-  const onClickRegisterClub = useCallback(() => {
-    if (selectedType === RegistrationType.Renewal)
-      router.push(`register-club/renewal`);
-    else if (selectedType === RegistrationType.Promotional)
-      router.push(`register-club/promotional`);
-    else if (selectedType === RegistrationType.Provisional)
-      router.push(`register-club/provisional`);
-  }, [selectedType]);
+    // 관리하던 동아리 신청 내역과는 상관없이 가등록(신규)의 경우 항상 가능
+    return selectedType === RegistrationTypeEnum.NewProvisional;
+  }, [availableRegistrationInfo, selectedType]);
 
   const isRegisterButtonDisabled =
     selectedType === null ||
@@ -103,21 +126,20 @@ const RegisterClubFrame: React.FC = () => {
         isLoading={isLoading || isLoadingMyClubRegistration}
         isError={isError || isErrorMyClubRegistration}
       >
-        {!canRegisterClub && (
+        {selectedType && !canRegisterClub && (
           <WarningInfo
-            linkText="동아리 등록 신청 내역 바로가기"
-            onClickLink={
-              myClubRegistrationData &&
-              myClubRegistrationData.registrations.length > 0
-                ? () =>
-                    router.push(
-                      `my/register-club/${myClubRegistrationData?.registrations[0].id}`,
-                    )
-                : undefined
+            linkText={
+              showWarningInfoLinkedText ? "동아리 등록 신청 내역 바로가기" : ""
+            }
+            onClickLink={() =>
+              router.push(
+                `my/register-club/${myClubRegistrationData?.registrations[0].id}`,
+              )
             }
           >
             <Typography fs={16} lh={24}>
-              동아리 등록 신청 내역이 이미 존재하여 추가로 신청할 수 없습니다
+              관리하는 동아리의 동아리 등록 신청 내역이 이미 존재하거나 등록
+              신청 조건에 만족하지 않아 신청할 수 없습니다.
             </Typography>
           </WarningInfo>
         )}

--- a/packages/web/src/features/register-club/hooks/useGetAvailableRegistrationInfo.ts
+++ b/packages/web/src/features/register-club/hooks/useGetAvailableRegistrationInfo.ts
@@ -1,0 +1,19 @@
+import useGetRegistrationAvailableClubs from "../services/useGetRegistrationAvailableClubs";
+
+const useGetAvailableRegistrationInfo = () => {
+  const { data, isLoading, isError } = useGetRegistrationAvailableClubs();
+
+  return {
+    data: {
+      ...data,
+      noManageClub: data?.club == null,
+      haveAvailableRegistration:
+        data?.club && data.club.availableRegistrationTypeEnums.length > 0,
+      availableRegistrations: data?.club?.availableRegistrationTypeEnums ?? [],
+    },
+    isLoading,
+    isError,
+  };
+};
+
+export default useGetAvailableRegistrationInfo;

--- a/packages/web/src/features/register-club/services/useGetRegistrationAvailableClubs.ts
+++ b/packages/web/src/features/register-club/services/useGetRegistrationAvailableClubs.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import apiReg025, {
+  ApiReg025ResponseOk,
+} from "@sparcs-clubs/interface/api/registration/endpoint/apiReg025";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useGetRegistrationAvailableClubs = () =>
+  useQuery<ApiReg025ResponseOk, Error>({
+    queryKey: [apiReg025.url()],
+    queryFn: async (): Promise<ApiReg025ResponseOk> => {
+      const { data } = await axiosClientWithAuth.get(apiReg025.url(), {});
+
+      return data;
+    },
+  });
+
+export default useGetRegistrationAvailableClubs;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiReg025.url()).reply(() => [200, {}]);
+});


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

참고 스레드: https://sparcs.slack.com/archives/C06RTP91S3H/p1740129063238229
- 동아리 등록 페이지에서 타입별로 신청 가능한지 여부 판단하고 버튼 활성화 여부 결정하는 로직 수정
- 등록 페이지에서 버튼 클릭 후 신청 form 진입이 아니라, url로 진입 시에도 리라우팅 페이지 뜨게 추가함
- 동아리 신청 내역 상세조회에서 내가 신청한 것이 아니라도 대표자/대의원이면 url로 접근시 접근 가능. 
  - 이 경우 수정, 삭제 버튼 안 보이게 막음


## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 등록 페이지: http://localhost:3000/register-club
![image](https://github.com/user-attachments/assets/ebf501e4-51ca-4c2b-a27c-fc37cdd22f07)

2. 상세조회에서 내가 신청한거 아니면 수정삭제 버튼 막음: http://localhost:3000/my/register-club/190
![image](https://github.com/user-attachments/assets/f81166db-d381-45a8-af37-62c25a46510d)
