### PR TITLE
[TU-408] add gb to 2026 spring credits

### DIFF
--- a/packages/web/src/features/credits/credits.ts
+++ b/packages/web/src/features/credits/credits.ts
@@ -21,6 +21,18 @@ export interface SemesterCredit {
 
 const credits: SemesterCredit[] = [
   {
+    semester: "2026년 봄",
+    members: [
+      {
+        nickname: "gb",
+        name: "권혁원",
+        role: "BE",
+        roleType: RoleType.member,
+        comment: "AI와 함께하는 클럽스",
+      },
+    ],
+  },
+  {
     semester: "2025년 가을",
     members: [
       {


### PR DESCRIPTION
## Summary
- add a new `2026년 봄` credits section
- add `gb / 권혁원` as a `BE` member entry
- set the hover comment to `AI와 함께하는 클럽스`

## Task Context
- Notion: https://www.notion.so/35bc25603b0b8173a0a7ce3e73a33a2b
- Task ID: TU-408

## Details
- `RoleType.member` is used because the credits model does not define a separate `MemberBE` type
- display role text is `BE`

## Verification
- `pnpm --filter domain build`
- `pnpm --filter interface build`
- `pnpm --filter web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team credits with a new contributor entry for Spring 2026.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1772)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->