### PR TITLE
[TU-70] Club Summary Fetch logic Fix

### DIFF
--- a/packages/api/src/feature/club/repository/club.repository.ts
+++ b/packages/api/src/feature/club/repository/club.repository.ts
@@ -1,5 +1,16 @@
 import { Inject, Injectable, NotFoundException } from "@nestjs/common";
-import { and, eq, gt, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import { union } from "drizzle-orm/mysql-core";
 import { MySql2Database } from "drizzle-orm/mysql2";
 import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
@@ -459,21 +470,13 @@ export default class ClubRepository {
   }
 
   async fetchSummary(clubId: number): Promise<VClubSummary> {
-    const cur = getKSTDate();
     const result = await this.db
       .select()
       .from(Club)
-      .leftJoin(
-        ClubT,
-        and(
-          eq(Club.id, ClubT.clubId),
-          and(
-            lte(ClubT.startTerm, cur),
-            or(gte(ClubT.endTerm, cur), isNull(ClubT.endTerm)),
-          ),
-        ),
-      )
-      .where(eq(Club.id, clubId));
+      .innerJoin(ClubT, eq(Club.id, ClubT.clubId))
+      .where(eq(Club.id, clubId))
+      .orderBy(desc(ClubT.startTerm))
+      .limit(1);
 
     if (result.length !== 1) {
       throw new NotFoundException("Club not found");


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

https://www.notion.so/club-fetch-summary-1a2c25603b0b8083a505f009b8856407?pvs=4

It closes #issue_number

- 작업요약1
- 작업요약2

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
