### PR TITLE
[TU-368] 시간대 오류로 인한 중복 동아리 표시 버그

### DIFF
--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -202,8 +202,8 @@ export class AuthRepository {
         SELECT e.id, e.student_id AS studentId
         FROM executive e
         INNER JOIN executive_t et ON et.executive_id = e.id
-          AND et.start_term <= ${currentDate}
-          AND (et.end_term >= ${currentDate} OR et.end_term IS NULL)
+          AND et.start_term <= NOW()
+          AND (et.end_term >= NOW() OR et.end_term IS NULL)
           AND et.deleted_at IS NULL
         WHERE e.student_id = ${student.id}
           AND e.deleted_at IS NULL

--- a/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
+++ b/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
@@ -103,22 +103,31 @@ export class ClubDelegateDRepository {
     clubId: number,
     startTerm?: Date,
   ): Promise<{ name: string }> {
-    const currentDate = new Date();
-    const refDate = startTerm || currentDate;
+    const query = startTerm
+      ? Prisma.sql`
+          SELECT s.name
+          FROM club_delegate_d cd
+          LEFT JOIN student s ON s.id = cd.student_id
+          WHERE cd.club_id = ${clubId}
+            AND cd.club_delegate_enum_id = 1
+            AND cd.start_term <= ${startTerm}
+            AND (cd.end_term >= ${startTerm} OR cd.end_term IS NULL)
+          ORDER BY cd.end_term
+          LIMIT 1
+        `
+      : Prisma.sql`
+          SELECT s.name
+          FROM club_delegate_d cd
+          LEFT JOIN student s ON s.id = cd.student_id
+          WHERE cd.club_id = ${clubId}
+            AND cd.club_delegate_enum_id = 1
+            AND cd.start_term <= NOW()
+            AND (cd.end_term >= NOW() OR cd.end_term IS NULL)
+          ORDER BY cd.end_term
+          LIMIT 1
+        `;
 
-    const result = await this.prisma.$queryRaw<Array<{ name: string }>>(
-      Prisma.sql`
-        SELECT s.name
-        FROM club_delegate_d cd
-        LEFT JOIN student s ON s.id = cd.student_id
-        WHERE cd.club_id = ${clubId}
-          AND cd.club_delegate_enum_id = 1
-          AND cd.start_term <= ${refDate}
-          AND (cd.end_term >= ${refDate} OR cd.end_term IS NULL)
-        ORDER BY cd.end_term
-        LIMIT 1
-      `,
-    );
+    const result = await this.prisma.$queryRaw<Array<{ name: string }>>(query);
 
     return takeOne(result);
   }
@@ -206,9 +215,7 @@ export class ClubDelegateDRepository {
     semesterId: number;
     filterClubDelegateEnum: Array<ClubDelegateEnum>;
   }) {
-    const today = new Date();
     logger.debug(param.semesterId);
-    logger.debug(today);
 
     const filterEnums = param.filterClubDelegateEnum;
     const hasFilter = filterEnums.length !== 0;
@@ -243,8 +250,8 @@ export class ClubDelegateDRepository {
           ON u.id = s.user_id
         LEFT JOIN club_delegate_d cd
           ON cd.student_id = s.id
-          AND cd.start_term <= ${today}
-          AND (cd.end_term >= ${today} OR cd.end_term IS NULL)
+          AND cd.start_term <= NOW()
+          AND (cd.end_term >= NOW() OR cd.end_term IS NULL)
           AND cd.deleted_at IS NULL
         WHERE c.id = ${param.clubId}
           AND cst.semester_id = ${param.semesterId}

--- a/packages/api/src/feature/club/repository-old/club-old.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club-old.repository.ts
@@ -53,7 +53,6 @@ export class ClubOldRepository {
   }
 
   async findClubDetail(clubId: number) {
-    const crt = new Date();
     const clubInfoRows = await this.prisma.$queryRaw<
       Array<{
         id: number;
@@ -79,8 +78,8 @@ export class ClubOldRepository {
       LEFT JOIN professor p ON p.id = ct.professor_id
       WHERE c.id = ${clubId}
         AND (
-          (ct.end_term IS NULL AND ct.start_term <= ${crt})
-          OR ct.end_term >= ${crt}
+          (ct.end_term IS NULL AND ct.start_term <= NOW())
+          OR ct.end_term >= NOW()
         )
         AND (ct.club_status_enum_id = 1 OR ct.club_status_enum_id = 2)
       LIMIT 1
@@ -104,7 +103,6 @@ export class ClubOldRepository {
   }
 
   async getAllClubsGroupedByDivision(): Promise<ApiClb001ResponseOK> {
-    const crt = new Date();
     const clubs = await this.prisma.$queryRaw<
       Array<{
         divId: number;
@@ -137,23 +135,25 @@ export class ClubOldRepository {
       LEFT JOIN club c ON c.division_id = d.id
       INNER JOIN club_t ct ON c.id = ct.club_id
         AND (
-          (ct.end_term IS NULL AND ct.start_term <= ${crt})
-          OR ct.end_term >= ${crt}
+          (ct.end_term IS NULL AND ct.start_term <= NOW())
+          OR ct.end_term >= NOW()
         )
         AND (ct.club_status_enum_id = 1 OR ct.club_status_enum_id = 2)
         AND ct.deleted_at IS NULL
       LEFT JOIN professor p ON ct.professor_id = p.id
       LEFT JOIN club_student_t cst ON c.id = cst.club_id
-        AND cst.start_term <= ${crt}
-        AND (cst.end_term IS NULL OR cst.end_term >= ${crt})
+        AND cst.start_term <= NOW()
+        AND (cst.end_term IS NULL OR cst.end_term >= NOW())
         AND cst.deleted_at IS NULL
       LEFT JOIN club_delegate_d cdd ON c.id = cdd.club_id
         AND cdd.club_delegate_enum_id = 1
-        AND (cdd.end_term IS NULL OR cdd.end_term >= ${crt})
+        AND cdd.start_term <= NOW()
+        AND (cdd.end_term IS NULL OR cdd.end_term >= NOW())
+        AND cdd.deleted_at IS NULL
       LEFT JOIN student s ON cdd.student_id = s.id
       LEFT JOIN division_permanent_club_d dpcd ON dpcd.club_id = c.id
-        AND dpcd.start_term <= ${crt}
-        AND (dpcd.end_term >= ${crt} OR dpcd.end_term IS NULL)
+        AND dpcd.start_term <= NOW()
+        AND (dpcd.end_term >= NOW() OR dpcd.end_term IS NULL)
       GROUP BY d.id, d.name, c.id, c.name_kr, c.name_en,
                ct.club_status_enum_id, ct.characteristic_kr,
                s.name, p.name, dpcd.id
@@ -302,8 +302,6 @@ export class ClubOldRepository {
   ) {
     const result = await this.prisma.$transaction(
       async (tx: PrismaTransactionClient) => {
-        const cur = new Date();
-
         const club = await tx.$queryRaw<
           Array<{
             id: number;
@@ -329,21 +327,21 @@ export class ClubOldRepository {
             SELECT p.id, p.name, p.email
             FROM professor p
             INNER JOIN professor_t pt ON p.id = pt.professor_id
-              AND pt.start_term <= ${cur}
-              AND (pt.end_term > ${cur} OR pt.end_term IS NULL)
+              AND pt.start_term <= NOW()
+              AND (pt.end_term > NOW() OR pt.end_term IS NULL)
               AND pt.deleted_at IS NULL
             WHERE p.deleted_at IS NULL
           ) AS prof ON prof.id = ct.professor_id
           LEFT JOIN professor_t pt ON pt.professor_id = prof.id
-            AND pt.start_term <= ${cur}
-            AND (pt.end_term > ${cur} OR pt.end_term IS NULL)
+            AND pt.start_term <= NOW()
+            AND (pt.end_term > NOW() OR pt.end_term IS NULL)
             AND pt.deleted_at IS NULL
           WHERE c.id IN (
             SELECT cdd.club_id
             FROM club_delegate_d cdd
             WHERE cdd.student_id = ${studentId}
-              AND cdd.start_term <= ${cur}
-              AND (cdd.end_term >= ${cur} OR cdd.end_term IS NULL)
+              AND cdd.start_term <= NOW()
+              AND (cdd.end_term >= NOW() OR cdd.end_term IS NULL)
               AND cdd.deleted_at IS NULL
           )
           AND c.deleted_at IS NULL
@@ -375,8 +373,6 @@ export class ClubOldRepository {
 
     const result = await this.prisma.$transaction(
       async (tx: PrismaTransactionClient) => {
-        const cur = new Date();
-
         const response = await tx.$queryRaw<
           Array<{
             id: number;
@@ -406,8 +402,8 @@ export class ClubOldRepository {
                     SELECT cdd.club_id
                     FROM club_delegate_d cdd
                     WHERE cdd.student_id = ${studentId}
-                      AND cdd.start_term <= ${cur}
-                      AND (cdd.end_term >= ${cur} OR cdd.end_term IS NULL)
+                      AND cdd.start_term <= NOW()
+                      AND (cdd.end_term >= NOW() OR cdd.end_term IS NULL)
                       AND cdd.deleted_at IS NULL
                   )
                   AND ct2.deleted_at IS NULL
@@ -425,29 +421,29 @@ export class ClubOldRepository {
                     SELECT cdd.club_id
                     FROM club_delegate_d cdd
                     WHERE cdd.student_id = ${studentId}
-                      AND cdd.start_term <= ${cur}
-                      AND (cdd.end_term >= ${cur} OR cdd.end_term IS NULL)
+                      AND cdd.start_term <= NOW()
+                      AND (cdd.end_term >= NOW() OR cdd.end_term IS NULL)
                       AND cdd.deleted_at IS NULL
                   )
                   AND ct3.deleted_at IS NULL
                 GROUP BY c3.id
               ) AS sq
             )
-            AND ct.start_term <= ${cur}
+            AND ct.start_term <= NOW()
             AND ct.deleted_at IS NULL
-            AND (ct.end_term IS NULL OR ct.end_term > ${cur})
+            AND (ct.end_term IS NULL OR ct.end_term > NOW())
           LEFT JOIN (
             SELECT p.id, p.name, p.email
             FROM professor p
             INNER JOIN professor_t ppt ON p.id = ppt.professor_id
-              AND ppt.start_term <= ${cur}
-              AND (ppt.end_term > ${cur} OR ppt.end_term IS NULL)
+              AND ppt.start_term <= NOW()
+              AND (ppt.end_term > NOW() OR ppt.end_term IS NULL)
               AND ppt.deleted_at IS NULL
             WHERE p.deleted_at IS NULL
           ) AS prof ON prof.id = ct.professor_id
           LEFT JOIN professor_t pt ON pt.professor_id = prof.id
-            AND pt.start_term <= ${cur}
-            AND (pt.end_term > ${cur} OR pt.end_term IS NULL)
+            AND pt.start_term <= NOW()
+            AND (pt.end_term > NOW() OR pt.end_term IS NULL)
             AND pt.deleted_at IS NULL
           WHERE c.deleted_at IS NULL
         `);
@@ -568,9 +564,8 @@ export class ClubOldRepository {
         Prisma.sql`ct.semester_id IN (${Prisma.join(semesterIds)})`,
       );
     } else {
-      const cur = new Date();
       whereConditions.push(
-        Prisma.sql`ct.start_term <= ${cur} AND (ct.end_term >= ${cur} OR ct.end_term IS NULL)`,
+        Prisma.sql`ct.start_term <= NOW() AND (ct.end_term >= NOW() OR ct.end_term IS NULL)`,
       );
     }
     whereConditions.push(Prisma.sql`c.deleted_at IS NULL`);

--- a/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
@@ -11,8 +11,6 @@ export class ClubRoomTRepository {
   async findClubLocationById(
     clubId: number,
   ): Promise<{ room: string; buildingName: string }> {
-    const currentDate = new Date();
-
     const roomDetails = await this.prisma.$queryRaw<
       Array<{ room: string | null; buildingName: string | null }>
     >(Prisma.sql`
@@ -20,8 +18,8 @@ export class ClubRoomTRepository {
       FROM club_room_t crt
       LEFT JOIN club_building_enum cbe ON crt.club_building_enum = cbe.id
       WHERE crt.club_id = ${clubId}
-        AND crt.start_term <= ${currentDate}
-        AND (crt.end_term >= ${currentDate} OR crt.end_term IS NULL)
+        AND crt.start_term <= NOW()
+        AND (crt.end_term >= NOW() OR crt.end_term IS NULL)
       ORDER BY crt.created_at DESC
       LIMIT 1
     `);

--- a/packages/api/src/feature/club/repository-old/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-student-t.repository.ts
@@ -105,7 +105,6 @@ export default class ClubStudentTRepository {
   }
 
   async getClubsByStudentId(studentId: number) {
-    const today = new Date();
     const clubs = await this.prisma.$queryRaw<
       Array<{
         id: number;
@@ -117,8 +116,8 @@ export default class ClubStudentTRepository {
       FROM club_student_t cst
       LEFT JOIN club c ON c.id = cst.club_id
       WHERE cst.student_id = ${studentId}
-        AND cst.start_term <= ${today}
-        AND (cst.end_term >= ${today} OR cst.end_term IS NULL)
+        AND cst.start_term <= NOW()
+        AND (cst.end_term >= NOW() OR cst.end_term IS NULL)
     `);
     return clubs;
   }

--- a/packages/api/src/feature/club/repository-old/club.get-student-club-brief.ts
+++ b/packages/api/src/feature/club/repository-old/club.get-student-club-brief.ts
@@ -11,7 +11,6 @@ export class ClubGetStudentClubBrief {
   constructor(private readonly prisma: PrismaService) {}
 
   async getStudentClubBrief(clubId: number): Promise<ApiClb004ResponseOK> {
-    const crt = new Date();
     const result = await this.prisma.$queryRaw<
       Array<{ description: string | null; roomPassword: string | null }>
     >(Prisma.sql`
@@ -20,13 +19,13 @@ export class ClubGetStudentClubBrief {
       LEFT JOIN club c ON ct.club_id = c.id AND c.deleted_at IS NULL
       LEFT JOIN club_room_t crt ON ct.club_id = crt.club_id
         AND (
-          (crt.end_term IS NULL AND crt.start_term <= ${crt})
-          OR (crt.end_term >= ${crt} AND crt.start_term <= ${crt})
+          (crt.end_term IS NULL AND crt.start_term <= NOW())
+          OR (crt.end_term >= NOW() AND crt.start_term <= NOW())
         )
       WHERE ct.club_id = ${clubId}
         AND (
-          (ct.end_term IS NULL AND ct.start_term <= ${crt})
-          OR (ct.end_term >= ${crt} AND ct.start_term <= ${crt})
+          (ct.end_term IS NULL AND ct.start_term <= NOW())
+          OR (ct.end_term >= NOW() AND ct.start_term <= NOW())
         )
       LIMIT 1
     `);

--- a/packages/api/src/feature/club/repository-old/club.put-student-club-brief.ts
+++ b/packages/api/src/feature/club/repository-old/club.put-student-club-brief.ts
@@ -12,7 +12,6 @@ export class ClubPutStudentClubBrief {
     description: string,
     roomPassword: string,
   ): Promise<boolean> {
-    const crt = new Date();
     await this.prisma.$transaction(async tx => {
       // This is a complex multi-table UPDATE with JOINs - preserve as raw SQL
       const result = await tx.$executeRaw(Prisma.sql`
@@ -21,14 +20,14 @@ export class ClubPutStudentClubBrief {
         LEFT JOIN club_room_t crt ON
           (ct.club_id = crt.club_id AND
             (
-              (crt.end_term IS NULL AND crt.start_term <= ${crt})
-              OR (crt.end_term >= ${crt})
+              (crt.end_term IS NULL AND crt.start_term <= NOW())
+              OR (crt.end_term >= NOW())
             )
           )
         SET c.description = ${description}, crt.room_password = ${roomPassword}
         WHERE (ct.club_id = ${clubId}
-        AND ((ct.end_term IS NULL AND ct.start_term <= ${crt})
-        OR (ct.end_term >= ${crt})))
+        AND ((ct.end_term IS NULL AND ct.start_term <= NOW())
+        OR (ct.end_term >= NOW())))
       `);
       if (result !== 1) {
         throw new Error("putStudentClubBrief failed");

--- a/packages/api/src/feature/division/repository/old.division.repository.ts
+++ b/packages/api/src/feature/division/repository/old.division.repository.ts
@@ -20,8 +20,6 @@ export default class OldDivisionRepository {
   }
 
   async selectDivisionsAndDivisionPresidents() {
-    const today = new Date();
-
     const rows = await this.prisma.$queryRaw<
       Array<{
         divisionId: number;
@@ -35,8 +33,8 @@ export default class OldDivisionRepository {
         ON d.deleted_at IS NULL
         AND dp.deleted_at IS NULL
         AND d.id = dp.division_id
-        AND dp.start_term <= ${today}
-        AND dp.end_term >= ${today}
+        AND dp.start_term <= NOW()
+        AND dp.end_term >= NOW()
     `);
     return rows.map(row => ({
       division: { id: row.divisionId, name: row.divisionName },

--- a/packages/api/src/feature/registration/repository/club-registration.repository.ts
+++ b/packages/api/src/feature/registration/repository/club-registration.repository.ts
@@ -88,8 +88,8 @@ export class ClubRegistrationRepository {
           FROM club_delegate_d cd
           WHERE cd.student_id = ${studentId}
             AND cd.club_id = ${body.clubId}
-            AND cd.start_term <= ${cur}
-            AND (cd.end_term >= ${cur} OR cd.end_term IS NULL)
+            AND cd.start_term <= NOW()
+            AND (cd.end_term >= NOW() OR cd.end_term IS NULL)
             AND cd.deleted_at IS NULL
           FOR SHARE
         `);

--- a/packages/api/src/feature/user/repository/executive.repository.ts
+++ b/packages/api/src/feature/user/repository/executive.repository.ts
@@ -13,28 +13,26 @@ export default class ExecutiveRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findExecutiveById(id: number): Promise<boolean> {
-    const now = new Date();
     const result = await this.prisma.$queryRaw<Array<{ id: number }>>(
       Prisma.sql`
         SELECT et.id
         FROM executive_t et
         WHERE et.executive_id = ${id}
-          AND (DATE(et.end_term) >= DATE(${now}) OR et.end_term IS NULL)
-          AND DATE(et.start_term) <= DATE(${now})
+          AND (DATE(et.end_term) >= DATE(NOW()) OR et.end_term IS NULL)
+          AND DATE(et.start_term) <= DATE(NOW())
       `,
     );
     return result.length > 0;
   }
 
   async findExecutiveByUserId(id: number): Promise<boolean> {
-    const now = new Date();
     const result = await this.prisma.$queryRaw<Array<{ id: number }>>(
       Prisma.sql`
         SELECT e.id
         FROM executive e
         INNER JOIN executive_t et ON et.executive_id = e.id
-          AND (DATE(et.end_term) >= DATE(${now}) OR et.end_term IS NULL)
-          AND DATE(et.start_term) <= DATE(${now})
+          AND (DATE(et.end_term) >= DATE(NOW()) OR et.end_term IS NULL)
+          AND DATE(et.start_term) <= DATE(NOW())
         WHERE e.user_id = ${id}
           AND e.deleted_at IS NULL
       `,
@@ -56,7 +54,6 @@ export default class ExecutiveRepository {
   }
 
   async getExecutivePhoneNumber(id: number) {
-    const crt = new Date();
     const result = await this.prisma.$queryRaw<
       Array<{ phoneNumber: string | null }>
     >(
@@ -65,8 +62,8 @@ export default class ExecutiveRepository {
         FROM executive e
         LEFT JOIN user u ON u.id = e.user_id
         LEFT JOIN executive_t et ON et.executive_id = e.id
-          AND (et.end_term >= ${crt} OR et.end_term IS NULL)
-          AND et.start_term <= ${crt}
+          AND (et.end_term >= NOW() OR et.end_term IS NULL)
+          AND et.start_term <= NOW()
           AND et.deleted_at IS NULL
         WHERE e.user_id = ${id}
         LIMIT 1
@@ -361,7 +358,6 @@ export default class ExecutiveRepository {
   }
 
   async getExecutives() {
-    const now = new Date();
     const result = await this.prisma.$queryRaw<
       Array<{
         id: number;
@@ -380,8 +376,8 @@ export default class ExecutiveRepository {
                et.start_term AS startTerm, et.end_term AS endTerm
         FROM executive e
         INNER JOIN executive_t et ON et.executive_id = e.id
-          AND (DATE(et.end_term) >= DATE(${now}) OR et.end_term IS NULL)
-          AND DATE(et.start_term) <= DATE(${now})
+          AND (DATE(et.end_term) >= DATE(NOW()) OR et.end_term IS NULL)
+          AND DATE(et.start_term) <= DATE(NOW())
           AND et.deleted_at IS NULL
         INNER JOIN user u ON u.id = e.user_id
           AND u.deleted_at IS NULL

--- a/packages/api/src/feature/user/repository/old.professor.repository.ts
+++ b/packages/api/src/feature/user/repository/old.professor.repository.ts
@@ -12,7 +12,6 @@ export default class OldProfessorRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async getProfessorPhoneNumber(id: number) {
-    const crt = new Date();
     const result = await this.prisma.$queryRaw<
       Array<{ phoneNumber: string | null }>
     >(Prisma.sql`
@@ -20,8 +19,8 @@ export default class OldProfessorRepository {
       FROM professor p
       LEFT JOIN user u ON u.id = p.user_id
       LEFT JOIN professor_t pt ON pt.professor_id = p.id
-        AND (pt.end_term >= ${crt} OR pt.end_term IS NULL)
-        AND pt.start_term <= ${crt}
+        AND (pt.end_term >= NOW() OR pt.end_term IS NULL)
+        AND pt.start_term <= NOW()
         AND pt.deleted_at IS NULL
       WHERE p.user_id = ${id} AND p.deleted_at IS NULL
       LIMIT 1

--- a/packages/api/src/feature/user/repository/old.student.repository.ts
+++ b/packages/api/src/feature/user/repository/old.student.repository.ts
@@ -95,7 +95,6 @@ export default class OldStudentRepository {
   }
 
   async getStudentPhoneNumber(id: number) {
-    const crt = new Date();
     const result = await this.prisma.$queryRaw<
       Array<{ phoneNumber: string | null }>
     >(Prisma.sql`
@@ -103,8 +102,8 @@ export default class OldStudentRepository {
       FROM student s
       LEFT JOIN user u ON u.id = s.user_id
       LEFT JOIN student_t st ON st.student_id = s.id
-        AND (st.end_term >= ${crt} OR st.end_term IS NULL)
-        AND st.start_term <= ${crt}
+        AND (st.end_term >= NOW() OR st.end_term IS NULL)
+        AND st.start_term <= NOW()
         AND st.deleted_at IS NULL
       WHERE s.user_id = ${id}
       LIMIT 1

--- a/packages/api/src/feature/user/repository/user.repository.ts
+++ b/packages/api/src/feature/user/repository/user.repository.ts
@@ -10,7 +10,6 @@ export default class UserRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findStudentById(studentId: number) {
-    const crt = new Date();
     const user = await this.prisma.$queryRaw<
       Array<{
         id: number;
@@ -26,8 +25,8 @@ export default class UserRepository {
       FROM student s
       LEFT JOIN user u ON u.id = s.user_id
       LEFT JOIN student_t st ON st.student_id = s.id
-        AND st.start_term <= ${crt}
-        AND (st.end_term >= ${crt} OR st.end_term IS NULL)
+        AND st.start_term <= NOW()
+        AND (st.end_term >= NOW() OR st.end_term IS NULL)
       LEFT JOIN department d ON d.id = st.department
       WHERE s.id = ${studentId}
     `);


### PR DESCRIPTION
…multiple repositories

# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 작업요약1
- 작업요약2

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated date and time filtering across authentication, club management, division, registration, and user account features to use database server timestamps instead of application-calculated date values for term and eligibility boundary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->