### PR TITLE
[TU-76] update register-club professor initial data trigger logic

### DIFF
--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
@@ -175,6 +175,7 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
           </FlexWrapper>
           {isProvisionalClub ? (
             <ProvisionalBasicInformFrame
+              isInitialCheckedProfessor={initialData.professor != null}
               editMode
               profile={{
                 name: initialData.representative.name,

--- a/packages/web/src/features/register-club/components/RegisterClubForm.tsx
+++ b/packages/web/src/features/register-club/components/RegisterClubForm.tsx
@@ -183,6 +183,7 @@ const RegisterClubForm: React.FC<RegisterClubFormProps> = ({
           <AsyncBoundary isLoading={isLoadingProfile} isError={isErrorProfile}>
             {isProvisionalClub ? (
               <ProvisionalBasicInformFrame
+                isInitialCheckedProfessor={initialData?.professor != null}
                 profile={
                   profile
                     ? { name: profile.name, phoneNumber: profile.phoneNumber }

--- a/packages/web/src/features/register-club/components/basic-info/BasicInformFrame.tsx
+++ b/packages/web/src/features/register-club/components/basic-info/BasicInformFrame.tsx
@@ -41,6 +41,7 @@ const BasicInformFrame: React.FC<BasicInformSectionProps> = ({
 
   const { watch, control, setValue } = useFormContext<RegisterClubModel>();
   const clubId = watch("clubId");
+  const professor = watch("professor");
 
   const {
     data: promotionalList,
@@ -63,6 +64,7 @@ const BasicInformFrame: React.FC<BasicInformSectionProps> = ({
   }, [clubId, clubList]);
 
   useEffect(() => {
+    if (professor) return;
     if (professorInfo === undefined || !isCheckedProfessor) {
       setValue("professor", undefined, { shouldValidate: true });
       return;

--- a/packages/web/src/features/register-club/components/basic-info/ProfessorInformFrame.tsx
+++ b/packages/web/src/features/register-club/components/basic-info/ProfessorInformFrame.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import styled from "styled-components";
 
@@ -21,7 +21,17 @@ const RowWrapper = styled.div`
 `;
 
 const ProfessorInformFrame: React.FC = () => {
-  const { control } = useFormContext<RegisterClubModel>();
+  const {
+    control,
+    trigger,
+    formState: { isValid },
+  } = useFormContext<RegisterClubModel>();
+
+  useEffect(() => {
+    if (!isValid) {
+      trigger();
+    }
+  }, [isValid]);
 
   return (
     <FlexWrapper direction="column" gap={40}>

--- a/packages/web/src/features/register-club/components/basic-info/ProvisionalBasicInformFrame.tsx
+++ b/packages/web/src/features/register-club/components/basic-info/ProvisionalBasicInformFrame.tsx
@@ -27,13 +27,18 @@ import YearSelect from "./_atomic/YearSelect";
 import ProfessorInformFrame from "./ProfessorInformFrame";
 
 interface ProvisionalBasicInformFrameProps {
+  isInitialCheckedProfessor?: boolean;
   editMode?: boolean;
   profile?: { name: string; phoneNumber?: string };
 }
 
 const ProvisionalBasicInformFrame: React.FC<
   ProvisionalBasicInformFrameProps
-> = ({ editMode = false, profile = undefined }) => {
+> = ({
+  isInitialCheckedProfessor = false,
+  editMode = false,
+  profile = undefined,
+}) => {
   const { control, setValue, watch } = useFormContext();
 
   const registrationType = watch("registrationTypeEnumId");
@@ -45,7 +50,9 @@ const ProvisionalBasicInformFrame: React.FC<
     isError: isErrorAvailableRegistrationInfo,
   } = useGetAvailableRegistrationInfo();
 
-  const [isCheckedProfessor, setIsCheckedProfessor] = useState(false);
+  const [isCheckedProfessor, setIsCheckedProfessor] = useState(
+    isInitialCheckedProfessor,
+  );
 
   useEffect(() => {
     if (!isCheckedProfessor) {


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 동아리 등록 임시저장 가져올 때 트리거 한 번 날리는거 추가
- 지도교수 쪽 임시저장 시 데이터 리셋 되는 이슈 수정
- 가등록쪽 지도교수 데이터 있으면 checkbox true가 initial value가 되도록 수정

동연 제보 참고: https://www.notion.so/sparcs/1a3c25603b0b8042a3c6d5798779632f?pvs=4

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 등록 페이지: http://localhost:3000/register-club/renewal
