### PR TITLE
[TU-293] 지원금 신청 기간 조회/추가/삭제 기능

### DIFF
--- a/packages/api/src/feature/semester/controller/activity-duration.controller.ts
+++ b/packages/api/src/feature/semester/controller/activity-duration.controller.ts
@@ -34,6 +34,12 @@ import type {
   ApiSem013ResponseNotImplemented,
   ApiSem014RequestParam,
   ApiSem014ResponseNotImplemented,
+  ApiSem015RequestBody,
+  ApiSem015ResponseCreated,
+  ApiSem016RequestQuery,
+  ApiSem016ResponseOk,
+  ApiSem017RequestParam,
+  ApiSem017ResponseOk,
 } from "@clubs/interface/api/semester/index";
 import {
   apiSem006,
@@ -45,6 +51,9 @@ import {
   apiSem012,
   apiSem013,
   apiSem014,
+  apiSem015,
+  apiSem016,
+  apiSem017,
 } from "@clubs/interface/api/semester/index";
 
 import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
@@ -53,11 +62,13 @@ import { GetExecutive } from "@sparcs-clubs/api/common/util/decorators/param-dec
 import logger from "@sparcs-clubs/api/common/util/logger";
 
 import { ActivityDurationService } from "../service/activity-duration.service";
+import { FundingDeadlineService } from "../service/funding-deadline.service";
 
 @Controller()
 export class ActivityDurationController {
   constructor(
     private readonly activityDurationService: ActivityDurationService,
+    private readonly fundingDeadlineService: FundingDeadlineService,
   ) {}
 
   @Executive()
@@ -164,5 +175,47 @@ export class ActivityDurationController {
       `User executive_id: ${executive.id} trying to call unimplemented feature`,
     );
     throw new NotImplementedException();
+  }
+
+  @Executive()
+  @Post("/executive/semesters/funding-deadlines")
+  @UsePipes(new ZodPipe(apiSem015))
+  async createFundingDeadline(
+    @GetExecutive() executive: GetExecutive,
+    @Body() body: ApiSem015RequestBody,
+  ): Promise<ApiSem015ResponseCreated> {
+    return this.fundingDeadlineService.createFundingDeadline(
+      executive.id,
+      body,
+    );
+  }
+
+  @Executive()
+  @Get("/executive/semesters/funding-deadlines")
+  @UsePipes(new ZodPipe(apiSem016))
+  async getFundingDeadlines(
+    @GetExecutive() executive: GetExecutive,
+    @Query() query: ApiSem016RequestQuery,
+  ): Promise<ApiSem016ResponseOk> {
+    if (!query.activityDId) {
+      return this.fundingDeadlineService.getFundingDeadlines(executive.id);
+    }
+    return this.fundingDeadlineService.getFundingDeadlines(
+      executive.id,
+      query.activityDId,
+    );
+  }
+
+  @Executive()
+  @Delete("/executive/semesters/funding-deadlines/:fundingDeadlineId")
+  @UsePipes(new ZodPipe(apiSem017))
+  async deleteFundingDeadline(
+    @GetExecutive() executive: GetExecutive,
+    @Param() param: ApiSem017RequestParam,
+  ): Promise<ApiSem017ResponseOk> {
+    return this.fundingDeadlineService.deleteFundingDeadline(
+      executive.id,
+      param.fundingDeadlineId,
+    );
   }
 }

