### PR TITLE
chore: add gb to 2026 spring credits with AI comment

### DIFF
--- a/packages/web/src/features/credits/credits.ts
+++ b/packages/web/src/features/credits/credits.ts
@@ -21,6 +21,18 @@ export interface SemesterCredit {
 
 const credits: SemesterCredit[] = [
   {
+    semester: "2026년 봄",
+    members: [
+      {
+        nickname: "gb",
+        name: "권혁원",
+        role: "BE",
+        roleType: RoleType.member,
+        comment: "AI와 함께하는 클럽스",
+      },
+    ],
+  },
+  {
     semester: "2025년 가을",
     members: [
       {


### PR DESCRIPTION
## Summary
- add a 2026 spring credits entry for gb
- set role to backend team member
- add comment: AI와 함께하는 클럽스

## Testing
- not run (static data change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new team member information to credits for the Spring 2026 semester.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->