### PR TITLE
[TU-389] 동아리별 지원금 검토율 버그 수정

### DIFF
--- a/packages/web/src/features/executive/funding/components/ExecutiveFundingChargedTable.tsx
+++ b/packages/web/src/features/executive/funding/components/ExecutiveFundingChargedTable.tsx
@@ -44,12 +44,12 @@ const openAssignModal = (data: ApiFnd008ResponseOk["executives"][number]) => {
       clubTypeEnum: club.typeEnum,
       divisionName: club.division.name,
       clubName: club.name,
-      totalCount: data.totalCount,
-      appliedCount: data.appliedCount,
-      approvedCount: data.approvedCount,
-      rejectedCount: data.rejectedCount,
-      committeeCount: data.committeeCount,
-      partialCount: data.partialCount,
+      totalCount: club.totalCount,
+      appliedCount: club.appliedCount,
+      approvedCount: club.approvedCount,
+      rejectedCount: club.rejectedCount,
+      committeeCount: club.committeeCount,
+      partialCount: club.partialCount,
     }),
   );
 


### PR DESCRIPTION
## Summary
- 담당자별 지원금 상세 모달에서 동아리별 row count가 담당자 전체 count를 사용하던 문제를 수정
- chargedClubs의 club별 total/applied/approved/rejected/committee/partial count를 모달 테이블에 전달하도록 변경
- web lint와 web build, 임시 fixture 화면으로 모달 표시 회귀 확인

## Task Context
- Task ID: TU-389
- Notion: https://www.notion.so/358c25603b0b80f3a2cad6d1c9e30318



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect count calculations for charged clubs in the funding modal, ensuring per-club data is now accurately displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->