### PR TITLE
[TU-409] fix activity duration date handling

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -271,7 +271,8 @@ export default class ActivityService {
         ],
       })
       .then(takeExist());
-    const activityDId = await this.activityDurationPublicService.loadId();
+    const activityD = await this.activityDurationPublicService.load();
+    const activityDId = activityD.id;
     const activities = await this.activityRepository.count({
       clubId: body.clubId,
       activityDId,
@@ -288,7 +289,19 @@ export default class ActivityService {
     const participants = await Promise.all(
       body.participants.map(async e => e.studentId),
     );
-    // TODO: ActivityDuration 과 입력된 Duration들이 유효한 지 확인하는 로직
+    body.duration.forEach(duration => {
+      if (
+        activityD.startTerm <= duration.startTerm &&
+        duration.endTerm <= activityD.endTerm
+      ) {
+        return;
+      }
+      throw new HttpException(
+        "Some duration is not in the last activity duration",
+        HttpStatus.BAD_REQUEST,
+      );
+    });
+
     // TODO: 해당 학기에 활동한 인원인지 검사하는 로직
     // TODO: 파일 유효한지 검사하는 로직도 필요해요! 이건 파일 모듈 구성되면 public할듯
 

--- a/packages/api/src/feature/semester/controller/activity-duration.controller.ts
+++ b/packages/api/src/feature/semester/controller/activity-duration.controller.ts
@@ -30,7 +30,7 @@ import type {
   ApiSem012ResponseOK,
   ApiSem013RequestBody,
   ApiSem013RequestParam,
-  ApiSem013ResponseNotImplemented,
+  ApiSem013ResponseOk,
   ApiSem014RequestParam,
   ApiSem014ResponseOk,
   ApiSem015RequestBody,
@@ -159,14 +159,13 @@ export class ActivityDurationController {
   @Put("/executive/semesters/activity-durations/:activityDurationId")
   @UsePipes(new ZodPipe(apiSem013))
   async updateActivityDuration(
-    @GetExecutive() executive: GetExecutive,
-    @Param() _param: ApiSem013RequestParam,
-    @Body() _body: ApiSem013RequestBody,
-  ): Promise<ApiSem013ResponseNotImplemented> {
-    logger.info(
-      `User executive_id: ${executive.id} trying to call unimplemented feature`,
+    @Param() param: ApiSem013RequestParam,
+    @Body() body: ApiSem013RequestBody,
+  ): Promise<ApiSem013ResponseOk> {
+    return this.activityDurationService.updateActivityDuration(
+      param.activityDurationId,
+      body,
     );
-    throw new NotImplementedException();
   }
 
   @Executive()

--- a/packages/api/src/feature/semester/repository/activity.duration.repository.ts
+++ b/packages/api/src/feature/semester/repository/activity.duration.repository.ts
@@ -7,6 +7,7 @@ import {
   PrimitiveConditionValue,
 } from "@sparcs-clubs/api/common/base/base.repository";
 import { BaseSingleTableRepository } from "@sparcs-clubs/api/common/base/base.single.repository";
+import { MActivity } from "@sparcs-clubs/api/feature/activity/model/activity.model.new";
 import {
   IActivityDurationCreate,
   MActivityDuration,
@@ -114,5 +115,54 @@ export class ActivityDurationRepository extends BaseSingleTableRepository<
     }
 
     throw new Error(`Invalid key: ${key}`);
+  }
+
+  async findActivitiesByDurationId(
+    activityDurationId: MActivityDuration["id"],
+  ): Promise<MActivity[]> {
+    const activities = await this.prisma.activity.findMany({
+      where: {
+        activityDId: activityDurationId,
+        deletedAt: null,
+      },
+      include: {
+        activityTs: {
+          where: {
+            deletedAt: null,
+          },
+        },
+      },
+    });
+
+    return activities.map(
+      activity =>
+        new MActivity({
+          id: activity.id,
+          club: { id: activity.clubId },
+          name: activity.name,
+          activityTypeEnum: activity.activityTypeEnumId,
+          activityStatusEnum: activity.activityStatusEnumId,
+          activityDuration: { id: activity.activityDId },
+          durations: activity.activityTs.map(duration => ({
+            startTerm: duration.startTerm,
+            endTerm: duration.endTerm,
+          })),
+          location: activity.location,
+          purpose: activity.purpose,
+          detail: activity.detail,
+          evidence: activity.evidence,
+          evidenceFiles: [],
+          participants: [],
+          chargedExecutive: activity.chargedExecutiveId
+            ? { id: activity.chargedExecutiveId }
+            : null,
+          editedAt: activity.editedAt,
+          professorApprovedAt: activity.professorApprovedAt,
+          commentedAt: activity.commentedAt,
+          commentedExecutive: activity.commentedExecutiveId
+            ? { id: activity.commentedExecutiveId }
+            : null,
+        }),
+    );
   }
 }

--- a/packages/api/src/feature/semester/service/activity-duration.service.ts
+++ b/packages/api/src/feature/semester/service/activity-duration.service.ts
@@ -9,10 +9,13 @@ import type {
   ApiSem011ResponseCreated,
   ApiSem012RequestQuery,
   ApiSem012ResponseOK,
+  ApiSem013RequestBody,
+  ApiSem013ResponseOk,
   ApiSem014ResponseOk,
 } from "@clubs/interface/api/semester/index";
 
 import { takeOnlyOne } from "@sparcs-clubs/api/common/util/util";
+import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 import { MActivityDuration } from "../model/activity.duration.model";
 import { ActivityDeadlineRepository } from "../repository/activity.deadline.repository";
@@ -25,6 +28,7 @@ export class ActivityDurationService {
     private readonly activityDurationRepository: ActivityDurationRepository,
     private readonly activityDeadlineRepository: ActivityDeadlineRepository,
     private readonly semesterRepository: SemesterRepository,
+    private readonly prisma: PrismaService,
   ) {}
 
   async createActivityDeadline(param: {
@@ -220,6 +224,71 @@ export class ActivityDurationService {
     } as Parameters<typeof this.activityDurationRepository.delete>[0]);
 
     return {};
+  }
+
+  async updateActivityDuration(
+    activityDurationId: number,
+    body: ApiSem013RequestBody,
+  ): Promise<ApiSem013ResponseOk> {
+    const existing = await this.activityDurationRepository.find({
+      id: activityDurationId,
+    } as Parameters<typeof this.activityDurationRepository.find>[0]);
+
+    if (!existing || existing.length === 0) {
+      throw new HttpException(
+        "해당 활동반기를 찾을 수 없습니다.",
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const { startTerm, endTerm } = body;
+    if (new Date(startTerm) >= new Date(endTerm)) {
+      throw new HttpException(
+        "시작날짜는 종료날짜보다 이전이어야 합니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const activityIds = (
+      await this.prisma.activity.findMany({
+        where: {
+          activityDId: activityDurationId,
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+        },
+      })
+    ).map(activity => activity.id);
+
+    const outOfRangeActivityTerm = await this.prisma.activityT.findFirst({
+      where: {
+        activityId: { in: activityIds },
+        deletedAt: null,
+        OR: [{ startTerm: { lt: startTerm } }, { endTerm: { gt: endTerm } }],
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (outOfRangeActivityTerm) {
+      throw new HttpException(
+        "수정하려는 활동반기 밖에 위치한 활동보고서 기간이 있어 수정할 수 없습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const activityDuration = existing[0];
+    await this.activityDurationRepository.put(
+      new MActivityDuration({
+        ...activityDuration,
+        startTerm,
+        endTerm,
+      }),
+    );
+
+    return { id: activityDurationId };
   }
 
   async getActivityDurations(param: {

--- a/packages/api/src/feature/semester/service/activity-duration.service.ts
+++ b/packages/api/src/feature/semester/service/activity-duration.service.ts
@@ -15,7 +15,6 @@ import type {
 } from "@clubs/interface/api/semester/index";
 
 import { takeOnlyOne } from "@sparcs-clubs/api/common/util/util";
-import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 import { MActivityDuration } from "../model/activity.duration.model";
 import { ActivityDeadlineRepository } from "../repository/activity.deadline.repository";
@@ -28,7 +27,6 @@ export class ActivityDurationService {
     private readonly activityDurationRepository: ActivityDurationRepository,
     private readonly activityDeadlineRepository: ActivityDeadlineRepository,
     private readonly semesterRepository: SemesterRepository,
-    private readonly prisma: PrismaService,
   ) {}
 
   async createActivityDeadline(param: {
@@ -230,11 +228,13 @@ export class ActivityDurationService {
     activityDurationId: number,
     body: ApiSem013RequestBody,
   ): Promise<ApiSem013ResponseOk> {
-    const existing = await this.activityDurationRepository.find({
-      id: activityDurationId,
-    } as Parameters<typeof this.activityDurationRepository.find>[0]);
+    const activityDuration = await this.activityDurationRepository
+      .find({
+        id: activityDurationId,
+      } as Parameters<typeof this.activityDurationRepository.find>[0])
+      .then(takeOnlyOne(MActivityDuration));
 
-    if (!existing || existing.length === 0) {
+    if (!activityDuration) {
       throw new HttpException(
         "해당 활동반기를 찾을 수 없습니다.",
         HttpStatus.NOT_FOUND,
@@ -249,37 +249,25 @@ export class ActivityDurationService {
       );
     }
 
-    const activityIds = (
-      await this.prisma.activity.findMany({
-        where: {
-          activityDId: activityDurationId,
-          deletedAt: null,
-        },
-        select: {
-          id: true,
-        },
-      })
-    ).map(activity => activity.id);
+    const activities =
+      await this.activityDurationRepository.findActivitiesByDurationId(
+        activityDurationId,
+      );
 
-    const outOfRangeActivityTerm = await this.prisma.activityT.findFirst({
-      where: {
-        activityId: { in: activityIds },
-        deletedAt: null,
-        OR: [{ startTerm: { lt: startTerm } }, { endTerm: { gt: endTerm } }],
-      },
-      select: {
-        id: true,
-      },
-    });
+    const hasOutOfRangeActivityTerm = activities.some(activity =>
+      activity.durations.some(
+        duration =>
+          duration.startTerm < startTerm || duration.endTerm > endTerm,
+      ),
+    );
 
-    if (outOfRangeActivityTerm) {
+    if (hasOutOfRangeActivityTerm) {
       throw new HttpException(
         "수정하려는 활동반기 밖에 위치한 활동보고서 기간이 있어 수정할 수 없습니다.",
         HttpStatus.BAD_REQUEST,
       );
     }
 
-    const activityDuration = existing[0];
     await this.activityDurationRepository.put(
       new MActivityDuration({
         ...activityDuration,

--- a/packages/interface/src/api/semester/apiSem013.ts
+++ b/packages/interface/src/api/semester/apiSem013.ts
@@ -7,7 +7,7 @@ import { registry } from "@clubs/interface/open-api";
 
 /**
  * @version v0.1
- * @description 활동반기를 수정합니다. (구현 예정)
+ * @description 활동반기의 시작/종료일을 수정합니다.
  */
 
 const url = (activityDurationId: number) =>
@@ -21,17 +21,14 @@ const requestParam = z.object({
 const requestQuery = z.object({});
 
 const requestBody = z.object({
-  semesterId: zActivityDuration.shape.semester.shape.id.optional(),
-  activityDurationTypeEnum:
-    zActivityDuration.shape.activityDurationTypeEnum.optional(),
-  year: zActivityDuration.shape.year.optional(),
-  name: zActivityDuration.shape.name.optional(),
-  startTerm: zActivityDuration.shape.startTerm.optional(),
-  endTerm: zActivityDuration.shape.endTerm.optional(),
+  startTerm: zActivityDuration.shape.startTerm,
+  endTerm: zActivityDuration.shape.endTerm,
 });
 
 const responseBodyMap = {
-  [HttpStatusCode.NotImplemented]: z.object({}),
+  [HttpStatusCode.Ok]: z.object({
+    id: zActivityDuration.shape.id,
+  }),
 };
 
 const responseErrorMap = {};
@@ -49,29 +46,25 @@ export const apiSem013 = {
 type ApiSem013RequestParam = z.infer<typeof apiSem013.requestParam>;
 type ApiSem013RequestQuery = z.infer<typeof apiSem013.requestQuery>;
 type ApiSem013RequestBody = z.infer<typeof apiSem013.requestBody>;
-type ApiSem013ResponseNotImplemented = z.infer<
-  (typeof apiSem013.responseBodyMap)[501]
->;
+type ApiSem013ResponseOk = z.infer<(typeof apiSem013.responseBodyMap)[200]>;
 
 export type {
   ApiSem013RequestParam,
   ApiSem013RequestQuery,
   ApiSem013RequestBody,
-  ApiSem013ResponseNotImplemented,
+  ApiSem013ResponseOk,
 };
 
 registry.registerPath({
   tags: ["semester"],
   method: "put",
   path: "/executive/semesters/activity-durations/{activityDurationId}",
-  summary: "SEM-013: 활동반기 수정하기 (미구현)",
+  summary: "SEM-013: 활동반기 시작/종료일 수정하기",
   description: `
-  활동반기를 수정합니다. 활동반기는 학기, 활동반기 분류, 년도, 이름, 시작/종료일로 구성되어 있습니다.
-  1. (활동반기명, 년도) 쌍은 유일해야 합니다.
-  2. 모든 활동반기는 시작일이 종료일보다 이전이어야 합니다.
-  3. 시작일은 포함하고 종료일은 포함하지 않습니다.
-  4. 모든 기간은 겹치면 안 됩니다.
-  5. 활동반기 분류는 1(정규) 또는 2(신규등록)여야 합니다.
+  활동반기의 시작/종료일을 수정합니다.
+  1. 수정하려는 활동반기가 존재해야 합니다.
+  2. 시작일은 종료일보다 이전이어야 합니다.
+  3. 기존 활동보고서 기간이 수정 후 활동반기 밖으로 벗어나면 수정할 수 없습니다.
   `,
   request: {
     params: apiSem013.requestParam,
@@ -84,8 +77,13 @@ registry.registerPath({
     },
   },
   responses: {
-    501: {
-      description: "아직 구현되지 않은 기능입니다.",
+    200: {
+      description: "활동반기가 수정되었습니다.",
+      content: {
+        "application/json": {
+          schema: apiSem013.responseBodyMap[HttpStatusCode.Ok],
+        },
+      },
     },
   },
 });

--- a/packages/web/src/common/components/Forms/DateInput.tsx
+++ b/packages/web/src/common/components/Forms/DateInput.tsx
@@ -62,6 +62,9 @@ const DateInput: React.FC<
   ...props
 }) => {
   const datePickerRef = useRef<DatePicker | null>(null);
+  const popperClassName = ["sparcs-date-input-popper", props.popperClassName]
+    .filter(Boolean)
+    .join(" ");
 
   const handleInputClick = () => {
     if (
@@ -88,6 +91,9 @@ const DateInput: React.FC<
             props.showTimeInput ? "20XX.XX.XX XX:XX" : "20XX.XX.XX"
           }
           {...props}
+          portalId={props.portalId ?? "sparcs-date-input-portal"}
+          popperClassName={popperClassName}
+          popperProps={{ strategy: "fixed", ...props.popperProps }}
         />
         {showIcon && (
           <Icon type="event" size={20} color={disabled ? "#DDDDDD" : "BLACK"} />

--- a/packages/web/src/features/executive/activity-duration/components/ActivityDurationEditModal.tsx
+++ b/packages/web/src/features/executive/activity-duration/components/ActivityDurationEditModal.tsx
@@ -28,7 +28,10 @@ const ActivityDurationEditModal = ({
 }: ActivityDurationEditModalProps) => {
   const [startTerm, setStartTerm] = useState<Date | null>(null);
   const [endTerm, setEndTerm] = useState<Date | null>(null);
-  const { mutate: updateActivityDuration } = useUpdateActivityDuration();
+  const {
+    mutate: updateActivityDuration,
+    isPending: isUpdatingActivityDuration,
+  } = useUpdateActivityDuration();
 
   useEffect(() => {
     if (!isOpen || !duration) return;
@@ -44,14 +47,18 @@ const ActivityDurationEditModal = ({
   const handleSave = () => {
     if (!duration || !startTerm || !endTerm) return;
 
-    updateActivityDuration({
-      activityDurationId: duration.id,
-      body: {
-        startTerm: getLocalDateOnly(startTerm),
-        endTerm: getLocalDateLastTime(endTerm),
+    updateActivityDuration(
+      {
+        activityDurationId: duration.id,
+        body: {
+          startTerm: getLocalDateOnly(startTerm),
+          endTerm: getLocalDateLastTime(endTerm),
+        },
       },
-    });
-    onClose();
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (
@@ -61,7 +68,9 @@ const ActivityDurationEditModal = ({
         onClose={handleClose}
         confirmButtonText="저장"
         closeButtonText="취소"
-        confirmDisabled={!duration || !startTerm || !endTerm}
+        confirmDisabled={
+          !duration || !startTerm || !endTerm || isUpdatingActivityDuration
+        }
       >
         <FlexWrapper direction="column" gap={20} style={{ width: "400px" }}>
           <Typography fs={18} lh={24} fw="MEDIUM">

--- a/packages/web/src/features/executive/activity-duration/components/ActivityDurationEditModal.tsx
+++ b/packages/web/src/features/executive/activity-duration/components/ActivityDurationEditModal.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+import { ApiSem012ResponseOK } from "@clubs/interface/api/semester/apiSem012";
+
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import DateInput from "@sparcs-clubs/web/common/components/Forms/DateInput";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useUpdateActivityDuration from "@sparcs-clubs/web/features/executive/services/useUpdateActivityDuration";
+import {
+  getLocalDateLastTime,
+  getLocalDateOnly,
+} from "@sparcs-clubs/web/utils/Date/getKSTDate";
+
+type ActivityDurationItem = ApiSem012ResponseOK["activityDurations"][number];
+
+interface ActivityDurationEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  duration: ActivityDurationItem | null;
+}
+
+const ActivityDurationEditModal = ({
+  isOpen,
+  onClose,
+  duration,
+}: ActivityDurationEditModalProps) => {
+  const [startTerm, setStartTerm] = useState<Date | null>(null);
+  const [endTerm, setEndTerm] = useState<Date | null>(null);
+  const { mutate: updateActivityDuration } = useUpdateActivityDuration();
+
+  useEffect(() => {
+    if (!isOpen || !duration) return;
+
+    setStartTerm(duration.startTerm);
+    setEndTerm(duration.endTerm);
+  }, [duration, isOpen]);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (!duration || !startTerm || !endTerm) return;
+
+    updateActivityDuration({
+      activityDurationId: duration.id,
+      body: {
+        startTerm: getLocalDateOnly(startTerm),
+        endTerm: getLocalDateLastTime(endTerm),
+      },
+    });
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <CancellableModalContent
+        onConfirm={handleSave}
+        onClose={handleClose}
+        confirmButtonText="저장"
+        closeButtonText="취소"
+        confirmDisabled={!duration || !startTerm || !endTerm}
+      >
+        <FlexWrapper direction="column" gap={20} style={{ width: "400px" }}>
+          <Typography fs={18} lh={24} fw="MEDIUM">
+            활동기간 수정
+          </Typography>
+          <DateInput
+            label="시작일"
+            selected={startTerm}
+            onChange={(date: Date | null) => setStartTerm(date)}
+          />
+          <DateInput
+            label="종료일"
+            selected={endTerm}
+            onChange={(date: Date | null) => setEndTerm(date)}
+          />
+        </FlexWrapper>
+      </CancellableModalContent>
+    </Modal>
+  );
+};
+
+export default ActivityDurationEditModal;

--- a/packages/web/src/features/executive/activity-duration/components/ActivityDurationTable.tsx
+++ b/packages/web/src/features/executive/activity-duration/components/ActivityDurationTable.tsx
@@ -5,7 +5,7 @@ import {
 } from "@tanstack/react-table";
 import { ko } from "date-fns/locale";
 import { formatInTimeZone } from "date-fns-tz";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { ActivityDurationTypeEnum } from "@clubs/domain/semester/activity-duration";
 
@@ -15,6 +15,8 @@ import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Table from "@sparcs-clubs/web/common/components/Table";
 import useDeleteActivityDuration from "@sparcs-clubs/web/features/executive/services/useDeleteActivityDuration";
+
+import ActivityDurationEditModal from "./ActivityDurationEditModal";
 
 const activityDurationTypeEnumToString = (
   value: ActivityDurationTypeEnum,
@@ -42,6 +44,8 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
     mutate: deleteActivityDuration,
     isPending: isDeletingActivityDuration,
   } = useDeleteActivityDuration();
+  const [editingDuration, setEditingDuration] =
+    useState<ActivityDurationItem | null>(null);
 
   const sortedDurations = useMemo(() => {
     if (!durations) return [];
@@ -55,12 +59,15 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
     deleteActivityDuration({ activityDurationId: id });
   };
 
-  const actionsCellRenderer = (id: number) => (
-    <TextButton
-      text="삭제"
-      onClick={() => handleDelete(id)}
-      disabled={isDeletingActivityDuration}
-    />
+  const actionsCellRenderer = (duration: ActivityDurationItem) => (
+    <FlexWrapper direction="row" gap={8}>
+      <TextButton text="수정" onClick={() => setEditingDuration(duration)} />
+      <TextButton
+        text="삭제"
+        onClick={() => handleDelete(duration.id)}
+        disabled={isDeletingActivityDuration}
+      />
+    </FlexWrapper>
   );
 
   const columnHelper = createColumnHelper<ActivityDurationItem>();
@@ -111,8 +118,8 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
     columnHelper.display({
       id: "actions",
       header: "관리",
-      cell: ({ row }) => actionsCellRenderer(row.original.id),
-      size: 120,
+      cell: ({ row }) => actionsCellRenderer(row.original),
+      size: 140,
     }),
   ];
 
@@ -126,6 +133,11 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
   return (
     <FlexWrapper direction="column" gap={8}>
       <Table count={sortedDurations.length} table={table} />
+      <ActivityDurationEditModal
+        isOpen={editingDuration != null}
+        duration={editingDuration}
+        onClose={() => setEditingDuration(null)}
+      />
     </FlexWrapper>
   );
 };

--- a/packages/web/src/features/executive/services/getApiErrorMessage.ts
+++ b/packages/web/src/features/executive/services/getApiErrorMessage.ts
@@ -1,0 +1,21 @@
+import { AxiosError } from "axios";
+
+type ApiErrorResponse = {
+  message?: string | string[];
+  error?: string;
+};
+
+const getApiErrorMessage = (error: Error, fallbackMessage: string) => {
+  if (!(error instanceof AxiosError)) {
+    return fallbackMessage;
+  }
+
+  const data = error.response?.data as ApiErrorResponse | undefined;
+  const message = Array.isArray(data?.message)
+    ? data.message.join("\n")
+    : data?.message;
+
+  return [fallbackMessage, message || data?.error].filter(Boolean).join("\n");
+};
+
+export default getApiErrorMessage;

--- a/packages/web/src/features/executive/services/useDeleteActivityDuration.ts
+++ b/packages/web/src/features/executive/services/useDeleteActivityDuration.ts
@@ -7,10 +7,13 @@ import {
   ApiSem014ResponseOk,
 } from "@clubs/interface/api/semester/apiSem014";
 
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import {
   axiosClientWithAuth,
   defineAxiosMock,
 } from "@sparcs-clubs/web/lib/axios";
+
+import getApiErrorMessage from "./getApiErrorMessage";
 
 const useDeleteActivityDuration = () => {
   const queryClient = useQueryClient();
@@ -25,6 +28,11 @@ const useDeleteActivityDuration = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [apiSem012.url()] });
+    },
+    onError: error => {
+      errorHandler(
+        getApiErrorMessage(error, "활동기간 삭제에 실패하였습니다."),
+      );
     },
   });
 };

--- a/packages/web/src/features/executive/services/useUpdateActivityDuration.ts
+++ b/packages/web/src/features/executive/services/useUpdateActivityDuration.ts
@@ -9,10 +9,13 @@ import {
   ApiSem013ResponseOk,
 } from "@clubs/interface/api/semester/apiSem013";
 
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import {
   axiosClientWithAuth,
   defineAxiosMock,
 } from "@sparcs-clubs/web/lib/axios";
+
+import getApiErrorMessage from "./getApiErrorMessage";
 
 type UpdateActivityDurationParams = ApiSem013RequestParam & {
   body: ApiSem013RequestBody;
@@ -36,6 +39,11 @@ const useUpdateActivityDuration = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [apiSem012.url()] });
       queryClient.invalidateQueries({ queryKey: [apiAct018.url()] });
+    },
+    onError: error => {
+      errorHandler(
+        getApiErrorMessage(error, "활동기간 수정에 실패하였습니다."),
+      );
     },
   });
 };

--- a/packages/web/src/features/executive/services/useUpdateActivityDuration.ts
+++ b/packages/web/src/features/executive/services/useUpdateActivityDuration.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import apiAct018 from "@clubs/interface/api/activity/endpoint/apiAct018";
+import { apiSem012 } from "@clubs/interface/api/semester/apiSem012";
+import {
+  apiSem013,
+  ApiSem013RequestBody,
+  ApiSem013RequestParam,
+  ApiSem013ResponseOk,
+} from "@clubs/interface/api/semester/apiSem013";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+type UpdateActivityDurationParams = ApiSem013RequestParam & {
+  body: ApiSem013RequestBody;
+};
+
+const useUpdateActivityDuration = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiSem013ResponseOk, Error, UpdateActivityDurationParams>({
+    mutationFn: async ({
+      activityDurationId,
+      body,
+    }): Promise<ApiSem013ResponseOk> => {
+      const { data } = await axiosClientWithAuth.put(
+        apiSem013.url(activityDurationId),
+        body,
+      );
+
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [apiSem012.url()] });
+      queryClient.invalidateQueries({ queryKey: [apiAct018.url()] });
+    },
+  });
+};
+
+export default useUpdateActivityDuration;
+
+defineAxiosMock(mock => {
+  mock.onPut(apiSem013.url(1)).reply(() => [200, { id: 1 }]);
+});

--- a/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
@@ -1,4 +1,3 @@
-import { addDays, subDays } from "date-fns";
 import React, { useCallback, useMemo } from "react";
 import { Control, useFieldArray } from "react-hook-form";
 
@@ -104,17 +103,8 @@ const EditActivityTermModal: React.FC<EditActivityTermModalProps> = ({
                   renderItem={({ value, onChange, errorMessage }) => (
                     <DateInput
                       selectsRange
-                      minDate={
-                        deadline?.targetTerm?.startTerm
-                          ? addDays(deadline.targetTerm.startTerm, 1)
-                          : undefined
-                      }
-                      maxDate={
-                        deadline?.targetTerm?.endTerm == null ||
-                        new Date() < deadline?.targetTerm?.endTerm
-                          ? new Date()
-                          : subDays(deadline.targetTerm.endTerm, 1)
-                      }
+                      minDate={deadline?.targetTerm?.startTerm ?? undefined}
+                      maxDate={deadline?.targetTerm?.endTerm ?? undefined}
                       startDate={value?.startTerm}
                       endDate={value?.endTerm}
                       onChange={(dates: [Date, Date] | null) => {

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -61,6 +61,11 @@ main {
   margin-right: 5px;
 }
 
-.sparcs-date-input-popper {
-  z-index: 120;
+#sparcs-date-input-portal {
+  position: relative;
+  z-index: 1000;
+}
+
+#sparcs-date-input-portal .react-datepicker-popper.sparcs-date-input-popper {
+  z-index: 1000;
 }

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -60,3 +60,7 @@ main {
   margin-left: 5px;
   margin-right: 5px;
 }
+
+.sparcs-date-input-popper {
+  z-index: 120;
+}


### PR DESCRIPTION
## Summary
- use activity deadline target terms as-is in the activity report date selector instead of applying hardcoded day shifts
- implement SEM-013 to update activity duration start/end dates from the executive dashboard
- validate activity date ranges against the active activity duration and prevent shrinking durations around existing activity reports
- render date picker poppers through a portal so calendar selectors are not clipped by modals

## Task Context
- Notion: https://www.notion.so/361c25603b0b811f9476d1ec1fd655ee
- Task ID: TU-409
- Follow-up context: activity report period management inquiry and date boundary mismatch investigation

## Details
- SEM-013 now accepts only start/end term updates and returns the updated activity duration id
- the executive activity duration table now exposes a 수정 action next to 삭제 and opens a date-only edit modal
- activity report creation rejects activity terms outside the loaded activity duration
- DateInput uses a fixed-position portal popper with a higher z-index to avoid modal overflow clipping

## Verification
- corepack pnpm --filter=interface build
- corepack pnpm exec eslint src/feature/activity/service/activity.service.new.ts src/feature/semester/controller/activity-duration.controller.ts src/feature/semester/service/activity-duration.service.ts
- corepack pnpm exec eslint src/common/components/Forms/DateInput.tsx src/features/executive/activity-duration/components/ActivityDurationTable.tsx src/features/executive/activity-duration/components/ActivityDurationEditModal.tsx src/features/executive/services/useUpdateActivityDuration.ts src/features/register-club/components/activity-report/EditActivityTermModal.tsx
- corepack pnpm --filter=api exec tsc -p tsconfig.json --noEmit --pretty false
- corepack pnpm --filter=web exec tsc -p tsconfig.json --noEmit --pretty false
- pre-commit lint-staged checks for staged api/web/interface files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editable activity-duration endpoint and UI modal to update start/end terms
  * Client hook to submit duration updates

* **Bug Fixes**
  * Server-side validation rejects submitted activity durations outside the last activity window
  * Deletion errors now surface friendly API messages

* **Improvements**
  * Improved date input popper positioning and portal styling
  * Simplified date-range constraints and standardized API error message extraction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1774)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->