### PR TITLE
fix: pin docker node alpine image

### DIFF
--- a/.docker/dockerfile/api.Dockerfile
+++ b/.docker/dockerfile/api.Dockerfile
@@ -1,7 +1,7 @@
 # 시험공부하기 싫은 hama@sparcs.org의 빌드 개조
 # turbo 편하네요
 
-FROM node:22-alpine AS base
+FROM node:22.22.1-alpine AS base
 
 
 

--- a/.docker/dockerfile/web.bundle.production.Dockerfile
+++ b/.docker/dockerfile/web.bundle.production.Dockerfile
@@ -3,7 +3,7 @@
 # 참고자료
 # - https://hanyunseong-log.dev/post/build-and-run-nextjs-monorepo-with-docker
 
-FROM node:22-alpine AS base
+FROM node:22.22.1-alpine AS base
 
 
 

--- a/.docker/dockerfile/web.bundle.stage.Dockerfile
+++ b/.docker/dockerfile/web.bundle.stage.Dockerfile
@@ -3,7 +3,7 @@
 # 참고자료
 # - https://hanyunseong-log.dev/post/build-and-run-nextjs-monorepo-with-docker
 
-FROM node:22-alpine AS base
+FROM node:22.22.1-alpine AS base
 
 
 


### PR DESCRIPTION
## Summary
- Pin Docker base images from `node:22-alpine` to `node:22.22.1-alpine` for API, stage web, and production web builds.
- Keep `useNodeVersion: 22.22.1` intact so pnpm workspace settings continue to enforce the intended Node version.
- Fix the staging Docker build failure from https://github.com/sparcs-kaist/clubs/actions/runs/25954681686, where `node:22-alpine` did not satisfy the exact pnpm-managed Node version and pnpm attempted to fetch Node on MUSL.

## Verification
- `docker run --rm node:22.22.1-alpine node -v` -> `v22.22.1`
- API Docker builder completed successfully with the pinned image and no `useNodeVersion` mutation.
- PR CI passed before the final sed removal; checks are rerunning for this amended commit.