--- a/packages/api/src/feature/semester/repository/funding.sql.repository.ts
+++ b/packages/api/src/feature/semester/repository/funding.sql.repository.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { and, eq, gt, isNull, lt, or, sql } from "drizzle-orm";
+import { MySql2Database } from "drizzle-orm/mysql2";
+
+import { IntentionalRollback } from "@sparcs-clubs/api/common/util/exception.filter";
+import { getKSTDateForQuery } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import { FundingDeadlineD } from "@sparcs-clubs/api/drizzle/schema/semester.schema";
+
+@Injectable()
+export class FundingDeadlineSqlRepository {
+  constructor(@Inject(DrizzleAsyncProvider) private db: MySql2Database) {}
+
+  async checkExistingFundingDeadline(
+    semesterId: number,
+    startTermStr: string,
+    endTermStr: string,
+  ): Promise<boolean> {
+    const existingDeadlines = await this.db
+      .select()
+      .from(FundingDeadlineD)
+      .where(
+        and(
+          or(
+            and(
+              gt(sql`DATE(${FundingDeadlineD.endTerm})`, startTermStr),
+              lt(sql`DATE(${FundingDeadlineD.endTerm})`, endTermStr),
+            ),
+            and(
+              gt(sql`DATE(${FundingDeadlineD.startTerm})`, startTermStr),
+              lt(sql`DATE(${FundingDeadlineD.startTerm})`, endTermStr),
+            ),
+            eq(sql`DATE(${FundingDeadlineD.startTerm})`, startTermStr),
+            eq(sql`DATE(${FundingDeadlineD.endTerm})`, endTermStr),
+            and(
+              lt(sql`DATE(${FundingDeadlineD.startTerm})`, endTermStr),
+              gt(sql`DATE(${FundingDeadlineD.endTerm})`, endTermStr),
+            ),
+            and(
+              gt(sql`DATE(${FundingDeadlineD.startTerm})`, startTermStr),
+              lt(sql`DATE(${FundingDeadlineD.endTerm})`, startTermStr),
+            ),
+          ),
+          eq(FundingDeadlineD.semesterId, semesterId),
+          isNull(FundingDeadlineD.deletedAt),
+        ),
+      );
+
+    return existingDeadlines.length > 0;
+  }
+
+  async createFundingDeadline(
+    startTermStr: string,
+    endTermStr: string,
+    deadlineEnum: number,
+    semesterId: number,
+  ): Promise<boolean> {
+    try {
+      await this.db.transaction(async tx => {
+        const [result] = await tx.insert(FundingDeadlineD).values({
+          startTerm: sql`DATE(${startTermStr})`,
+          endTerm: sql`DATE(${endTermStr})`,
+          deadlineEnum,
+          semesterId,
+        });
+        if (result.affectedRows === 0) {
+          throw new IntentionalRollback();
+        }
+        return true;
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof IntentionalRollback) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async getFundingDeadlines(semesterId: number) {
+    const fundingDeadlines = await this.db
+      .select()
+      .from(FundingDeadlineD)
+      .where(
+        and(
+          eq(FundingDeadlineD.semesterId, semesterId),
+          isNull(FundingDeadlineD.deletedAt),
+        ),
+      );
+    return fundingDeadlines;
+  }
+
+  async deleteFundingDeadline(deadlineId: number): Promise<boolean> {
+    const cur = getKSTDateForQuery();
+    try {
+      await this.db.transaction(async tx => {
+        const [result] = await tx
+          .update(FundingDeadlineD)
+          .set({ deletedAt: cur })
+          .where(
+            and(
+              eq(FundingDeadlineD.id, deadlineId),
+              isNull(FundingDeadlineD.deletedAt),
+            ),
+          );
+        if (result.affectedRows === 0) {
+          throw new IntentionalRollback();
+        }
+        return true;
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof IntentionalRollback) {
+        return false;
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/api/src/feature/semester/semester.module.ts
+++ b/packages/api/src/feature/semester/semester.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 
 import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
+import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 import { ActivityDurationController } from "./controller/activity-duration.controller";
 import { SemesterController } from "./controller/semester.controller";
@@ -12,14 +13,16 @@ import { SemesterPublicService } from "./publicService/semester.public.service";
 import { ActivityDeadlineRepository } from "./repository/activity.deadline.repository";
 import { ActivityDurationRepository } from "./repository/activity.duration.repository";
 import { FundingDeadlineRepository } from "./repository/funding.deadline.repository";
+import { FundingDeadlineSqlRepository } from "./repository/funding.sql.repository";
 import { RegistrationDeadlineRepository } from "./repository/registration.deadline.repository";
 import { SemesterRepository } from "./repository/semester.repository";
 import { SemesterSQLRepository } from "./repository/semester.sql.repository";
 import { ActivityDurationService } from "./service/activity-duration.service";
+import { FundingDeadlineService } from "./service/funding-deadline.service";
 import { SemesterService } from "./service/semester.service";
 
 @Module({
-  imports: [DrizzleModule],
+  imports: [DrizzleModule, UserModule],
   controllers: [SemesterController, ActivityDurationController],
   providers: [
     SemesterService,
@@ -34,6 +37,8 @@ import { SemesterService } from "./service/semester.service";
     ActivityDurationRepository,
     ActivityDeadlineRepository,
     FundingDeadlineRepository,
+    FundingDeadlineSqlRepository,
+    FundingDeadlineService,
     RegistrationDeadlineRepository,
   ],
   exports: [

--- a/packages/api/src/feature/semester/service/funding-deadline.service.ts
+++ b/packages/api/src/feature/semester/service/funding-deadline.service.ts
@@ -1,0 +1,150 @@
+import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { formatInTimeZone } from "date-fns-tz";
+
+import {
+  ApiSem015RequestBody,
+  ApiSem015ResponseCreated,
+  ApiSem016ResponseOk,
+  ApiSem017ResponseOk,
+} from "@clubs/interface/api/semester/index";
+
+import { takeOnlyOne } from "@sparcs-clubs/api/common/util/util";
+
+import UserPublicService from "../../user/service/user.public.service";
+import { MActivityDuration } from "../model/activity.duration.model";
+import { ActivityDurationRepository } from "../repository/activity.duration.repository";
+import { FundingDeadlineSqlRepository } from "../repository/funding.sql.repository";
+import { SemesterRepository } from "../repository/semester.repository";
+
+@Injectable()
+export class FundingDeadlineService {
+  constructor(
+    private readonly activityDurationRepository: ActivityDurationRepository,
+    private readonly fundingDeadlineSqlRepository: FundingDeadlineSqlRepository,
+    private readonly semesterRepository: SemesterRepository,
+    private readonly userpulicservice: UserPublicService,
+  ) {}
+
+  async createFundingDeadline(
+    executiveId: number,
+    body: ApiSem015RequestBody,
+  ): Promise<ApiSem015ResponseCreated> {
+    const { activityDId, deadlineEnum, startTerm, endTerm } = body;
+
+    await this.userpulicservice.checkCurrentExecutiveById(executiveId);
+
+    const startTermStr = formatInTimeZone(
+      startTerm,
+      "Asia/Seoul",
+      "yyyy-MM-dd",
+    );
+    const endTermStr = formatInTimeZone(endTerm, "Asia/Seoul", "yyyy-MM-dd");
+    const activityDuration = await this.activityDurationRepository
+      .find({ id: activityDId })
+      .then(takeOnlyOne(MActivityDuration));
+
+    if (!activityDuration) {
+      throw new HttpException(
+        `해당 활동 기간을 찾을 수 없습니다.`,
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    if (startTermStr >= endTermStr) {
+      throw new HttpException(
+        "시작날짜는 종료날짜보다 이전이어야 합니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (
+      await this.fundingDeadlineSqlRepository.checkExistingFundingDeadline(
+        activityDuration.semester.id,
+        startTermStr,
+        endTermStr,
+      )
+    ) {
+      throw new HttpException(
+        "중복되는 기한이 존재합니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (
+      !(await this.fundingDeadlineSqlRepository.createFundingDeadline(
+        startTermStr,
+        endTermStr,
+        deadlineEnum,
+        activityDuration.semester.id,
+      ))
+    ) {
+      throw new HttpException(
+        "Failed to create funding deadline",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return {};
+  }
+
+  async getFundingDeadlines(
+    executiveId: number,
+    activityDId?: number,
+  ): Promise<ApiSem016ResponseOk> {
+    await this.userpulicservice.checkCurrentExecutiveById(executiveId);
+
+    let activityDurations: MActivityDuration[];
+    if (activityDId) {
+      const found = await this.activityDurationRepository.find({
+        id: activityDId,
+      });
+      if (found.length === 0) {
+        throw new HttpException(
+          `해당 활동 기간을 찾을 수 없습니다.`,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+      activityDurations = found;
+    } else {
+      activityDurations = await this.activityDurationRepository.find({});
+    }
+    const deadlines = (
+      await Promise.all(
+        activityDurations.map(async duration => {
+          const fundingDeadlines =
+            await this.fundingDeadlineSqlRepository.getFundingDeadlines(
+              duration.semester.id,
+            );
+          return fundingDeadlines.map(deadline => ({
+            id: deadline.id,
+            startTerm: deadline.startTerm,
+            endTerm: deadline.endTerm,
+            deadlineEnum: deadline.deadlineEnum,
+            semesterId: duration.semester.id,
+            activityDId: duration.id,
+          }));
+        }),
+      )
+    ).flat();
+
+    return { deadlines };
+  }
+
+  async deleteFundingDeadline(
+    executiveId: number,
+    deadlineId: number,
+  ): Promise<ApiSem017ResponseOk> {
+    await this.userpulicservice.checkCurrentExecutiveById(executiveId);
+    if (
+      !(await this.fundingDeadlineSqlRepository.deleteFundingDeadline(
+        deadlineId,
+      ))
+    ) {
+      throw new HttpException(
+        "Failed to delete funding deadline",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    return {};
+  }
+}

--- a/packages/api/src/feature/user/service/user.public.service.ts
+++ b/packages/api/src/feature/user/service/user.public.service.ts
@@ -65,6 +65,12 @@ export default class UserPublicService {
     return executives[0];
   }
 
+  async checkCurrentExecutiveById(executiveId) {
+    if (!(await this.executiveRepository.findExecutiveByUserId(executiveId))) {
+      throw new HttpException("권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+  }
+
   /**
    * 현재 모든 집행부원을 가져옵니다.
    * 느려요~

--- a/packages/interface/src/api/semester/apiSem015.ts
+++ b/packages/interface/src/api/semester/apiSem015.ts
@@ -1,0 +1,95 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
+import { zFundingDeadline } from "@clubs/domain/semester/deadline";
+
+import { registry } from "@clubs/interface/open-api";
+
+/**
+ * @version v0.1
+ * @description 지원금 신청 기간을 추가합니다.
+ */
+
+const url = `/executive/semesters/funding-deadlines`;
+const method = "POST";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({
+  activityDId: zActivityDuration.shape.id,
+  deadlineEnum: zFundingDeadline.shape.deadlineEnum,
+  startTerm: zFundingDeadline.shape.startTerm,
+  endTerm: zFundingDeadline.shape.endTerm,
+});
+
+const responseBodyMap = {
+  [HttpStatusCode.Created]: z.object({}),
+};
+
+const responseErrorMap = {};
+
+export const apiSem015 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiSem015RequestParam = z.infer<typeof apiSem015.requestParam>;
+type ApiSem015RequestQuery = z.infer<typeof apiSem015.requestQuery>;
+type ApiSem015RequestBody = z.infer<typeof apiSem015.requestBody>;
+type ApiSem015ResponseCreated = z.infer<
+  (typeof apiSem015.responseBodyMap)[201]
+>;
+
+export type {
+  ApiSem015RequestParam,
+  ApiSem015RequestQuery,
+  ApiSem015RequestBody,
+  ApiSem015ResponseCreated,
+};
+
+registry.registerPath({
+  tags: ["semester"],
+  method: "post",
+  path: "/executive/semesters/funding-deadlines",
+  summary: "SEM-015: 지원금 신청 기간 추가하기",
+  description: `
+  지원금 신청 기간을 추가합니다.
+  1. 대상 활동 기간은 activityDId로 식별합니다.
+  2. 시작일과 종료일이 포함되어야 합니다.
+  3. 시작일은 종료일보다 이전이어야 합니다.
+  4. 동일 학기에 대해서 기간은 겹치지 않아야 합니다.
+  `,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: apiSem015.requestBody,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "지원금 신청 기간이 추가되었습니다.",
+      content: {
+        "application/json": {
+          schema: apiSem015.responseBodyMap[HttpStatusCode.Created],
+        },
+      },
+    },
+    400: {
+      description: "잘못된 요청입니다.",
+    },
+    404: {
+      description: "해당 활동 기간을 찾을 수 없습니다.",
+    },
+  },
+});

--- a/packages/interface/src/api/semester/apiSem016.ts
+++ b/packages/interface/src/api/semester/apiSem016.ts
@@ -1,0 +1,95 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
+import { zFundingDeadline } from "@clubs/domain/semester/deadline";
+import { zSemester } from "@clubs/domain/semester/semester";
+
+import { registry } from "@clubs/interface/open-api";
+
+/**
+ * @version v0.1
+ * @description 지원금 신청 기간 목록을 조회합니다.
+ */
+
+const url = `/executive/semesters/funding-deadlines`;
+const method = "GET";
+
+const requestParam = z.object({});
+
+const requestQuery = z.object({
+  activityDId: zActivityDuration.shape.id.optional(),
+});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({
+    deadlines: z.array(
+      z.object({
+        id: zFundingDeadline.shape.id,
+        semesterId: zSemester.shape.id,
+        activityDId: zActivityDuration.shape.id,
+        deadlineEnum: zFundingDeadline.shape.deadlineEnum,
+        startTerm: zFundingDeadline.shape.startTerm,
+        endTerm: zFundingDeadline.shape.endTerm,
+      }),
+    ),
+  }),
+};
+
+const responseErrorMap = {};
+
+export const apiSem016 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiSem016RequestParam = z.infer<typeof apiSem016.requestParam>;
+type ApiSem016RequestQuery = z.infer<typeof apiSem016.requestQuery>;
+type ApiSem016RequestBody = z.infer<typeof apiSem016.requestBody>;
+type ApiSem016ResponseOk = z.infer<(typeof apiSem016.responseBodyMap)[200]>;
+
+export type {
+  ApiSem016RequestParam,
+  ApiSem016RequestQuery,
+  ApiSem016RequestBody,
+  ApiSem016ResponseOk,
+};
+
+registry.registerPath({
+  tags: ["semester"],
+  method: "get",
+  path: "/executive/semesters/funding-deadlines",
+  summary: "SEM-016: 지원금 신청 기간 목록 조회하기",
+  description: `
+  지원금 신청 기간을 목록을 조회합니다.
+  1. 활동 기간 ID로 특정 지원금 신청 기간을 조회할 수 있습니다.
+  2. 페이지네이션 없이 전체를 반환합니다.
+  3. 각 항목은 연관된 학기(semesterId)와 활동 기간(activityDId) 정보를 포함합니다.
+  `,
+  request: {
+    query: apiSem016.requestQuery,
+  },
+  responses: {
+    200: {
+      description: "지원금 신청 기간이 조회되었습니다.",
+      content: {
+        "application/json": {
+          schema: apiSem016.responseBodyMap[HttpStatusCode.Ok],
+        },
+      },
+    },
+    400: {
+      description: "잘못된 요청입니다.",
+    },
+    404: {
+      description: "해당 활동 기간을 찾을 수 없습니다.",
+    },
+  },
+});

--- a/packages/interface/src/api/semester/apiSem017.ts
+++ b/packages/interface/src/api/semester/apiSem017.ts
@@ -1,0 +1,82 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+import { zFundingDeadline } from "@clubs/domain/semester/deadline";
+
+import { registry } from "@clubs/interface/open-api";
+
+/**
+ * @version v0.1
+ * @description 지원금 신청 기간을 삭제합니다.
+ */
+
+const url = (fundingDeadlineId: number) =>
+  `/executive/semesters/funding-deadlines/${fundingDeadlineId}`;
+const method = "DELETE";
+
+const requestParam = z.object({
+  fundingDeadlineId: zFundingDeadline.shape.id,
+});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({}),
+};
+
+const responseErrorMap = {};
+
+export const apiSem017 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiSem017RequestParam = z.infer<typeof apiSem017.requestParam>;
+type ApiSem017RequestQuery = z.infer<typeof apiSem017.requestQuery>;
+type ApiSem017RequestBody = z.infer<typeof apiSem017.requestBody>;
+type ApiSem017ResponseOk = z.infer<(typeof apiSem017.responseBodyMap)[200]>;
+
+export type {
+  ApiSem017RequestParam,
+  ApiSem017RequestQuery,
+  ApiSem017RequestBody,
+  ApiSem017ResponseOk,
+};
+
+registry.registerPath({
+  tags: ["semester"],
+  method: "delete",
+  path: "/executive/semesters/funding-deadlines/{fundingDeadlineId}",
+  summary: "SEM-017: 지원금 신청 기간 삭제하기",
+  description: `
+  지원금 신청 기간을 삭제합니다.
+  1. fundingDeadlineId를 request parameter로 받습니다.
+  2. 해당 기간이 존재하지 않으면 404 에러를 반환합니다.
+  `,
+  request: {
+    params: apiSem017.requestParam,
+  },
+  responses: {
+    200: {
+      description: "지원금 신청 기간이 삭제되었습니다.",
+      content: {
+        "application/json": {
+          schema: apiSem017.responseBodyMap[HttpStatusCode.Ok],
+        },
+      },
+    },
+    400: {
+      description: "잘못된 요청입니다.",
+    },
+    404: {
+      description: "해당 지원금 신청 기간을 찾을 수 없습니다.",
+    },
+  },
+});

--- a/packages/interface/src/api/semester/index.ts
+++ b/packages/interface/src/api/semester/index.ts
@@ -18,6 +18,9 @@ export * from "./apiSem011";
 export * from "./apiSem012";
 export * from "./apiSem013";
 export * from "./apiSem014";
+export * from "./apiSem015";
+export * from "./apiSem016";
+export * from "./apiSem017";
 
 registry.registerPath({
   tags: ["semester"],


### PR DESCRIPTION
1. 추가
- 기간의 중복은 막아두었음.
- 추가 검사 기준은 semesterId임. 즉, 학기가 다른 경우 기간이 중복되는 지원금 신청 존재 가능함.
- 또한 enum은 별도로 검사하지 않기 때문에 기간이 다르다면 동일 학기, 동일 enum을 갖는 지원금 신청 기간이 존재할 수 있음. 
2. 조회
- activityDId를 넘겨주지 않는 경우 모든 funding deadline 을 조회함.
- 이때 activityDId를 기준으로 semester를 찾고 해당 semester로 funding deadline을 검사하기 때문에 중복된 funding deadline 여러개를 넘겨줌. 단, 이 경우 activityDId는 다름.
3. 삭제
- funding deadlineId를 기준으로 삭제함.