### PR TITLE
[TU-410] web 패키지 빌드 시 린트 체크 제거

### DIFF
--- a/.docker/dockerfile/web.bundle.production.Dockerfile
+++ b/.docker/dockerfile/web.bundle.production.Dockerfile
@@ -26,8 +26,6 @@ WORKDIR /app
 COPY --from=prunner /app/out/json/ .
 COPY --from=prunner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=prunner /app/out/full/ .
-COPY --from=prunner /app/.prettierrc ./.prettierrc
-COPY --from=prunner /app/.prettierignore ./.prettierignore
 RUN corepack enable
 RUN pnpm install
 

--- a/.docker/dockerfile/web.bundle.stage.Dockerfile
+++ b/.docker/dockerfile/web.bundle.stage.Dockerfile
@@ -26,8 +26,6 @@ WORKDIR /app
 COPY --from=prunner /app/out/json/ .
 COPY --from=prunner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=prunner /app/out/full/ .
-COPY --from=prunner /app/.prettierrc ./.prettierrc
-COPY --from=prunner /app/.prettierignore ./.prettierignore
 RUN corepack enable
 RUN pnpm install
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test:api": "turbo run test --filter=api"
   },
   "lint-staged": {
+    "**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,css,scss,md,mdx,yml,yaml}": [
+      "prettier --check --ignore-unknown"
+    ],
     "./packages/api/**/*.ts": [
       "pnpm --filter=api lint"
     ],

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -6,6 +6,9 @@ const nextConfig = {
     // Enables the styled-components SWC transform
     styledComponents: true,
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   output: "standalone",
   headers: async () => {
     return [


### PR DESCRIPTION
## Summary
- Disable ESLint during `next build` for the web package so Docker image builds only package the already-validated app
- Revert the TU-409-fix Dockerfile copies of root Prettier config
- Add explicit staged Prettier checks to `lint-staged` for local pre-commit validation

## Verification
- `pnpm exec prettier --check package.json packages/web/next.config.mjs`
- `pnpm exec lint-staged --diff=HEAD`
- `pnpm exec turbo run build --filter=web` confirmed `Skipping linting` during Next build
- `pnpm lint` passed with existing warnings only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary configuration files from Docker build processes to streamline production and staging images.
  * Enhanced code quality checks by adding formatting validation to pre-commit hooks.
  * Updated build configuration to allow builds to proceed despite linting warnings, improving development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->