### PR TITLE
[TU-72] 집행부원 상세페이지에 comment toast 추가

### DIFF
--- a/packages/web/src/common/components/MyMenu/_atomic/ProfileList.tsx
+++ b/packages/web/src/common/components/MyMenu/_atomic/ProfileList.tsx
@@ -42,7 +42,6 @@ const ProfileList: React.FC<ProfileListProps> = ({
     setSelectedToken(profile.token);
     setLocalStorageItem("accessToken", profile.token);
     setIsMenuOpen(false);
-    window.location.href = "/";
   };
 
   return (

--- a/packages/web/src/features/activity-report/components/ActivityReportStatusSection.tsx
+++ b/packages/web/src/features/activity-report/components/ActivityReportStatusSection.tsx
@@ -4,9 +4,9 @@ import { ActivityStatusEnum } from "@sparcs-clubs/interface/common/enum/activity
 
 import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
 import CommentToast from "@sparcs-clubs/web/common/components/Toast/CommentToast";
+import { Comment } from "@sparcs-clubs/web/types/comment";
 
 import { getActivityReportProgress } from "../constants/activityReportProgress";
-import { Comment } from "../types/activityReport";
 
 interface ActivityReportStatusSectionProps {
   status: ActivityStatusEnum;

--- a/packages/web/src/features/activity-report/components/ExecutiveActivityReportApprovalSection.tsx
+++ b/packages/web/src/features/activity-report/components/ExecutiveActivityReportApprovalSection.tsx
@@ -9,11 +9,11 @@ import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { Comment } from "@sparcs-clubs/web/types/comment";
 import { formatSlashDateTime } from "@sparcs-clubs/web/utils/Date/formatDate";
 
 import useExecutiveApproveActivityReport from "../hooks/useExecutiveApproveActivityReport";
 import useExecutiveRejectActivityReport from "../hooks/useExecutiveRejectActivityReport";
-import { Comment } from "../types/activityReport";
 
 const ExecutiveActivityReportApprovalSection: React.FC<{
   comments: Comment[];

--- a/packages/web/src/features/activity-report/hooks/useGetActivityReportComments.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetActivityReportComments.ts
@@ -1,9 +1,9 @@
 import { UserTypeEnum } from "@sparcs-clubs/interface/common/enum/user.enum";
 
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
+import { Comment } from "@sparcs-clubs/web/types/comment";
 
 import { useGetActivityReport } from "../services/useGetActivityReport";
-import { Comment } from "../types/activityReport";
 
 const useGetActivityReportComments = (
   activityId: number,

--- a/packages/web/src/features/activity-report/types/activityReport.ts
+++ b/packages/web/src/features/activity-report/types/activityReport.ts
@@ -5,16 +5,12 @@ import {
 } from "@sparcs-clubs/interface/common/enum/activity.enum";
 
 import { FileDetail } from "@sparcs-clubs/web/common/components/File/attachment";
+import { Comment } from "@sparcs-clubs/web/types/comment";
 import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 
 type Duration = {
   startTerm: Date;
   endTerm: Date;
-};
-
-export type Comment = {
-  content: string;
-  createdAt: Date;
 };
 
 export interface BaseActivityReport {

--- a/packages/web/src/features/activity-report/utils/filterComment.ts
+++ b/packages/web/src/features/activity-report/utils/filterComment.ts
@@ -1,4 +1,4 @@
-import { Comment } from "../types/activityReport";
+import { Comment } from "@sparcs-clubs/web/types/comment";
 
 const filterActivityComments = (comments: Comment[]): Comment[] =>
   comments.filter(comment => comment.content !== "활동이 승인되었습니다");

--- a/packages/web/src/features/executive/register-club/components/RegisterClubStatusSection.tsx
+++ b/packages/web/src/features/executive/register-club/components/RegisterClubStatusSection.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from "react";
+
+import { RegistrationStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+
+import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
+import CommentToast from "@sparcs-clubs/web/common/components/Toast/CommentToast";
+import { getRegisterClubProgress } from "@sparcs-clubs/web/features/register-club/constants/registerClubProgress";
+import { Comment } from "@sparcs-clubs/web/types/comment";
+
+interface RegisterClubStatusSectionProps {
+  status: RegistrationStatusEnum;
+  editedAt: Date;
+  comments: Comment[];
+}
+
+const RegisterClubStatusSection: React.FC<RegisterClubStatusSectionProps> = ({
+  status,
+  editedAt,
+  comments,
+}) => {
+  const progressStatus = getRegisterClubProgress(status, editedAt);
+
+  const ToastSection = useMemo(() => {
+    if (status === RegistrationStatusEnum.Rejected) {
+      return (
+        <CommentToast
+          title="코멘트"
+          reasons={comments.map(comment => ({
+            datetime: comment.createdAt,
+            reason: comment.content,
+          }))}
+          color="red"
+        />
+      );
+    }
+
+    return (
+      <CommentToast
+        title="코멘트"
+        reasons={comments.map(comment => ({
+          datetime: comment.createdAt,
+          reason: comment.content,
+        }))}
+        color="green"
+      />
+    );
+  }, [comments, status]);
+
+  return (
+    <ProgressStatus
+      labels={progressStatus.labels}
+      progress={progressStatus.progress}
+      optional={comments && comments.length > 0 && ToastSection}
+    />
+  );
+};
+
+export default RegisterClubStatusSection;

--- a/packages/web/src/features/executive/register-club/frames/ClubRegisterApproveFrame.tsx
+++ b/packages/web/src/features/executive/register-club/frames/ClubRegisterApproveFrame.tsx
@@ -1,5 +1,8 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
+import apiReg014 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg014";
+import apiReg015 from "@sparcs-clubs/interface/api/registration/endpoint/apiReg015";
 import { RegistrationStatusEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
@@ -15,9 +18,18 @@ import { patchClubRegistrationExecutive } from "../services/patchClubRegistratio
 import { postClubRegistrationSendBack } from "../services/postClubRegistrationSendBack";
 
 const ClubRegisterApproveFrame = ({ applyId }: { applyId: number }) => {
+  const queryClient = useQueryClient();
+
+  const invalidateClubRegisterStatus = () => {
+    queryClient.invalidateQueries({ queryKey: [apiReg014.url()] });
+    queryClient.invalidateQueries({
+      queryKey: [apiReg015.url(applyId.toString())],
+    });
+  };
+
   const [rejectionDetail, setRejectionDetail] = useState("");
 
-  const { data, isLoading, isError, refetch } = useRegisterClubDetail({
+  const { data, isLoading, isError } = useRegisterClubDetail({
     applyId,
   });
 
@@ -65,9 +77,9 @@ const ClubRegisterApproveFrame = ({ applyId }: { applyId: number }) => {
                 ? "default"
                 : "disabled"
             }
-            onClick={() => {
-              patchClubRegistrationExecutive({ applyId });
-              refetch();
+            onClick={async () => {
+              await patchClubRegistrationExecutive({ applyId });
+              invalidateClubRegisterStatus();
             }}
           >
             신청 승인
@@ -79,7 +91,7 @@ const ClubRegisterApproveFrame = ({ applyId }: { applyId: number }) => {
                 { applyId },
                 { comment: rejectionDetail },
               );
-              refetch();
+              invalidateClubRegisterStatus();
               setRejectionDetail("");
             }}
           >

--- a/packages/web/src/features/executive/register-club/frames/ClubRegisterDetailFrame.tsx
+++ b/packages/web/src/features/executive/register-club/frames/ClubRegisterDetailFrame.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 
-import {
-  RegistrationStatusEnum,
-  RegistrationTypeEnum,
-} from "@sparcs-clubs/interface/common/enum/registration.enum";
+import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
 import { UserTypeEnum } from "@sparcs-clubs/interface/common/enum/user.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
@@ -14,9 +11,7 @@ import {
   IndentedItem,
   ListItem,
 } from "@sparcs-clubs/web/common/components/ListItem";
-import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import CommentToast from "@sparcs-clubs/web/common/components/Toast/CommentToast";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import useGetDivisionType from "@sparcs-clubs/web/common/hooks/useGetDivisionType";
 import {
@@ -25,7 +20,6 @@ import {
 } from "@sparcs-clubs/web/constants/tableTagList";
 import MyRegisterClubActFrame from "@sparcs-clubs/web/features/my/register-club/frames/MyRegisterClubActFrame";
 import { FilePreviewContainer } from "@sparcs-clubs/web/features/my/register-club/frames/MyRegisterClubDetailFrame";
-import { getRegisterClubProgress } from "@sparcs-clubs/web/features/register-club/constants/registerClubProgress";
 import { isProvisional } from "@sparcs-clubs/web/features/register-club/utils/registrationType";
 import {
   getActualMonth,
@@ -34,6 +28,7 @@ import {
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 import { professorEnumToText } from "@sparcs-clubs/web/utils/getUserType";
 
+import RegisterClubStatusSection from "../components/RegisterClubStatusSection";
 import useRegisterClubDetail from "../services/getRegisterClubDetail";
 
 export interface ClubRegisterDetail {
@@ -60,38 +55,10 @@ const ClubRegisterDetailFrame: React.FC<ClubRegisterDetail> = ({
     >
       <Card padding="32px" gap={20} outline>
         {data && (
-          <ProgressStatus
-            labels={
-              getRegisterClubProgress(
-                data?.registrationStatusEnumId,
-                data?.updatedAt,
-              ).labels
-            }
-            progress={
-              getRegisterClubProgress(
-                data?.registrationStatusEnumId,
-                data?.updatedAt,
-              ).progress
-            }
-            optional={
-              data.comments &&
-              data.comments.length > 0 && (
-                <CommentToast
-                  title="코멘트"
-                  reasons={data.comments.map(comment => ({
-                    datetime: comment.createdAt,
-                    reason: comment.content,
-                    status: "반려 사유",
-                  }))}
-                  color={
-                    data.registrationStatusEnumId ===
-                    RegistrationStatusEnum.Approved
-                      ? "green"
-                      : "red"
-                  }
-                />
-              )
-            }
+          <RegisterClubStatusSection
+            status={data.registrationStatusEnumId}
+            editedAt={data.updatedAt}
+            comments={data.comments}
           />
         )}
         <FlexWrapper gap={20} direction="row">

--- a/packages/web/src/features/executive/register-club/frames/ClubRegisterDetailFrame.tsx
+++ b/packages/web/src/features/executive/register-club/frames/ClubRegisterDetailFrame.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-import { RegistrationTypeEnum } from "@sparcs-clubs/interface/common/enum/registration.enum";
+import {
+  RegistrationStatusEnum,
+  RegistrationTypeEnum,
+} from "@sparcs-clubs/interface/common/enum/registration.enum";
 import { UserTypeEnum } from "@sparcs-clubs/interface/common/enum/user.enum";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
@@ -11,8 +14,9 @@ import {
   IndentedItem,
   ListItem,
 } from "@sparcs-clubs/web/common/components/ListItem";
-import ProgressCheckSection from "@sparcs-clubs/web/common/components/ProgressCheckSection";
+import ProgressStatus from "@sparcs-clubs/web/common/components/ProgressStatus";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
+import CommentToast from "@sparcs-clubs/web/common/components/Toast/CommentToast";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import useGetDivisionType from "@sparcs-clubs/web/common/hooks/useGetDivisionType";
 import {
@@ -55,27 +59,41 @@ const ClubRegisterDetailFrame: React.FC<ClubRegisterDetail> = ({
       isError={isError || divisionError}
     >
       <Card padding="32px" gap={20} outline>
-        <FlexWrapper gap={16} direction="column">
-          <Typography fw="MEDIUM" lh={20} fs={16}>
-            신청 상태
-          </Typography>
-          {data && (
-            <ProgressCheckSection
-              labels={
-                getRegisterClubProgress(
-                  data?.registrationStatusEnumId,
-                  data?.updatedAt,
-                ).labels
-              }
-              progress={
-                getRegisterClubProgress(
-                  data?.registrationStatusEnumId,
-                  data?.updatedAt,
-                ).progress
-              }
-            />
-          )}
-        </FlexWrapper>
+        {data && (
+          <ProgressStatus
+            labels={
+              getRegisterClubProgress(
+                data?.registrationStatusEnumId,
+                data?.updatedAt,
+              ).labels
+            }
+            progress={
+              getRegisterClubProgress(
+                data?.registrationStatusEnumId,
+                data?.updatedAt,
+              ).progress
+            }
+            optional={
+              data.comments &&
+              data.comments.length > 0 && (
+                <CommentToast
+                  title="코멘트"
+                  reasons={data.comments.map(comment => ({
+                    datetime: comment.createdAt,
+                    reason: comment.content,
+                    status: "반려 사유",
+                  }))}
+                  color={
+                    data.registrationStatusEnumId ===
+                    RegistrationStatusEnum.Approved
+                      ? "green"
+                      : "red"
+                  }
+                />
+              )
+            }
+          />
+        )}
         <FlexWrapper gap={20} direction="row">
           <Typography fw="MEDIUM" lh={20} fs={16} style={{ flex: 1 }}>
             등록 구분
@@ -162,7 +180,7 @@ const ClubRegisterDetailFrame: React.FC<ClubRegisterDetail> = ({
                     <ThumbnailPreviewList
                       fileList={[
                         {
-                          id: "1",
+                          id: data?.activityPlanFile?.id,
                           name: data?.activityPlanFile?.name,
                           url: data?.activityPlanFile?.url,
                         },
@@ -182,7 +200,7 @@ const ClubRegisterDetailFrame: React.FC<ClubRegisterDetail> = ({
                   <ThumbnailPreviewList
                     fileList={[
                       {
-                        id: "1",
+                        id: data?.clubRuleFile?.id,
                         name: data?.clubRuleFile?.name,
                         url: data?.clubRuleFile?.url,
                       },
@@ -201,7 +219,7 @@ const ClubRegisterDetailFrame: React.FC<ClubRegisterDetail> = ({
                   <ThumbnailPreviewList
                     fileList={[
                       {
-                        id: "1",
+                        id: data?.externalInstructionFile?.id,
                         name: data?.externalInstructionFile?.name,
                         url: data?.externalInstructionFile?.url,
                       },

--- a/packages/web/src/types/comment.ts
+++ b/packages/web/src/types/comment.ts
@@ -1,0 +1,4 @@
+export type Comment = {
+  content: string;
+  createdAt: Date;
+};


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 집행부원 동아리 등록 상세페이지에 comment toast 추가 (RegisterClubStatusSection 구현)
- 집행부원 동아리 등록 승인/반려 시 invalidateQuery 수정
- 프로필 전환 시 리다이렉트 하는 로직 삭제

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- activity-report 하위에 있던 Comment 타입을 common으로 이동
- 승인/반려 시 progress status는 바로 바뀌고 코멘트 목록도 업데이트 되는데, 토스트 색이 바로 안 변하는 문제가 있음. 활보/집행부 쪽과 동일한 로직인데 어디에서 문제가 생기는지 모르겠음 (시간 지나면 색 바뀜)

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 동아리 등록 상세 페이지 관련 frame 리팩토링


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 등록 집행부 상세조회 페이지: http://localhost:3000/executive/register-club/167
2. 동아리 등록 집행부 목록 페이지 (승인/반려시 업데이트 확인): http://localhost:3000/executive/register-club
