### PR TITLE
fix: update executive member term management

### DIFF
--- a/packages/api/src/feature/user/controller/user.controller.ts
+++ b/packages/api/src/feature/user/controller/user.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Put,
   Query,
   UsePipes,
 } from "@nestjs/common";
@@ -27,6 +28,10 @@ import {
   apiUsr008,
   type ApiUsr008RequestParam,
   type ApiUsr008ResponseOk,
+  apiUsr009,
+  type ApiUsr009RequestBody,
+  type ApiUsr009RequestParam,
+  type ApiUsr009ResponseOk,
 } from "@clubs/interface/api/user/endpoint/index";
 
 import { ZodPipe } from "@sparcs-clubs/api/common/pipe/zod-pipe";
@@ -186,6 +191,18 @@ export class UserController {
     @Param() param: ApiUsr008RequestParam,
   ): Promise<ApiUsr008ResponseOk> {
     await this.userService.deleteExecutive(user.id, param.executiveId);
+    return {};
+  }
+
+  @Executive()
+  @Put("/executive/user/executives/:executiveTId")
+  @UsePipes(new ZodPipe(apiUsr009))
+  async updateExecutiveTerm(
+    @GetUser() user: GetUser,
+    @Param() param: ApiUsr009RequestParam,
+    @Body() body: ApiUsr009RequestBody,
+  ): Promise<ApiUsr009ResponseOk> {
+    await this.userService.updateExecutiveTerm(user.id, param, body);
     return {};
   }
 }

--- a/packages/api/src/feature/user/repository/executive.repository.spec.ts
+++ b/packages/api/src/feature/user/repository/executive.repository.spec.ts
@@ -1,0 +1,215 @@
+import ExecutiveRepository from "./executive.repository";
+
+describe("ExecutiveRepository", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("findExecutiveByUserId", () => {
+    it("checks current executives with prisma relation query", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2025-03-15T12:00:00.000Z"));
+
+      const prisma = {
+        executive: {
+          findFirst: jest.fn().mockResolvedValue({ id: 1 }),
+        },
+      };
+      const repository = new ExecutiveRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ExecutiveRepository
+        >[0],
+      );
+
+      const result = await repository.findExecutiveByUserId(10);
+
+      expect(prisma.executive.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: 10,
+          deletedAt: null,
+          executiveTs: {
+            some: {
+              deletedAt: null,
+              startTerm: { lte: new Date("2025-03-15T12:00:00.000Z") },
+              OR: [
+                { endTerm: { gte: new Date("2025-03-15T12:00:00.000Z") } },
+                { endTerm: null },
+              ],
+            },
+          },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkExistExecutiveByIdDate", () => {
+    it("checks overlapping executive terms with prisma relation query", async () => {
+      const prisma = {
+        executive: {
+          findFirst: jest.fn().mockResolvedValue({ id: 1 }),
+        },
+      };
+      const repository = new ExecutiveRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ExecutiveRepository
+        >[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+      const endTerm = new Date("2025-03-31T14:59:00.000Z");
+
+      const result = await repository.checkExistExecutiveByIdDate(
+        1,
+        startTerm,
+        endTerm,
+      );
+
+      expect(prisma.executive.findFirst).toHaveBeenCalledWith({
+        where: {
+          studentId: 1,
+          deletedAt: null,
+          executiveTs: {
+            some: {
+              deletedAt: null,
+              startTerm: { lte: endTerm },
+              OR: [{ endTerm: { gte: startTerm } }, { endTerm: null }],
+            },
+          },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("checks open-ended executive terms without a new end boundary", async () => {
+      const prisma = {
+        executive: {
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+      };
+      const repository = new ExecutiveRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ExecutiveRepository
+        >[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+
+      const result = await repository.checkExistExecutiveByIdDate(
+        1,
+        startTerm,
+        null,
+        10,
+      );
+
+      expect(prisma.executive.findFirst).toHaveBeenCalledWith({
+        where: {
+          studentId: 1,
+          deletedAt: null,
+          executiveTs: {
+            some: {
+              id: { not: 10 },
+              deletedAt: null,
+              OR: [{ endTerm: { gte: startTerm } }, { endTerm: null }],
+            },
+          },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("createExecutive", () => {
+    it("creates executive_t rows with prisma create", async () => {
+      const tx = {
+        executive: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: jest.fn().mockResolvedValue({ id: 3 }),
+        },
+        executiveT: {
+          create: jest.fn().mockResolvedValue({ id: 4 }),
+        },
+      };
+      const prisma = {
+        $transaction: jest.fn(async callback => callback(tx)),
+      };
+      const repository = new ExecutiveRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ExecutiveRepository
+        >[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+      const endTerm = new Date("2025-03-31T14:59:00.000Z");
+
+      const result = await repository.createExecutive(
+        1,
+        2,
+        "student@kaist.ac.kr",
+        "홍길동",
+        startTerm,
+        endTerm,
+      );
+
+      expect(tx.executive.create).toHaveBeenCalledWith({
+        data: {
+          userId: 2,
+          studentId: 1,
+          email: "student@kaist.ac.kr",
+          name: "홍길동",
+        },
+      });
+      expect(tx.executiveT.create).toHaveBeenCalledWith({
+        data: {
+          executiveId: 3,
+          executiveStatusEnum: 1,
+          executiveBureauEnum: 1,
+          startTerm,
+          endTerm,
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("creates open-ended executive_t rows with null endTerm", async () => {
+      const tx = {
+        executive: {
+          findMany: jest.fn().mockResolvedValue([{ id: 3, deletedAt: null }]),
+          create: jest.fn(),
+        },
+        executiveT: {
+          create: jest.fn().mockResolvedValue({ id: 4 }),
+        },
+      };
+      const prisma = {
+        $transaction: jest.fn(async callback => callback(tx)),
+      };
+      const repository = new ExecutiveRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ExecutiveRepository
+        >[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+
+      const result = await repository.createExecutive(
+        1,
+        2,
+        "student@kaist.ac.kr",
+        "홍길동",
+        startTerm,
+        null,
+      );
+
+      expect(tx.executive.create).not.toHaveBeenCalled();
+      expect(tx.executiveT.create).toHaveBeenCalledWith({
+        data: {
+          executiveId: 3,
+          executiveStatusEnum: 1,
+          executiveBureauEnum: 1,
+          startTerm,
+          endTerm: null,
+        },
+      });
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/feature/user/repository/executive.repository.ts
+++ b/packages/api/src/feature/user/repository/executive.repository.ts
@@ -8,6 +8,25 @@ import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 import { VExecutiveSummary } from "../model/executive.summary.model";
 
+const buildExecutiveTermOverlapWhere = (
+  startTerm: Date,
+  endTerm: Date | null,
+  excludeExecutiveTId?: number,
+): Prisma.ExecutiveTWhereInput => ({
+  ...(excludeExecutiveTId === undefined
+    ? {}
+    : {
+        id: { not: excludeExecutiveTId },
+      }),
+  deletedAt: null,
+  ...(endTerm === null
+    ? {}
+    : {
+        startTerm: { lte: endTerm },
+      }),
+  OR: [{ endTerm: { gte: startTerm } }, { endTerm: null }],
+});
+
 @Injectable()
 export default class ExecutiveRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -26,18 +45,18 @@ export default class ExecutiveRepository {
   }
 
   async findExecutiveByUserId(id: number): Promise<boolean> {
-    const result = await this.prisma.$queryRaw<Array<{ id: number }>>(
-      Prisma.sql`
-        SELECT e.id
-        FROM executive e
-        INNER JOIN executive_t et ON et.executive_id = e.id
-          AND (DATE(et.end_term) >= DATE(NOW()) OR et.end_term IS NULL)
-          AND DATE(et.start_term) <= DATE(NOW())
-        WHERE e.user_id = ${id}
-          AND e.deleted_at IS NULL
-      `,
-    );
-    return result.length > 0;
+    const today = new Date();
+    const result = await this.prisma.executive.findFirst({
+      where: {
+        userId: id,
+        deletedAt: null,
+        executiveTs: {
+          some: buildExecutiveTermOverlapWhere(today, today),
+        },
+      },
+      select: { id: true },
+    });
+    return result !== null;
   }
 
   async getExecutiveById(id: number) {
@@ -275,46 +294,34 @@ export default class ExecutiveRepository {
 
   async checkExistExecutiveByIdDate(
     studentId: number,
-    startTerm: string,
-    endTerm: string,
+    startTerm: Date,
+    endTerm: Date | null,
+    excludeExecutiveTId?: number,
   ) {
-    const result = await this.prisma.$queryRaw<Array<{ id: number }>>(
-      Prisma.sql`
-        SELECT e.id
-        FROM executive e
-        INNER JOIN executive_t et ON et.executive_id = e.id
-          AND et.deleted_at IS NULL
-          AND (
-            (
-              et.end_term IS NOT NULL
-              AND (
-                (DATE(et.start_term) >= ${startTerm} AND DATE(et.start_term) <= ${endTerm})
-                OR (DATE(et.end_term) >= ${startTerm} AND DATE(et.end_term) <= ${endTerm})
-                OR (DATE(et.start_term) <= ${startTerm} AND DATE(et.end_term) >= ${endTerm})
-              )
-            )
-            OR (
-              et.end_term IS NULL
-              AND (
-                (DATE(et.start_term) >= ${startTerm} AND DATE(et.start_term) <= ${endTerm})
-                OR DATE(et.start_term) <= ${startTerm}
-              )
-            )
-          )
-        WHERE e.student_id = ${studentId}
-          AND e.deleted_at IS NULL
-      `,
-    );
-    return result.length > 0;
+    const result = await this.prisma.executive.findFirst({
+      where: {
+        studentId,
+        deletedAt: null,
+        executiveTs: {
+          some: buildExecutiveTermOverlapWhere(
+            startTerm,
+            endTerm,
+            excludeExecutiveTId,
+          ),
+        },
+      },
+      select: { id: true },
+    });
+    return result !== null;
   }
 
   async createExecutive(
     studentId: number,
-    userId: number,
-    email: string,
+    userId: number | null,
+    email: string | null,
     name: string,
-    startTerm: string,
-    endTerm: string,
+    startTerm: Date,
+    endTerm: Date | null,
   ) {
     try {
       await this.prisma.$transaction(async tx => {
@@ -340,10 +347,15 @@ export default class ExecutiveRepository {
           executiveId = newExecutive.id;
         }
 
-        await tx.$executeRaw(Prisma.sql`
-          INSERT INTO executive_t (executive_id, executive_status_enum, executive_bureau_enum, start_term, end_term)
-          VALUES (${executiveId}, 1, 1, DATE(${startTerm}), DATE(${endTerm}))
-        `);
+        await tx.executiveT.create({
+          data: {
+            executiveId,
+            executiveStatusEnum: 1,
+            executiveBureauEnum: 1,
+            startTerm,
+            endTerm,
+          },
+        });
 
         return true;
       });
@@ -358,35 +370,95 @@ export default class ExecutiveRepository {
   }
 
   async getExecutives() {
-    const result = await this.prisma.$queryRaw<
-      Array<{
-        id: number;
-        userId: number | null;
-        studentNumber: number;
-        name: string;
-        email: string | null;
-        phoneNumber: string | null;
-        startTerm: Date;
-        endTerm: Date | null;
-      }>
-    >(
-      Prisma.sql`
-        SELECT e.id, e.user_id AS userId, s.number AS studentNumber,
-               u.name, u.email, u.phone_number AS phoneNumber,
-               et.start_term AS startTerm, et.end_term AS endTerm
-        FROM executive e
-        INNER JOIN executive_t et ON et.executive_id = e.id
-          AND (DATE(et.end_term) >= DATE(NOW()) OR et.end_term IS NULL)
-          AND DATE(et.start_term) <= DATE(NOW())
-          AND et.deleted_at IS NULL
-        INNER JOIN user u ON u.id = e.user_id
-          AND u.deleted_at IS NULL
-        INNER JOIN student s ON s.id = e.student_id
-          AND s.deleted_at IS NULL
-        WHERE e.deleted_at IS NULL
-      `,
-    );
-    return result;
+    const today = new Date();
+    const result = await this.prisma.executiveT.findMany({
+      where: {
+        ...buildExecutiveTermOverlapWhere(today, today),
+        executive: {
+          deletedAt: null,
+          user: {
+            is: {
+              deletedAt: null,
+            },
+          },
+          student: {
+            deletedAt: null,
+          },
+        },
+      },
+      select: {
+        id: true,
+        startTerm: true,
+        endTerm: true,
+        executive: {
+          select: {
+            id: true,
+            userId: true,
+            name: true,
+            email: true,
+            user: {
+              select: {
+                name: true,
+                email: true,
+                phoneNumber: true,
+              },
+            },
+            student: {
+              select: {
+                number: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    return result.map(executiveTerm => ({
+      id: executiveTerm.executive.id,
+      executiveTId: executiveTerm.id,
+      userId: executiveTerm.executive.userId,
+      studentNumber: String(executiveTerm.executive.student.number),
+      name: executiveTerm.executive.user?.name ?? executiveTerm.executive.name,
+      email:
+        executiveTerm.executive.user?.email ?? executiveTerm.executive.email,
+      phoneNumber: executiveTerm.executive.user?.phoneNumber ?? null,
+      startTerm: executiveTerm.startTerm,
+      endTerm: executiveTerm.endTerm,
+    }));
+  }
+
+  async selectExecutiveTermById(executiveTId: number) {
+    return this.prisma.executiveT.findFirst({
+      where: {
+        id: executiveTId,
+        deletedAt: null,
+        executive: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        executive: {
+          select: {
+            studentId: true,
+          },
+        },
+      },
+    });
+  }
+
+  async updateExecutiveTerm(
+    executiveTId: number,
+    startTerm: Date,
+    endTerm: Date | null,
+  ) {
+    const result = await this.prisma.executiveT.updateMany({
+      where: { id: executiveTId, deletedAt: null },
+      data: {
+        startTerm,
+        endTerm,
+      },
+    });
+    return result.count > 0;
   }
 
   async deleteExecutiveById(executiveId: number) {

--- a/packages/api/src/feature/user/repository/user.repository.spec.ts
+++ b/packages/api/src/feature/user/repository/user.repository.spec.ts
@@ -1,0 +1,116 @@
+import UserRepository from "./user.repository";
+
+describe("UserRepository", () => {
+  describe("findStudentByStudentNumberNameDate", () => {
+    it("finds students with prisma query and maps them to the shape used by user service", async () => {
+      const prisma = {
+        student: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 1,
+              userId: 2,
+              email: "student@kaist.ac.kr",
+            },
+          ]),
+        },
+      };
+      const repository = new UserRepository(
+        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+      const endTerm = new Date("2025-03-31T14:59:00.000Z");
+
+      const result = await repository.findStudentByStudentNumberNameDate(
+        "20201234",
+        "홍길동",
+        startTerm,
+        endTerm,
+      );
+
+      expect(prisma.student.findMany).toHaveBeenCalledWith({
+        where: {
+          number: 20201234,
+          name: "홍길동",
+          deletedAt: null,
+          studentTs: {
+            some: {
+              deletedAt: null,
+              startTerm: { lte: startTerm },
+              OR: [{ endTerm: { gte: endTerm } }, { endTerm: null }],
+            },
+          },
+        },
+        select: {
+          id: true,
+          userId: true,
+          email: true,
+        },
+      });
+      expect(result).toEqual([
+        {
+          student: {
+            id: 1,
+            userId: 2,
+            email: "student@kaist.ac.kr",
+          },
+        },
+      ]);
+    });
+
+    it("returns empty results for invalid student numbers", async () => {
+      const prisma = {
+        student: {
+          findMany: jest.fn(),
+        },
+      };
+      const repository = new UserRepository(
+        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+      const endTerm = new Date("2025-03-31T14:59:00.000Z");
+
+      const result = await repository.findStudentByStudentNumberNameDate(
+        "invalid",
+        "홍길동",
+        startTerm,
+        endTerm,
+      );
+
+      expect(prisma.student.findMany).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("uses the start date as the student term boundary when end date is null", async () => {
+      const prisma = {
+        student: {
+          findMany: jest.fn().mockResolvedValue([]),
+        },
+      };
+      const repository = new UserRepository(
+        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+
+      await repository.findStudentByStudentNumberNameDate(
+        "20201234",
+        "홍길동",
+        startTerm,
+        null,
+      );
+
+      expect(prisma.student.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            studentTs: {
+              some: {
+                deletedAt: null,
+                startTerm: { lte: startTerm },
+                OR: [{ endTerm: { gte: startTerm } }, { endTerm: null }],
+              },
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/packages/api/src/feature/user/repository/user.repository.spec.ts
+++ b/packages/api/src/feature/user/repository/user.repository.spec.ts
@@ -57,28 +57,31 @@ describe("UserRepository", () => {
       ]);
     });
 
-    it("returns empty results for invalid student numbers", async () => {
-      const prisma = {
-        student: {
-          findMany: jest.fn(),
-        },
-      };
-      const repository = new UserRepository(
-        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
-      );
-      const startTerm = new Date("2025-02-28T15:00:00.000Z");
-      const endTerm = new Date("2025-03-31T14:59:00.000Z");
+    it.each(["invalid", "20201234foo"])(
+      "returns empty results for invalid student numbers: %s",
+      async studentNumber => {
+        const prisma = {
+          student: {
+            findMany: jest.fn(),
+          },
+        };
+        const repository = new UserRepository(
+          prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+        );
+        const startTerm = new Date("2025-02-28T15:00:00.000Z");
+        const endTerm = new Date("2025-03-31T14:59:00.000Z");
 
-      const result = await repository.findStudentByStudentNumberNameDate(
-        "invalid",
-        "홍길동",
-        startTerm,
-        endTerm,
-      );
+        const result = await repository.findStudentByStudentNumberNameDate(
+          studentNumber,
+          "홍길동",
+          startTerm,
+          endTerm,
+        );
 
-      expect(prisma.student.findMany).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
-    });
+        expect(prisma.student.findMany).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+      },
+    );
 
     it("uses the start date as the student term boundary when end date is null", async () => {
       const prisma = {
@@ -148,20 +151,24 @@ describe("UserRepository", () => {
       expect(result).toEqual(student);
     });
 
-    it("returns null for invalid student numbers", async () => {
-      const prisma = {
-        student: {
-          findFirst: jest.fn(),
-        },
-      };
-      const repository = new UserRepository(
-        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
-      );
+    it.each(["invalid", "20201234foo"])(
+      "returns null for invalid student numbers: %s",
+      async studentNumber => {
+        const prisma = {
+          student: {
+            findFirst: jest.fn(),
+          },
+        };
+        const repository = new UserRepository(
+          prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+        );
 
-      const result = await repository.findStudentByStudentNumber("invalid");
+        const result =
+          await repository.findStudentByStudentNumber(studentNumber);
 
-      expect(prisma.student.findFirst).not.toHaveBeenCalled();
-      expect(result).toBeNull();
-    });
+        expect(prisma.student.findFirst).not.toHaveBeenCalled();
+        expect(result).toBeNull();
+      },
+    );
   });
 });

--- a/packages/api/src/feature/user/repository/user.repository.spec.ts
+++ b/packages/api/src/feature/user/repository/user.repository.spec.ts
@@ -113,4 +113,55 @@ describe("UserRepository", () => {
       );
     });
   });
+
+  describe("findStudentByStudentNumber", () => {
+    it("finds a student by student number for detailed validation", async () => {
+      const student = {
+        id: 1,
+        userId: 2,
+        email: "student@kaist.ac.kr",
+        name: "홍길동",
+      };
+      const prisma = {
+        student: {
+          findFirst: jest.fn().mockResolvedValue(student),
+        },
+      };
+      const repository = new UserRepository(
+        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+      );
+
+      const result = await repository.findStudentByStudentNumber("20201234");
+
+      expect(prisma.student.findFirst).toHaveBeenCalledWith({
+        where: {
+          number: 20201234,
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          userId: true,
+          email: true,
+          name: true,
+        },
+      });
+      expect(result).toEqual(student);
+    });
+
+    it("returns null for invalid student numbers", async () => {
+      const prisma = {
+        student: {
+          findFirst: jest.fn(),
+        },
+      };
+      const repository = new UserRepository(
+        prisma as unknown as ConstructorParameters<typeof UserRepository>[0],
+      );
+
+      const result = await repository.findStudentByStudentNumber("invalid");
+
+      expect(prisma.student.findFirst).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/api/src/feature/user/repository/user.repository.ts
+++ b/packages/api/src/feature/user/repository/user.repository.ts
@@ -5,6 +5,13 @@ import logger from "@sparcs-clubs/api/common/util/logger";
 import { takeOne } from "@sparcs-clubs/api/common/util/util";
 import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
+const parseStudentNumber = (studentNumber: string) => {
+  if (!/^\d+$/.test(studentNumber)) {
+    return null;
+  }
+  return Number(studentNumber);
+};
+
 @Injectable()
 export default class UserRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -39,8 +46,8 @@ export default class UserRepository {
     startTerm: Date,
     endTerm: Date | null,
   ) {
-    const studentnumber = Number.parseInt(studentNumber);
-    if (Number.isNaN(studentnumber)) {
+    const studentnumber = parseStudentNumber(studentNumber);
+    if (studentnumber === null) {
       return [];
     }
 
@@ -74,8 +81,8 @@ export default class UserRepository {
   }
 
   async findStudentByStudentNumber(studentNumber: string) {
-    const studentnumber = Number.parseInt(studentNumber);
-    if (Number.isNaN(studentnumber)) {
+    const studentnumber = parseStudentNumber(studentNumber);
+    if (studentnumber === null) {
       return null;
     }
 

--- a/packages/api/src/feature/user/repository/user.repository.ts
+++ b/packages/api/src/feature/user/repository/user.repository.ts
@@ -36,21 +36,41 @@ export default class UserRepository {
   async findStudentByStudentNumberNameDate(
     studentNumber: string,
     name: string,
-    startTerm: string,
-    endTerm: string,
+    startTerm: Date,
+    endTerm: Date | null,
   ) {
-    const studentnumber = parseInt(studentNumber);
-    const user = await this.prisma.$queryRaw(Prisma.sql`
-      SELECT s.*, st.*
-      FROM student s
-      INNER JOIN student_t st ON st.student_id = s.id
-        AND DATE(st.start_term) <= ${startTerm}
-        AND (DATE(st.end_term) >= ${endTerm} OR st.end_term IS NULL)
-      WHERE s.number = ${studentnumber}
-        AND s.name = ${name}
-        AND s.deleted_at IS NULL
-    `);
-    return user;
+    const studentnumber = Number.parseInt(studentNumber);
+    if (Number.isNaN(studentnumber)) {
+      return [];
+    }
+
+    const targetEndTerm = endTerm ?? startTerm;
+    const users = await this.prisma.student.findMany({
+      where: {
+        number: studentnumber,
+        name,
+        deletedAt: null,
+        studentTs: {
+          some: {
+            deletedAt: null,
+            startTerm: { lte: startTerm },
+            OR: [{ endTerm: { gte: targetEndTerm } }, { endTerm: null }],
+          },
+        },
+      },
+      select: {
+        id: true,
+        userId: true,
+        email: true,
+      },
+    });
+    return users.map(user => ({
+      student: {
+        id: user.id,
+        userId: user.userId,
+        email: user.email,
+      },
+    }));
   }
 
   async create(studentId: number) {

--- a/packages/api/src/feature/user/repository/user.repository.ts
+++ b/packages/api/src/feature/user/repository/user.repository.ts
@@ -73,6 +73,26 @@ export default class UserRepository {
     }));
   }
 
+  async findStudentByStudentNumber(studentNumber: string) {
+    const studentnumber = Number.parseInt(studentNumber);
+    if (Number.isNaN(studentnumber)) {
+      return null;
+    }
+
+    return this.prisma.student.findFirst({
+      where: {
+        number: studentnumber,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        userId: true,
+        email: true,
+        name: true,
+      },
+    });
+  }
+
   async create(studentId: number) {
     const user = await this.prisma.$queryRaw(Prisma.sql`
       SELECT s.*, u.*

--- a/packages/api/src/feature/user/service/user.service.spec.ts
+++ b/packages/api/src/feature/user/service/user.service.spec.ts
@@ -4,6 +4,12 @@ describe("UserService", () => {
   describe("createExecutive", () => {
     it("passes incoming dates through to prisma-backed repositories", async () => {
       const userRepository = {
+        findStudentByStudentNumber: jest.fn().mockResolvedValue({
+          id: 1,
+          userId: 2,
+          email: "student@kaist.ac.kr",
+          name: "홍길동",
+        }),
         findStudentByStudentNumberNameDate: jest.fn().mockResolvedValue([
           {
             student: {
@@ -53,6 +59,121 @@ describe("UserService", () => {
         startTerm,
         null,
       );
+    });
+
+    it("reports when a student number does not exist", async () => {
+      const userRepository = {
+        findStudentByStudentNumber: jest.fn().mockResolvedValue(null),
+        findStudentByStudentNumberNameDate: jest.fn(),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.createExecutive(10, {
+          studentNumber: "20201234",
+          name: "홍길동",
+          startTerm: new Date("2025-02-28T15:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        message: "해당 학번의 학생을 찾을 수 없습니다.",
+        status: 400,
+      });
+      expect(
+        userRepository.findStudentByStudentNumberNameDate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reports when student number and name do not match", async () => {
+      const userRepository = {
+        findStudentByStudentNumber: jest.fn().mockResolvedValue({
+          id: 1,
+          userId: 2,
+          email: "student@kaist.ac.kr",
+          name: "김철수",
+        }),
+        findStudentByStudentNumberNameDate: jest.fn(),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.createExecutive(10, {
+          studentNumber: "20201234",
+          name: "홍길동",
+          startTerm: new Date("2025-02-28T15:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        message: "학번과 이름이 일치하지 않습니다.",
+        status: 400,
+      });
+      expect(
+        userRepository.findStudentByStudentNumberNameDate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reports when the requested start date is outside the student term", async () => {
+      const userRepository = {
+        findStudentByStudentNumber: jest.fn().mockResolvedValue({
+          id: 1,
+          userId: 2,
+          email: "student@kaist.ac.kr",
+          name: "홍길동",
+        }),
+        findStudentByStudentNumberNameDate: jest.fn().mockResolvedValue([]),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.createExecutive(10, {
+          studentNumber: "20201234",
+          name: "홍길동",
+          startTerm: new Date("2025-02-28T15:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        message: "집행부원 시작일이 해당 학생의 학적 기간과 겹치지 않습니다.",
+        status: 400,
+      });
     });
   });
 

--- a/packages/api/src/feature/user/service/user.service.spec.ts
+++ b/packages/api/src/feature/user/service/user.service.spec.ts
@@ -175,6 +175,89 @@ describe("UserService", () => {
         status: 400,
       });
     });
+
+    it("rejects non-executive users", async () => {
+      const userRepository = {
+        findStudentByStudentNumber: jest.fn(),
+        findStudentByStudentNumberNameDate: jest.fn(),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(false),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.createExecutive(10, {
+          studentNumber: "20201234",
+          name: "홍길동",
+          startTerm: new Date("2025-02-28T15:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        message: "권한이 없습니다.",
+        status: 403,
+      });
+      expect(userRepository.findStudentByStudentNumber).not.toHaveBeenCalled();
+    });
+
+    it("reports when an executive term already overlaps", async () => {
+      const userRepository = {
+        findStudentByStudentNumber: jest.fn().mockResolvedValue({
+          id: 1,
+          userId: 2,
+          email: "student@kaist.ac.kr",
+          name: "홍길동",
+        }),
+        findStudentByStudentNumberNameDate: jest.fn().mockResolvedValue([
+          {
+            student: {
+              id: 1,
+              userId: 2,
+              email: "student@kaist.ac.kr",
+            },
+          },
+        ]),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        checkExistExecutiveByIdDate: jest.fn().mockResolvedValue(true),
+        createExecutive: jest.fn(),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.createExecutive(10, {
+          studentNumber: "20201234",
+          name: "홍길동",
+          startTerm: new Date("2025-02-28T15:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        message: "해당 기간에 이미 집행부원 임기가 존재합니다.",
+        status: 400,
+      });
+      expect(executiveRepository.createExecutive).not.toHaveBeenCalled();
+    });
   });
 
   describe("updateExecutiveTerm", () => {
@@ -222,6 +305,148 @@ describe("UserService", () => {
         startTerm,
         null,
       );
+    });
+
+    it("rejects non-executive users", async () => {
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(false),
+        selectExecutiveTermById: jest.fn(),
+      };
+      const service = new UserService(
+        {} as ConstructorParameters<typeof UserService>[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.updateExecutiveTerm(
+          10,
+          { executiveTId: 5 },
+          {
+            startTerm: new Date("2025-02-28T15:00:00.000Z"),
+            endTerm: null,
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: "권한이 없습니다.",
+        status: 403,
+      });
+      expect(
+        executiveRepository.selectExecutiveTermById,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid term ordering", async () => {
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        selectExecutiveTermById: jest.fn(),
+      };
+      const service = new UserService(
+        {} as ConstructorParameters<typeof UserService>[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.updateExecutiveTerm(
+          10,
+          { executiveTId: 5 },
+          {
+            startTerm: new Date("2025-03-31T14:59:00.000Z"),
+            endTerm: new Date("2025-02-28T15:00:00.000Z"),
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: "시작날짜는 종료날짜보다 이전이어야 합니다.",
+        status: 400,
+      });
+      expect(
+        executiveRepository.selectExecutiveTermById,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reports when the target executive term does not exist", async () => {
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        selectExecutiveTermById: jest.fn().mockResolvedValue(null),
+        checkExistExecutiveByIdDate: jest.fn(),
+      };
+      const service = new UserService(
+        {} as ConstructorParameters<typeof UserService>[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.updateExecutiveTerm(
+          10,
+          { executiveTId: 5 },
+          {
+            startTerm: new Date("2025-02-28T15:00:00.000Z"),
+            endTerm: null,
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: "집행부원 임기를 찾을 수 없습니다.",
+        status: 404,
+      });
+      expect(
+        executiveRepository.checkExistExecutiveByIdDate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reports when the updated term overlaps another term", async () => {
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        selectExecutiveTermById: jest.fn().mockResolvedValue({
+          id: 5,
+          executive: {
+            studentId: 1,
+          },
+        }),
+        checkExistExecutiveByIdDate: jest.fn().mockResolvedValue(true),
+        updateExecutiveTerm: jest.fn(),
+      };
+      const service = new UserService(
+        {} as ConstructorParameters<typeof UserService>[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+
+      await expect(
+        service.updateExecutiveTerm(
+          10,
+          { executiveTId: 5 },
+          {
+            startTerm: new Date("2025-02-28T15:00:00.000Z"),
+            endTerm: null,
+          },
+        ),
+      ).rejects.toMatchObject({
+        message: "수정하려는 기간이 같은 학생의 다른 집행부원 임기와 겹칩니다.",
+        status: 400,
+      });
+      expect(executiveRepository.updateExecutiveTerm).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/feature/user/service/user.service.spec.ts
+++ b/packages/api/src/feature/user/service/user.service.spec.ts
@@ -1,0 +1,106 @@
+import { UserService } from "./user.service";
+
+describe("UserService", () => {
+  describe("createExecutive", () => {
+    it("passes incoming dates through to prisma-backed repositories", async () => {
+      const userRepository = {
+        findStudentByStudentNumberNameDate: jest.fn().mockResolvedValue([
+          {
+            student: {
+              id: 1,
+              userId: 2,
+              email: "student@kaist.ac.kr",
+            },
+          },
+        ]),
+      };
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        checkExistExecutiveByIdDate: jest.fn().mockResolvedValue(false),
+        createExecutive: jest.fn().mockResolvedValue(true),
+      };
+      const service = new UserService(
+        userRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+
+      await service.createExecutive(10, {
+        studentNumber: "20201234",
+        name: "홍길동",
+        startTerm,
+      });
+
+      expect(
+        userRepository.findStudentByStudentNumberNameDate,
+      ).toHaveBeenCalledWith("20201234", "홍길동", startTerm, null);
+      expect(
+        executiveRepository.checkExistExecutiveByIdDate,
+      ).toHaveBeenCalledWith(1, startTerm, null);
+      expect(executiveRepository.createExecutive).toHaveBeenCalledWith(
+        1,
+        2,
+        "student@kaist.ac.kr",
+        "홍길동",
+        startTerm,
+        null,
+      );
+    });
+  });
+
+  describe("updateExecutiveTerm", () => {
+    it("passes nullable endTerm through to prisma-backed repositories", async () => {
+      const executiveRepository = {
+        findExecutiveByUserId: jest.fn().mockResolvedValue(true),
+        selectExecutiveTermById: jest.fn().mockResolvedValue({
+          id: 5,
+          executive: {
+            studentId: 1,
+          },
+        }),
+        checkExistExecutiveByIdDate: jest.fn().mockResolvedValue(false),
+        updateExecutiveTerm: jest.fn().mockResolvedValue(true),
+      };
+      const service = new UserService(
+        {} as ConstructorParameters<typeof UserService>[0],
+        {} as ConstructorParameters<typeof UserService>[1],
+        executiveRepository as unknown as ConstructorParameters<
+          typeof UserService
+        >[2],
+        {} as ConstructorParameters<typeof UserService>[3],
+        {} as ConstructorParameters<typeof UserService>[4],
+        {} as ConstructorParameters<typeof UserService>[5],
+      );
+      const startTerm = new Date("2025-02-28T15:00:00.000Z");
+
+      await service.updateExecutiveTerm(
+        10,
+        { executiveTId: 5 },
+        {
+          startTerm,
+          endTerm: null,
+        },
+      );
+
+      expect(executiveRepository.selectExecutiveTermById).toHaveBeenCalledWith(
+        5,
+      );
+      expect(
+        executiveRepository.checkExistExecutiveByIdDate,
+      ).toHaveBeenCalledWith(1, startTerm, null, 5);
+      expect(executiveRepository.updateExecutiveTerm).toHaveBeenCalledWith(
+        5,
+        startTerm,
+        null,
+      );
+    });
+  });
+});

--- a/packages/api/src/feature/user/service/user.service.ts
+++ b/packages/api/src/feature/user/service/user.service.ts
@@ -1,8 +1,11 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
-import { format } from "date-fns";
 
 import { ApiUsr002ResponseOk } from "@clubs/interface/api/user/endpoint/apiUsr002";
 import { ApiUsr006RequestBody } from "@clubs/interface/api/user/endpoint/apiUsr006";
+import {
+  ApiUsr009RequestBody,
+  ApiUsr009RequestParam,
+} from "@clubs/interface/api/user/endpoint/apiUsr009";
 
 import ClubStudentTRepository from "@sparcs-clubs/api/feature/club/repository-old/club.club-student-t.repository";
 import UserRepository from "@sparcs-clubs/api/feature/user/repository/user.repository";
@@ -104,23 +107,13 @@ export class UserService {
     if (!(await this.executiveRepository.findExecutiveByUserId(userId))) {
       throw new HttpException("권한이 없습니다.", HttpStatus.FORBIDDEN);
     }
-    const startTermStr = format(body.startTerm, "yyyy-MM-dd");
-    // let endTermStr: string | null = null;
-    // if (body.endTerm) {
-    const endTermStr = format(body.endTerm, "yyyy-MM-dd");
-    if (startTermStr >= endTermStr) {
-      throw new HttpException(
-        "시작날짜는 종료날짜보다 이전이어야 합니다.",
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-    // }
+
     const studentRaw =
       await this.userRepository.findStudentByStudentNumberNameDate(
         body.studentNumber,
         body.name,
-        startTermStr,
-        endTermStr,
+        body.startTerm,
+        null,
       );
     const student =
       Array.isArray(studentRaw) && studentRaw.length === 1
@@ -132,8 +125,8 @@ export class UserService {
     if (
       await this.executiveRepository.checkExistExecutiveByIdDate(
         student.student.id,
-        startTermStr,
-        endTermStr,
+        body.startTerm,
+        null,
       )
     ) {
       throw new HttpException(
@@ -147,8 +140,8 @@ export class UserService {
         student.student.userId,
         student.student.email,
         body.name,
-        startTermStr,
-        endTermStr,
+        body.startTerm,
+        null,
       ))
     ) {
       throw new HttpException(
@@ -156,6 +149,63 @@ export class UserService {
         HttpStatus.BAD_REQUEST,
       );
     }
+    return {};
+  }
+
+  async updateExecutiveTerm(
+    userId: number,
+    param: ApiUsr009RequestParam,
+    body: ApiUsr009RequestBody,
+  ) {
+    if (!(await this.executiveRepository.findExecutiveByUserId(userId))) {
+      throw new HttpException("권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+
+    if (body.endTerm !== null && body.startTerm >= body.endTerm) {
+      throw new HttpException(
+        "시작날짜는 종료날짜보다 이전이어야 합니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const executiveTerm =
+      await this.executiveRepository.selectExecutiveTermById(
+        param.executiveTId,
+      );
+    if (!executiveTerm) {
+      throw new HttpException(
+        "집행부원 임기를 찾을 수 없습니다.",
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    if (
+      await this.executiveRepository.checkExistExecutiveByIdDate(
+        executiveTerm.executive.studentId,
+        body.startTerm,
+        body.endTerm,
+        param.executiveTId,
+      )
+    ) {
+      throw new HttpException(
+        "이미 존재하는 집행부원입니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (
+      !(await this.executiveRepository.updateExecutiveTerm(
+        param.executiveTId,
+        body.startTerm,
+        body.endTerm,
+      ))
+    ) {
+      throw new HttpException(
+        "Failed to update executive term",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     return {};
   }
 

--- a/packages/api/src/feature/user/service/user.service.ts
+++ b/packages/api/src/feature/user/service/user.service.ts
@@ -108,10 +108,36 @@ export class UserService {
       throw new HttpException("권한이 없습니다.", HttpStatus.FORBIDDEN);
     }
 
+    const studentNumber = body.studentNumber.trim();
+    const name = body.name.trim();
+
+    if (!/^\d+$/.test(studentNumber)) {
+      throw new HttpException(
+        "학번은 숫자만 입력해주세요.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const studentByNumber =
+      await this.userRepository.findStudentByStudentNumber(studentNumber);
+    if (!studentByNumber) {
+      throw new HttpException(
+        "해당 학번의 학생을 찾을 수 없습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (studentByNumber.name !== name) {
+      throw new HttpException(
+        "학번과 이름이 일치하지 않습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     const studentRaw =
       await this.userRepository.findStudentByStudentNumberNameDate(
-        body.studentNumber,
-        body.name,
+        studentNumber,
+        name,
         body.startTerm,
         null,
       );
@@ -120,7 +146,10 @@ export class UserService {
         ? studentRaw[0]
         : null;
     if (!student) {
-      throw new HttpException("잘못된 입력입니다.", HttpStatus.BAD_REQUEST);
+      throw new HttpException(
+        "집행부원 시작일이 해당 학생의 학적 기간과 겹치지 않습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
     }
     if (
       await this.executiveRepository.checkExistExecutiveByIdDate(
@@ -130,7 +159,7 @@ export class UserService {
       )
     ) {
       throw new HttpException(
-        "이미 존재하는 집행부원입니다.",
+        "해당 기간에 이미 집행부원 임기가 존재합니다.",
         HttpStatus.BAD_REQUEST,
       );
     }
@@ -139,7 +168,7 @@ export class UserService {
         student.student.id,
         student.student.userId,
         student.student.email,
-        body.name,
+        name,
         body.startTerm,
         null,
       ))
@@ -188,7 +217,7 @@ export class UserService {
       )
     ) {
       throw new HttpException(
-        "이미 존재하는 집행부원입니다.",
+        "수정하려는 기간이 같은 학생의 다른 집행부원 임기와 겹칩니다.",
         HttpStatus.BAD_REQUEST,
       );
     }

--- a/packages/interface/src/api/user/endpoint/apiUsr006.ts
+++ b/packages/interface/src/api/user/endpoint/apiUsr006.ts
@@ -20,7 +20,6 @@ const requestBody = z.object({
   studentNumber: zExecutive.shape.studentNumber,
   name: zExecutive.shape.name,
   startTerm: z.coerce.date(),
-  endTerm: z.coerce.date(),
 });
 
 const responseBodyMap = {
@@ -60,13 +59,12 @@ registry.registerPath({
   summary: "USR-006: 집행부원 추가",
   description: `
 		집행부원을 추가하는 API입니다.
-		1. 집행부원은 학번, 이름, 시작날짜, 종료날짜로 식별됩니다.
-		2. 이름과 학번이 매칭되지 않는 경우 에러를 반환합니다.
-		3. 시작날짜와 종료날짜는 반드시 지정되어야 합니다.
-    4. 시작날짜는 종료날짜보다 이전이어야 합니다.
-    5. 기존에 존재하는 집행부원의 startTerm, endTerm과 추가하는 집행부원의 startTerm, endTerm이 겹치면 에러를 반환합니다.
-    6. student, studentT 테이블에서 학생을 먼저 찾고 추가하기 때문에 studentT의 한개의 row에 있는 startTerm, endTerm 단위 내에 추가하려는 startTerm, endTerm이 존재해야 합니다.
-	`,
+			1. 집행부원은 학번, 이름, 시작날짜로 추가됩니다.
+			2. 이름과 학번이 매칭되지 않는 경우 에러를 반환합니다.
+			3. 시작날짜는 반드시 지정되어야 합니다.
+	    4. 기존에 존재하는 집행부원의 임기와 추가하는 집행부원의 시작날짜 이후 임기가 겹치면 에러를 반환합니다.
+	    5. student, studentT 테이블에서 학생을 먼저 찾고 추가하기 때문에 studentT의 한개의 row에 있는 startTerm, endTerm 단위 내에 추가하려는 startTerm이 존재해야 합니다.
+		`,
   request: {
     body: {
       content: {

--- a/packages/interface/src/api/user/endpoint/apiUsr006.ts
+++ b/packages/interface/src/api/user/endpoint/apiUsr006.ts
@@ -64,7 +64,8 @@ registry.registerPath({
 			3. 시작날짜는 반드시 지정되어야 합니다.
 	    4. 기존에 존재하는 집행부원의 임기와 추가하는 집행부원의 시작날짜 이후 임기가 겹치면 에러를 반환합니다.
 	    5. student, studentT 테이블에서 학생을 먼저 찾고 추가하기 때문에 studentT의 한개의 row에 있는 startTerm, endTerm 단위 내에 추가하려는 startTerm이 존재해야 합니다.
-		`,
+	    6. 학번 형식 오류, 존재하지 않는 학번, 학번/이름 불일치, 학적 기간 불일치는 각각 다른 에러 메시지를 반환합니다.
+			`,
   request: {
     body: {
       content: {

--- a/packages/interface/src/api/user/endpoint/apiUsr007.ts
+++ b/packages/interface/src/api/user/endpoint/apiUsr007.ts
@@ -23,13 +23,14 @@ const responseBodyMap = {
     executives: z.array(
       z.object({
         id: zExecutive.shape.id,
-        userId: zExecutive.shape.userId,
-        studentNumber: zExecutive.shape.studentNumber,
+        executiveTId: z.coerce.number().int().min(1),
+        userId: zExecutive.shape.userId.nullable(),
+        studentNumber: z.coerce.string(),
         name: zExecutive.shape.name,
-        email: zExecutive.shape.email,
-        phoneNumber: zExecutive.shape.phoneNumber,
+        email: zExecutive.shape.email.nullable(),
+        phoneNumber: zExecutive.shape.phoneNumber.nullable(),
         startTerm: z.coerce.date(),
-        endTerm: z.coerce.date(),
+        endTerm: z.coerce.date().nullable(),
       }),
     ),
   }),
@@ -67,7 +68,7 @@ registry.registerPath({
   description: `
 		집행부원 목록을 조회하는 API입니다.
 		1. 현재 날짜 기준으로 유효한 모든 집행부원의 정보를 반환합니다.
-		2. id, userId, 학번, 이름, 이메일, 전화번호, 시작날짜, 종료날짜가 포함됩니다.
+			2. id, executiveTId, userId, 학번, 이름, 이메일, 전화번호, 시작날짜, 종료날짜가 포함됩니다.
     3. userId가 없는 집행부원의 경우 조회되지 않습니다.
 	`,
   request: {},

--- a/packages/interface/src/api/user/endpoint/apiUsr009.ts
+++ b/packages/interface/src/api/user/endpoint/apiUsr009.ts
@@ -1,0 +1,90 @@
+import { HttpStatusCode } from "axios";
+import { z } from "zod";
+
+import { registry } from "@clubs/interface/open-api";
+
+/**
+ * @version v0.1
+ * @description 집행부원 임기 시작/종료일을 수정합니다.
+ */
+
+const url = (executiveTId: number) =>
+  `/executive/user/executives/${executiveTId}`;
+const method = "PUT";
+
+const requestParam = z.object({
+  executiveTId: z.coerce.number().int().min(1),
+});
+
+const requestQuery = z.object({});
+
+const requestBody = z.object({
+  startTerm: z.coerce.date(),
+  endTerm: z.coerce.date().nullable(),
+});
+
+const responseBodyMap = {
+  [HttpStatusCode.Ok]: z.object({}),
+};
+
+const responseErrorMap = {};
+
+export const apiUsr009 = {
+  url,
+  method,
+  requestParam,
+  requestQuery,
+  requestBody,
+  responseBodyMap,
+  responseErrorMap,
+};
+
+type ApiUsr009RequestParam = z.infer<typeof apiUsr009.requestParam>;
+type ApiUsr009RequestQuery = z.infer<typeof apiUsr009.requestQuery>;
+type ApiUsr009RequestBody = z.infer<typeof apiUsr009.requestBody>;
+type ApiUsr009ResponseOk = z.infer<(typeof apiUsr009.responseBodyMap)[200]>;
+
+export type {
+  ApiUsr009RequestParam,
+  ApiUsr009RequestQuery,
+  ApiUsr009RequestBody,
+  ApiUsr009ResponseOk,
+};
+
+registry.registerPath({
+  tags: ["executive"],
+  method: "put",
+  path: "/executive/user/executives/:executiveTId",
+  summary: "USR-009: 집행부원 임기 수정하기",
+  description: `
+    집행부원 임기의 시작/종료일을 수정합니다.
+    1. 수정하려는 집행부원 임기가 존재해야 합니다.
+    2. 종료날짜는 비워둘 수 있습니다.
+    3. 종료날짜가 있는 경우 시작날짜는 종료날짜보다 이전이어야 합니다.
+    4. 같은 학생의 다른 집행부원 임기와 겹치면 에러를 반환합니다.
+  `,
+  request: {
+    params: apiUsr009.requestParam,
+    body: {
+      content: {
+        "application/json": {
+          schema: apiUsr009.requestBody,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "성공적으로 집행부원 임기를 수정했습니다.",
+    },
+    400: {
+      description: "잘못된 요청입니다.",
+    },
+    403: {
+      description: "권한이 없습니다.",
+    },
+    404: {
+      description: "존재하지 않는 집행부원 임기입니다.",
+    },
+  },
+});

--- a/packages/interface/src/api/user/endpoint/index.ts
+++ b/packages/interface/src/api/user/endpoint/index.ts
@@ -3,6 +3,7 @@ import { registry } from "@clubs/interface/open-api";
 export * from "./apiUsr006";
 export * from "./apiUsr007";
 export * from "./apiUsr008";
+export * from "./apiUsr009";
 
 registry.registerPath({
   tags: ["executive"],

--- a/packages/web/src/features/executive/components/ExecutiveMemberFormModal.tsx
+++ b/packages/web/src/features/executive/components/ExecutiveMemberFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import DateInput from "@sparcs-clubs/web/common/components/Forms/DateInput";
@@ -13,36 +13,75 @@ import {
 
 interface ExecutiveMemberData {
   id: number;
+  executiveTId: number;
   studentNumber: string;
   name: string;
   startTerm: Date;
-  endTerm: Date;
+  endTerm: Date | null;
+}
+
+interface ExecutiveMemberFormData {
+  executiveTId?: number;
+  studentNumber: string;
+  name: string;
+  startTerm: Date;
+  endTerm?: Date | null;
 }
 
 interface ExecutiveMemberFormModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (data: Omit<ExecutiveMemberData, "id">) => void;
+  onSave: (data: ExecutiveMemberFormData) => void;
+  initialData?: ExecutiveMemberData;
 }
 
 const ExecutiveMemberFormModal = ({
   isOpen,
   onClose,
   onSave,
+  initialData,
 }: ExecutiveMemberFormModalProps) => {
-  const [studentNumber, setStudentNumber] = useState("");
-  const [name, setName] = useState("");
-  const [startTerm, setStartTerm] = useState<Date | null>(null);
-  const [endTerm, setEndTerm] = useState<Date | null>(null);
+  const [studentNumber, setStudentNumber] = useState(
+    initialData?.studentNumber ?? "",
+  );
+  const [name, setName] = useState(initialData?.name ?? "");
+  const [startTerm, setStartTerm] = useState<Date | null>(
+    initialData?.startTerm ?? null,
+  );
+  const [endTerm, setEndTerm] = useState<Date | null>(
+    initialData?.endTerm ?? null,
+  );
+  const isEditing = initialData != null;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setStudentNumber(initialData?.studentNumber ?? "");
+    setName(initialData?.name ?? "");
+    setStartTerm(initialData?.startTerm ?? null);
+    setEndTerm(initialData?.endTerm ?? null);
+  }, [initialData, isOpen]);
+
+  const isTermRangeInvalid =
+    startTerm !== null && endTerm !== null && startTerm >= endTerm;
 
   const handleSave = () => {
-    if (studentNumber && name && startTerm && endTerm) {
-      onSave({
+    if (studentNumber && name && startTerm && !isTermRangeInvalid) {
+      const baseData = {
         studentNumber,
         name,
         startTerm: getLocalDateOnly(startTerm),
-        endTerm: getLocalDateLastTime(endTerm),
-      });
+      };
+
+      onSave(
+        isEditing
+          ? {
+              ...baseData,
+              executiveTId: initialData.executiveTId,
+              endTerm: endTerm === null ? null : getLocalDateLastTime(endTerm),
+            }
+          : baseData,
+      );
       onClose();
     }
   };
@@ -55,12 +94,15 @@ const ExecutiveMemberFormModal = ({
         confirmButtonText="저장"
         closeButtonText="취소"
         confirmDisabled={
-          !studentNumber.trim() || !name.trim() || !startTerm || !endTerm
+          !studentNumber.trim() ||
+          !name.trim() ||
+          !startTerm ||
+          isTermRangeInvalid
         }
       >
         <FlexWrapper direction="column" gap={20} style={{ width: "400px" }}>
           <Typography fs={18} lh={24} fw="MEDIUM">
-            새 집행부원 추가
+            {isEditing ? "집행부원 임기 수정" : "새 집행부원 추가"}
           </Typography>
 
           <TextInput
@@ -68,6 +110,7 @@ const ExecutiveMemberFormModal = ({
             placeholder="학번을 입력해주세요"
             value={studentNumber}
             onChange={e => setStudentNumber(e.target.value)}
+            disabled={isEditing}
           />
 
           <TextInput
@@ -75,6 +118,7 @@ const ExecutiveMemberFormModal = ({
             placeholder="이름을 입력해주세요"
             value={name}
             onChange={e => setName(e.target.value)}
+            disabled={isEditing}
           />
 
           <DateInput
@@ -83,16 +127,23 @@ const ExecutiveMemberFormModal = ({
             onChange={(date: Date | null) => setStartTerm(date)}
           />
 
-          <DateInput
-            label="종료일"
-            selected={endTerm}
-            onChange={(date: Date | null) => setEndTerm(date)}
-          />
+          {isEditing && (
+            <DateInput
+              label="종료일"
+              selected={endTerm}
+              onChange={(date: Date | null) => setEndTerm(date)}
+              isClearable
+            />
+          )}
         </FlexWrapper>
       </CancellableModalContent>
     </Modal>
   );
 };
 
-export type { ExecutiveMemberData, ExecutiveMemberFormModalProps };
+export type {
+  ExecutiveMemberData,
+  ExecutiveMemberFormData,
+  ExecutiveMemberFormModalProps,
+};
 export default ExecutiveMemberFormModal;

--- a/packages/web/src/features/executive/components/ExecutiveMemberFormModal.tsx
+++ b/packages/web/src/features/executive/components/ExecutiveMemberFormModal.tsx
@@ -63,7 +63,7 @@ const ExecutiveMemberFormModal = ({
   }, [initialData, isOpen]);
 
   const isTermRangeInvalid =
-    startTerm !== null && endTerm !== null && startTerm >= endTerm;
+    startTerm !== null && endTerm !== null && startTerm > endTerm;
 
   const handleSave = () => {
     if (studentNumber && name && startTerm && !isTermRangeInvalid) {

--- a/packages/web/src/features/executive/frames/ManageMemberFrame.tsx
+++ b/packages/web/src/features/executive/frames/ManageMemberFrame.tsx
@@ -10,23 +10,30 @@ import { useMemo } from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import Table from "@sparcs-clubs/web/common/components/Table";
 
 import ExecutiveMemberFormModal, {
   ExecutiveMemberData,
+  ExecutiveMemberFormData,
 } from "../components/ExecutiveMemberFormModal";
 import useDeleteExecutiveMember from "../services/deleteExecutiveMember";
 import useGetExecutiveMembers from "../services/getExecutiveMembers";
 import usePostExecutiveMember from "../services/postExecutiveMember";
+import usePutExecutiveMember from "../services/putExecutiveMember";
 
 const openExecutiveMemberModal = (
-  onSave: (data: Omit<ExecutiveMemberData, "id">) => void,
+  onSave: (data: ExecutiveMemberFormData) => void,
+  initialData?: ExecutiveMemberData,
 ) => {
   overlay.open(({ isOpen, close }) => (
-    <ExecutiveMemberFormModal isOpen={isOpen} onClose={close} onSave={onSave} />
+    <ExecutiveMemberFormModal
+      isOpen={isOpen}
+      onClose={close}
+      onSave={onSave}
+      initialData={initialData}
+    />
   ));
 };
 
@@ -34,6 +41,7 @@ const ManageMemberFrame = () => {
   const { data, isLoading, isError } = useGetExecutiveMembers();
 
   const postExecutiveMember = usePostExecutiveMember();
+  const putExecutiveMember = usePutExecutiveMember();
   const deleteExecutiveMember = useDeleteExecutiveMember();
 
   const sortedMembers = useMemo(() => {
@@ -43,15 +51,26 @@ const ManageMemberFrame = () => {
     );
   }, [data?.executives]);
 
-  const handleAddExecutiveMember = (
-    member: Omit<ExecutiveMemberData, "id">,
-  ) => {
+  const handleAddExecutiveMember = (member: ExecutiveMemberFormData) => {
     postExecutiveMember.mutate({
       body: {
         name: member.name,
         studentNumber: member.studentNumber,
         startTerm: member.startTerm,
-        endTerm: member.endTerm,
+      },
+    });
+  };
+
+  const handleEditExecutiveMember = (member: ExecutiveMemberFormData) => {
+    if (member.executiveTId === undefined) return;
+
+    putExecutiveMember.mutate({
+      param: {
+        executiveTId: member.executiveTId,
+      },
+      body: {
+        startTerm: member.startTerm,
+        endTerm: member.endTerm ?? null,
       },
     });
   };
@@ -69,12 +88,31 @@ const ManageMemberFrame = () => {
 
   const columnHelper = createColumnHelper<ExecutiveMemberData>();
 
-  const actionsCellRenderer = (id: number) => (
-    <TextButton
-      text="삭제"
-      onClick={() => handleDeleteExecutiveMember(id)}
-      disabled={deleteExecutiveMember.isPending}
-    />
+  const actionsCellRenderer = (member: ExecutiveMemberData) => (
+    <FlexWrapper direction="row" gap={8}>
+      <Button
+        type={putExecutiveMember.isPending ? "disabled" : "outlined"}
+        style={{ padding: "6px 10px", fontSize: 14, lineHeight: "18px" }}
+        onClick={event => {
+          event.preventDefault();
+          event.stopPropagation();
+          openExecutiveMemberModal(handleEditExecutiveMember, member);
+        }}
+      >
+        수정
+      </Button>
+      <Button
+        type={deleteExecutiveMember.isPending ? "disabled" : "outlined"}
+        style={{ padding: "6px 10px", fontSize: 14, lineHeight: "18px" }}
+        onClick={event => {
+          event.preventDefault();
+          event.stopPropagation();
+          handleDeleteExecutiveMember(member.id);
+        }}
+      >
+        삭제
+      </Button>
+    </FlexWrapper>
   );
 
   const columns = [
@@ -106,23 +144,22 @@ const ManageMemberFrame = () => {
     }),
     columnHelper.accessor("endTerm", {
       header: "종료일",
-      cell: info =>
-        info.getValue()
-          ? formatInTimeZone(
-              info.getValue(),
-              "Asia/Seoul",
-              "yyyy-MM-dd (ccc)",
-              { locale: ko },
-            )
-          : "-",
+      cell: info => {
+        const endTerm = info.getValue();
+        return endTerm
+          ? formatInTimeZone(endTerm, "Asia/Seoul", "yyyy-MM-dd (ccc)", {
+              locale: ko,
+            })
+          : "-";
+      },
       size: 150,
       enableSorting: false,
     }),
     columnHelper.display({
       id: "actions",
       header: "관리",
-      cell: ({ row }) => actionsCellRenderer(row.original.id),
-      size: 120,
+      cell: ({ row }) => actionsCellRenderer(row.original),
+      size: 140,
     }),
   ];
 

--- a/packages/web/src/features/executive/services/getExecutiveMembers.ts
+++ b/packages/web/src/features/executive/services/getExecutiveMembers.ts
@@ -14,7 +14,7 @@ const useGetExecutiveMembers = () =>
     queryFn: async (): Promise<ApiUsr007ResponseOk> => {
       const { data } = await axiosClientWithAuth.get(apiUsr007.url(), {});
 
-      return data;
+      return apiUsr007.responseBodyMap[200].parse(data);
     },
   });
 
@@ -27,13 +27,14 @@ defineAxiosMock(mock => {
       executives: [
         {
           id: 1,
+          executiveTId: 1,
           userId: 1,
           studentNumber: "201811111",
           name: "홍길동",
           email: "hong@gmail.com",
           phoneNumber: "01012345678",
           startTerm: "2025-03-01",
-          endTerm: "2025-06-30",
+          endTerm: null,
         },
       ],
     },

--- a/packages/web/src/features/executive/services/putExecutiveMember.ts
+++ b/packages/web/src/features/executive/services/putExecutiveMember.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import { apiUsr007 } from "@clubs/interface/api/user/endpoint/apiUsr007";
+import type {
+  ApiUsr009RequestBody,
+  ApiUsr009RequestParam,
+  ApiUsr009ResponseOk,
+} from "@clubs/interface/api/user/endpoint/apiUsr009";
+import { apiUsr009 } from "@clubs/interface/api/user/endpoint/apiUsr009";
+
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
+import { axiosClientWithAuth } from "@sparcs-clubs/web/lib/axios";
+
+const usePutExecutiveMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    ApiUsr009ResponseOk,
+    Error,
+    { param: ApiUsr009RequestParam; body: ApiUsr009RequestBody }
+  >({
+    mutationFn: async ({ param, body }): Promise<ApiUsr009ResponseOk> => {
+      const { data } = await axiosClientWithAuth.put(
+        apiUsr009.url(param.executiveTId),
+        body,
+      );
+
+      return apiUsr009.responseBodyMap[200].parse(data);
+    },
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: [apiUsr007.url()] });
+    },
+    onError: error => {
+      if (
+        error instanceof AxiosError &&
+        (error.response?.status === 400 ||
+          error.response?.status === 403 ||
+          error.response?.status === 404)
+      ) {
+        errorHandler(error.response?.data.message);
+        return;
+      }
+      errorHandler("집행부원 임기 수정에 실패하였습니다");
+    },
+  });
+};
+
+export default usePutExecutiveMember;


### PR DESCRIPTION
## Summary
- replace executive member lookup/overlap/create flows with Prisma queries
- make executive creation open-ended and add executive term update API/UI
- fix executive list response parsing for nullable fields and numeric student numbers

## Tests
- pnpm --filter=@clubs/interface build
- NODE_ENV=local SERVER_PORT=3000 SECRET_KEY=test DATABASE_URL=mysql://test:test@localhost:3306/test pnpm --filter=api exec jest --config ./test/jest-unit.json --runTestsByPath src/feature/user/service/user.service.spec.ts src/feature/user/repository/user.repository.spec.ts src/feature/user/repository/executive.repository.spec.ts
- pnpm --filter=api build
- pnpm --filter=web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit executive member term dates from the management UI (save nullable end date).
  * Added dedicated "Edit" and "Delete" buttons for each executive member.

* **Improvements**
  * Creation flow no longer requires an end date; start-date-only creation supported.
  * Executive list shows clearer term information and includes stable IDs for edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->