### PR TITLE
[TU-412] fix: 활동보고서 미래 활동 기간 제출 방지

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { APP_GUARD } from "@nestjs/core";
 
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
+import { ClockModule } from "./common/clock/clock.module";
 import ActivityModule from "./feature/activity/activity.module";
 import { ActivityCertificateModule } from "./feature/activity-certificate/activity-certificate.module";
 import { AuthModule } from "./feature/auth/auth.module";
@@ -23,6 +24,7 @@ import { PrismaModule } from "./prisma/prisma.module";
   imports: [
     // Database ORM Module
     PrismaModule,
+    ClockModule,
 
     // Feature Modules
     ActivityModule,

--- a/packages/api/src/common/clock/clock.module.ts
+++ b/packages/api/src/common/clock/clock.module.ts
@@ -1,10 +1,11 @@
 import { Global, Module } from "@nestjs/common";
 
-import { ClockService } from "./clock.service";
+import { CLOCK } from "./clock";
+import { SystemClock } from "./system-clock";
 
 @Global()
 @Module({
-  providers: [ClockService],
-  exports: [ClockService],
+  providers: [{ provide: CLOCK, useClass: SystemClock }],
+  exports: [CLOCK],
 })
 export class ClockModule {}

--- a/packages/api/src/common/clock/clock.module.ts
+++ b/packages/api/src/common/clock/clock.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from "@nestjs/common";
+
+import { ClockService } from "./clock.service";
+
+@Global()
+@Module({
+  providers: [ClockService],
+  exports: [ClockService],
+})
+export class ClockModule {}

--- a/packages/api/src/common/clock/clock.service.ts
+++ b/packages/api/src/common/clock/clock.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class ClockService {
+  now(): Date {
+    return new Date();
+  }
+}

--- a/packages/api/src/common/clock/clock.ts
+++ b/packages/api/src/common/clock/clock.ts
@@ -2,4 +2,5 @@ export const CLOCK = Symbol("CLOCK");
 
 export interface Clock {
   now(): Date;
+  endOfToday(): Date;
 }

--- a/packages/api/src/common/clock/clock.ts
+++ b/packages/api/src/common/clock/clock.ts
@@ -1,0 +1,5 @@
+export const CLOCK = Symbol("CLOCK");
+
+export interface Clock {
+  now(): Date;
+}

--- a/packages/api/src/common/clock/system-clock.spec.ts
+++ b/packages/api/src/common/clock/system-clock.spec.ts
@@ -1,0 +1,23 @@
+import { SystemClock } from "./system-clock";
+
+describe("SystemClock", () => {
+  it("returns the end of the current service day", () => {
+    const clock = new SystemClock();
+
+    jest
+      .spyOn(clock, "now")
+      .mockReturnValue(new Date("2026-05-17T03:00:00.000Z"));
+
+    expect(clock.endOfToday()).toEqual(new Date("2026-05-17T14:59:59.999Z"));
+  });
+
+  it("uses the service day even when the UTC runtime date differs", () => {
+    const clock = new SystemClock();
+
+    jest
+      .spyOn(clock, "now")
+      .mockReturnValue(new Date("2026-05-17T16:00:00.000Z"));
+
+    expect(clock.endOfToday()).toEqual(new Date("2026-05-18T14:59:59.999Z"));
+  });
+});

--- a/packages/api/src/common/clock/system-clock.ts
+++ b/packages/api/src/common/clock/system-clock.ts
@@ -2,9 +2,29 @@ import { Injectable } from "@nestjs/common";
 
 import { Clock } from "./clock";
 
+const UTC_RUNTIME_TO_SERVICE_TIME_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 @Injectable()
 export class SystemClock implements Clock {
   now(): Date {
     return new Date();
+  }
+
+  endOfToday(): Date {
+    const serviceNow = new Date(
+      this.now().getTime() + UTC_RUNTIME_TO_SERVICE_TIME_OFFSET_MS,
+    );
+
+    return new Date(
+      Date.UTC(
+        serviceNow.getUTCFullYear(),
+        serviceNow.getUTCMonth(),
+        serviceNow.getUTCDate(),
+        14,
+        59,
+        59,
+        999,
+      ),
+    );
   }
 }

--- a/packages/api/src/common/clock/system-clock.ts
+++ b/packages/api/src/common/clock/system-clock.ts
@@ -1,7 +1,9 @@
 import { Injectable } from "@nestjs/common";
 
+import { Clock } from "./clock";
+
 @Injectable()
-export class ClockService {
+export class SystemClock implements Clock {
   now(): Date {
     return new Date();
   }

--- a/packages/api/src/feature/activity/activity.module.ts
+++ b/packages/api/src/feature/activity/activity.module.ts
@@ -15,6 +15,7 @@ import { ActivityCommentRepository } from "./repository/activity-comment.reposit
 import ActivityPublicService from "./service/activity.public.service";
 import ActivityOldService from "./service/activity.service";
 import ActivityService from "./service/activity.service.new";
+import { ActivityDurationValidatorService } from "./service/activity-duration.validator";
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import ActivityService from "./service/activity.service.new";
     ActivityNewRepository,
     ActivityClubChargedExecutiveRepository,
     ActivityCommentRepository,
+    ActivityDurationValidatorService,
   ],
   exports: [ActivityPublicService],
 })

--- a/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from "@nestjs/testing";
 
-import { ClockService } from "@sparcs-clubs/api/common/clock/clock.service";
+import { CLOCK, Clock } from "@sparcs-clubs/api/common/clock/clock";
 
 import {
   ACTIVITY_DURATION_FUTURE_ERROR,
@@ -19,11 +19,11 @@ describe("activity-duration.validator", () => {
   const createValidator = async (now: Date) => {
     const clockService = {
       now: jest.fn(() => now),
-    };
+    } satisfies Clock;
     const moduleRef = await Test.createTestingModule({
       providers: [
         ActivityDurationValidatorService,
-        { provide: ClockService, useValue: clockService },
+        { provide: CLOCK, useValue: clockService },
       ],
     }).compile();
 

--- a/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
@@ -6,6 +6,7 @@ import {
   ACTIVITY_DURATION_FUTURE_ERROR,
   ACTIVITY_DURATION_OUT_OF_TARGET_ERROR,
   ActivityDurationValidatorService,
+  getActivityDurationValidationError,
   getKstEndOfToday,
 } from "./activity-duration.validator";
 
@@ -44,10 +45,10 @@ describe("activity-duration.validator", () => {
       },
     ];
 
-    expect(validator.getValidationError(durations, activityD)).toBeNull();
     expect(() =>
-      validator.assertSubmittable(durations, activityD),
+      validator.getValidationError(durations, activityD),
     ).not.toThrow();
+    expect(validator.getValidationError(durations, activityD)).toBeNull();
     expect(clockService.now).toHaveBeenCalled();
   });
 
@@ -109,5 +110,20 @@ describe("activity-duration.validator", () => {
     expect(getKstEndOfToday(new Date("2026-05-17T03:00:00.000Z"))).toEqual(
       new Date("2026-05-17T14:59:59.999Z"),
     );
+  });
+
+  it("returns validation errors from the pure function without using DI", () => {
+    expect(
+      getActivityDurationValidationError(
+        [
+          {
+            startTerm: new Date("2026-05-17T00:00:00.000Z"),
+            endTerm: new Date("2026-05-18T14:59:00.000Z"),
+          },
+        ],
+        activityD,
+        new Date("2026-05-17T03:00:00.000Z"),
+      ),
+    ).toBe(ACTIVITY_DURATION_FUTURE_ERROR);
   });
 });

--- a/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
@@ -1,7 +1,11 @@
+import { Test } from "@nestjs/testing";
+
+import { ClockService } from "@sparcs-clubs/api/common/clock/clock.service";
+
 import {
   ACTIVITY_DURATION_FUTURE_ERROR,
   ACTIVITY_DURATION_OUT_OF_TARGET_ERROR,
-  getActivityDurationValidationError,
+  ActivityDurationValidatorService,
   getKstEndOfToday,
 } from "./activity-duration.validator";
 
@@ -11,23 +15,48 @@ describe("activity-duration.validator", () => {
     endTerm: new Date("2026-06-30T14:59:59.999Z"),
   };
 
-  it("allows durations ending today when the activity duration continues", () => {
-    const result = getActivityDurationValidationError(
-      [
-        {
-          startTerm: new Date("2026-05-17T00:00:00.000Z"),
-          endTerm: new Date("2026-05-17T14:59:00.000Z"),
-        },
+  const createValidator = async (now: Date) => {
+    const clockService = {
+      now: jest.fn(() => now),
+    };
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ActivityDurationValidatorService,
+        { provide: ClockService, useValue: clockService },
       ],
-      activityD,
+    }).compile();
+
+    return {
+      clockService,
+      validator: moduleRef.get(ActivityDurationValidatorService),
+    };
+  };
+
+  it("allows durations ending today when the activity duration continues", async () => {
+    const { clockService, validator } = await createValidator(
       new Date("2026-05-17T03:00:00.000Z"),
     );
 
-    expect(result).toBeNull();
+    const durations = [
+      {
+        startTerm: new Date("2026-05-17T00:00:00.000Z"),
+        endTerm: new Date("2026-05-17T14:59:00.000Z"),
+      },
+    ];
+
+    expect(validator.getValidationError(durations, activityD)).toBeNull();
+    expect(() =>
+      validator.assertSubmittable(durations, activityD),
+    ).not.toThrow();
+    expect(clockService.now).toHaveBeenCalled();
   });
 
-  it("rejects durations ending after today with a future-date message", () => {
-    const result = getActivityDurationValidationError(
+  it("rejects durations ending after today with a future-date message", async () => {
+    const { validator } = await createValidator(
+      new Date("2026-05-17T03:00:00.000Z"),
+    );
+
+    const result = validator.getValidationError(
       [
         {
           startTerm: new Date("2026-05-17T00:00:00.000Z"),
@@ -35,14 +64,17 @@ describe("activity-duration.validator", () => {
         },
       ],
       activityD,
-      new Date("2026-05-17T03:00:00.000Z"),
     );
 
     expect(result).toBe(ACTIVITY_DURATION_FUTURE_ERROR);
   });
 
-  it("keeps the target-duration message for dates outside ActivityD", () => {
-    const result = getActivityDurationValidationError(
+  it("keeps the target-duration message for dates outside ActivityD", async () => {
+    const { validator } = await createValidator(
+      new Date("2026-06-29T03:00:00.000Z"),
+    );
+
+    const result = validator.getValidationError(
       [
         {
           startTerm: new Date("2026-06-30T00:00:00.000Z"),
@@ -50,7 +82,24 @@ describe("activity-duration.validator", () => {
         },
       ],
       activityD,
-      new Date("2026-06-29T03:00:00.000Z"),
+    );
+
+    expect(result).toBe(ACTIVITY_DURATION_OUT_OF_TARGET_ERROR);
+  });
+
+  it("rejects reversed durations with the target-duration message", async () => {
+    const { validator } = await createValidator(
+      new Date("2026-05-17T03:00:00.000Z"),
+    );
+
+    const result = validator.getValidationError(
+      [
+        {
+          startTerm: new Date("2026-05-18T00:00:00.000Z"),
+          endTerm: new Date("2026-05-17T14:59:00.000Z"),
+        },
+      ],
+      activityD,
     );
 
     expect(result).toBe(ACTIVITY_DURATION_OUT_OF_TARGET_ERROR);

--- a/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
@@ -1,0 +1,64 @@
+import {
+  ACTIVITY_DURATION_FUTURE_ERROR,
+  ACTIVITY_DURATION_OUT_OF_TARGET_ERROR,
+  getActivityDurationValidationError,
+  getKstEndOfToday,
+} from "./activity-duration.validator";
+
+describe("activity-duration.validator", () => {
+  const activityD = {
+    startTerm: new Date("2026-03-01T00:00:00.000Z"),
+    endTerm: new Date("2026-06-30T14:59:59.999Z"),
+  };
+
+  it("allows durations ending today when the activity duration continues", () => {
+    const result = getActivityDurationValidationError(
+      [
+        {
+          startTerm: new Date("2026-05-17T00:00:00.000Z"),
+          endTerm: new Date("2026-05-17T14:59:00.000Z"),
+        },
+      ],
+      activityD,
+      new Date("2026-05-17T03:00:00.000Z"),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects durations ending after today with a future-date message", () => {
+    const result = getActivityDurationValidationError(
+      [
+        {
+          startTerm: new Date("2026-05-17T00:00:00.000Z"),
+          endTerm: new Date("2026-05-18T14:59:00.000Z"),
+        },
+      ],
+      activityD,
+      new Date("2026-05-17T03:00:00.000Z"),
+    );
+
+    expect(result).toBe(ACTIVITY_DURATION_FUTURE_ERROR);
+  });
+
+  it("keeps the target-duration message for dates outside ActivityD", () => {
+    const result = getActivityDurationValidationError(
+      [
+        {
+          startTerm: new Date("2026-06-30T00:00:00.000Z"),
+          endTerm: new Date("2026-07-01T14:59:00.000Z"),
+        },
+      ],
+      activityD,
+      new Date("2026-06-29T03:00:00.000Z"),
+    );
+
+    expect(result).toBe(ACTIVITY_DURATION_OUT_OF_TARGET_ERROR);
+  });
+
+  it("calculates the end of today in KST", () => {
+    expect(getKstEndOfToday(new Date("2026-05-17T03:00:00.000Z"))).toEqual(
+      new Date("2026-05-17T14:59:59.999Z"),
+    );
+  });
+});

--- a/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.spec.ts
@@ -7,7 +7,6 @@ import {
   ACTIVITY_DURATION_OUT_OF_TARGET_ERROR,
   ActivityDurationValidatorService,
   getActivityDurationValidationError,
-  getKstEndOfToday,
 } from "./activity-duration.validator";
 
 describe("activity-duration.validator", () => {
@@ -16,9 +15,10 @@ describe("activity-duration.validator", () => {
     endTerm: new Date("2026-06-30T14:59:59.999Z"),
   };
 
-  const createValidator = async (now: Date) => {
+  const createValidator = async (endOfToday: Date) => {
     const clockService = {
-      now: jest.fn(() => now),
+      now: jest.fn(() => new Date("2026-05-17T03:00:00.000Z")),
+      endOfToday: jest.fn(() => endOfToday),
     } satisfies Clock;
     const moduleRef = await Test.createTestingModule({
       providers: [
@@ -35,13 +35,13 @@ describe("activity-duration.validator", () => {
 
   it("allows durations ending today when the activity duration continues", async () => {
     const { clockService, validator } = await createValidator(
-      new Date("2026-05-17T03:00:00.000Z"),
+      new Date("2026-05-17T14:59:59.999Z"),
     );
 
     const durations = [
       {
         startTerm: new Date("2026-05-17T00:00:00.000Z"),
-        endTerm: new Date("2026-05-17T14:59:00.000Z"),
+        endTerm: new Date("2026-05-17T14:59:59.999Z"),
       },
     ];
 
@@ -49,12 +49,12 @@ describe("activity-duration.validator", () => {
       validator.getValidationError(durations, activityD),
     ).not.toThrow();
     expect(validator.getValidationError(durations, activityD)).toBeNull();
-    expect(clockService.now).toHaveBeenCalled();
+    expect(clockService.endOfToday).toHaveBeenCalled();
   });
 
   it("rejects durations ending after today with a future-date message", async () => {
     const { validator } = await createValidator(
-      new Date("2026-05-17T03:00:00.000Z"),
+      new Date("2026-05-17T14:59:59.999Z"),
     );
 
     const result = validator.getValidationError(
@@ -72,7 +72,7 @@ describe("activity-duration.validator", () => {
 
   it("keeps the target-duration message for dates outside ActivityD", async () => {
     const { validator } = await createValidator(
-      new Date("2026-06-29T03:00:00.000Z"),
+      new Date("2026-06-29T14:59:59.999Z"),
     );
 
     const result = validator.getValidationError(
@@ -90,7 +90,7 @@ describe("activity-duration.validator", () => {
 
   it("rejects reversed durations with the target-duration message", async () => {
     const { validator } = await createValidator(
-      new Date("2026-05-17T03:00:00.000Z"),
+      new Date("2026-05-17T14:59:59.999Z"),
     );
 
     const result = validator.getValidationError(
@@ -106,12 +106,6 @@ describe("activity-duration.validator", () => {
     expect(result).toBe(ACTIVITY_DURATION_OUT_OF_TARGET_ERROR);
   });
 
-  it("calculates the end of today in KST", () => {
-    expect(getKstEndOfToday(new Date("2026-05-17T03:00:00.000Z"))).toEqual(
-      new Date("2026-05-17T14:59:59.999Z"),
-    );
-  });
-
   it("returns validation errors from the pure function without using DI", () => {
     expect(
       getActivityDurationValidationError(
@@ -122,7 +116,7 @@ describe("activity-duration.validator", () => {
           },
         ],
         activityD,
-        new Date("2026-05-17T03:00:00.000Z"),
+        new Date("2026-05-17T14:59:59.999Z"),
       ),
     ).toBe(ACTIVITY_DURATION_FUTURE_ERROR);
   });

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -1,0 +1,64 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+
+export const ACTIVITY_DURATION_OUT_OF_TARGET_ERROR =
+  "Some duration is not in the last activity duration";
+export const ACTIVITY_DURATION_FUTURE_ERROR =
+  "Activity duration cannot include future dates";
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+type ActivityDurationRange = {
+  startTerm: Date;
+  endTerm: Date;
+};
+
+export const getKstEndOfToday = (now = new Date()): Date => {
+  const kstNow = new Date(now.getTime() + KST_OFFSET_MS);
+
+  return new Date(
+    Date.UTC(
+      kstNow.getUTCFullYear(),
+      kstNow.getUTCMonth(),
+      kstNow.getUTCDate(),
+      14,
+      59,
+      59,
+      999,
+    ),
+  );
+};
+
+export const getActivityDurationValidationError = (
+  durations: ActivityDurationRange[],
+  activityD: ActivityDurationRange,
+  now = new Date(),
+): string | null => {
+  const hasOutOfTargetDuration = durations.some(
+    duration =>
+      duration.startTerm > duration.endTerm ||
+      duration.startTerm < activityD.startTerm ||
+      duration.endTerm > activityD.endTerm,
+  );
+
+  if (hasOutOfTargetDuration) {
+    return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
+  }
+
+  const todayEndTerm = getKstEndOfToday(now);
+  const hasFutureDuration = durations.some(
+    duration => duration.endTerm > todayEndTerm,
+  );
+
+  return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
+};
+
+export const assertActivityDurationsAreSubmittable = (
+  durations: ActivityDurationRange[],
+  activityD: ActivityDurationRange,
+): void => {
+  const errorMessage = getActivityDurationValidationError(durations, activityD);
+
+  if (errorMessage !== null) {
+    throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
+  }
+};

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -3,9 +3,9 @@ import { Inject, Injectable } from "@nestjs/common";
 import { CLOCK, Clock } from "@sparcs-clubs/api/common/clock/clock";
 
 export const ACTIVITY_DURATION_OUT_OF_TARGET_ERROR =
-  "Some duration is not in the last activity duration";
+  "활동보고서 활동 기간은 활동 기한 내에 포함되어야 합니다";
 export const ACTIVITY_DURATION_FUTURE_ERROR =
-  "Activity duration cannot include future dates";
+  "활동보고서 활동 기간에는 작성일 이후의 날짜를 포함할 수 없습니다";
 
 export type ActivityDurationRange = {
   startTerm: Date;

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -1,4 +1,6 @@
-import { HttpException, HttpStatus } from "@nestjs/common";
+import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+
+import { ClockService } from "@sparcs-clubs/api/common/clock/clock.service";
 
 export const ACTIVITY_DURATION_OUT_OF_TARGET_ERROR =
   "Some duration is not in the last activity duration";
@@ -28,37 +30,41 @@ export const getKstEndOfToday = (now = new Date()): Date => {
   );
 };
 
-export const getActivityDurationValidationError = (
-  durations: ActivityDurationRange[],
-  activityD: ActivityDurationRange,
-  now = new Date(),
-): string | null => {
-  const hasOutOfTargetDuration = durations.some(
-    duration =>
-      duration.startTerm > duration.endTerm ||
-      duration.startTerm < activityD.startTerm ||
-      duration.endTerm > activityD.endTerm,
-  );
+@Injectable()
+export class ActivityDurationValidatorService {
+  constructor(private readonly clockService: ClockService) {}
 
-  if (hasOutOfTargetDuration) {
-    return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
+  getValidationError(
+    durations: ActivityDurationRange[],
+    activityD: ActivityDurationRange,
+  ): string | null {
+    const hasOutOfTargetDuration = durations.some(
+      duration =>
+        duration.startTerm > duration.endTerm ||
+        duration.startTerm < activityD.startTerm ||
+        duration.endTerm > activityD.endTerm,
+    );
+
+    if (hasOutOfTargetDuration) {
+      return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
+    }
+
+    const todayEndTerm = getKstEndOfToday(this.clockService.now());
+    const hasFutureDuration = durations.some(
+      duration => duration.endTerm > todayEndTerm,
+    );
+
+    return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
   }
 
-  const todayEndTerm = getKstEndOfToday(now);
-  const hasFutureDuration = durations.some(
-    duration => duration.endTerm > todayEndTerm,
-  );
+  assertSubmittable(
+    durations: ActivityDurationRange[],
+    activityD: ActivityDurationRange,
+  ): void {
+    const errorMessage = this.getValidationError(durations, activityD);
 
-  return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
-};
-
-export const assertActivityDurationsAreSubmittable = (
-  durations: ActivityDurationRange[],
-  activityD: ActivityDurationRange,
-): void => {
-  const errorMessage = getActivityDurationValidationError(durations, activityD);
-
-  if (errorMessage !== null) {
-    throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
+    if (errorMessage !== null) {
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
+    }
   }
-};
+}

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -1,6 +1,6 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 
-import { ClockService } from "@sparcs-clubs/api/common/clock/clock.service";
+import { CLOCK, Clock } from "@sparcs-clubs/api/common/clock/clock";
 
 export const ACTIVITY_DURATION_OUT_OF_TARGET_ERROR =
   "Some duration is not in the last activity duration";
@@ -60,7 +60,7 @@ export const getActivityDurationValidationError = (
 
 @Injectable()
 export class ActivityDurationValidatorService {
-  constructor(private readonly clockService: ClockService) {}
+  constructor(@Inject(CLOCK) private readonly clock: Clock) {}
 
   getValidationError(
     durations: ActivityDurationRange[],
@@ -69,7 +69,7 @@ export class ActivityDurationValidatorService {
     return getActivityDurationValidationError(
       durations,
       activityD,
-      this.clockService.now(),
+      this.clock.now(),
     );
   }
 }

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -7,8 +7,6 @@ export const ACTIVITY_DURATION_OUT_OF_TARGET_ERROR =
 export const ACTIVITY_DURATION_FUTURE_ERROR =
   "Activity duration cannot include future dates";
 
-const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
 export type ActivityDurationRange = {
   startTerm: Date;
   endTerm: Date;
@@ -18,26 +16,10 @@ export type ActivityDurationValidationError =
   | typeof ACTIVITY_DURATION_OUT_OF_TARGET_ERROR
   | typeof ACTIVITY_DURATION_FUTURE_ERROR;
 
-export const getKstEndOfToday = (now: Date): Date => {
-  const kstNow = new Date(now.getTime() + KST_OFFSET_MS);
-
-  return new Date(
-    Date.UTC(
-      kstNow.getUTCFullYear(),
-      kstNow.getUTCMonth(),
-      kstNow.getUTCDate(),
-      14,
-      59,
-      59,
-      999,
-    ),
-  );
-};
-
 export const getActivityDurationValidationError = (
   durations: ActivityDurationRange[],
   activityD: ActivityDurationRange,
-  now: Date,
+  endOfToday: Date,
 ): ActivityDurationValidationError | null => {
   const hasOutOfTargetDuration = durations.some(
     duration =>
@@ -50,9 +32,8 @@ export const getActivityDurationValidationError = (
     return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
   }
 
-  const todayEndTerm = getKstEndOfToday(now);
   const hasFutureDuration = durations.some(
-    duration => duration.endTerm > todayEndTerm,
+    duration => duration.endTerm > endOfToday,
   );
 
   return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
@@ -69,7 +50,7 @@ export class ActivityDurationValidatorService {
     return getActivityDurationValidationError(
       durations,
       activityD,
-      this.clock.now(),
+      this.clock.endOfToday(),
     );
   }
 }

--- a/packages/api/src/feature/activity/service/activity-duration.validator.ts
+++ b/packages/api/src/feature/activity/service/activity-duration.validator.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 
 import { ClockService } from "@sparcs-clubs/api/common/clock/clock.service";
 
@@ -9,12 +9,16 @@ export const ACTIVITY_DURATION_FUTURE_ERROR =
 
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-type ActivityDurationRange = {
+export type ActivityDurationRange = {
   startTerm: Date;
   endTerm: Date;
 };
 
-export const getKstEndOfToday = (now = new Date()): Date => {
+export type ActivityDurationValidationError =
+  | typeof ACTIVITY_DURATION_OUT_OF_TARGET_ERROR
+  | typeof ACTIVITY_DURATION_FUTURE_ERROR;
+
+export const getKstEndOfToday = (now: Date): Date => {
   const kstNow = new Date(now.getTime() + KST_OFFSET_MS);
 
   return new Date(
@@ -30,6 +34,30 @@ export const getKstEndOfToday = (now = new Date()): Date => {
   );
 };
 
+export const getActivityDurationValidationError = (
+  durations: ActivityDurationRange[],
+  activityD: ActivityDurationRange,
+  now: Date,
+): ActivityDurationValidationError | null => {
+  const hasOutOfTargetDuration = durations.some(
+    duration =>
+      duration.startTerm > duration.endTerm ||
+      duration.startTerm < activityD.startTerm ||
+      duration.endTerm > activityD.endTerm,
+  );
+
+  if (hasOutOfTargetDuration) {
+    return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
+  }
+
+  const todayEndTerm = getKstEndOfToday(now);
+  const hasFutureDuration = durations.some(
+    duration => duration.endTerm > todayEndTerm,
+  );
+
+  return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
+};
+
 @Injectable()
 export class ActivityDurationValidatorService {
   constructor(private readonly clockService: ClockService) {}
@@ -37,34 +65,11 @@ export class ActivityDurationValidatorService {
   getValidationError(
     durations: ActivityDurationRange[],
     activityD: ActivityDurationRange,
-  ): string | null {
-    const hasOutOfTargetDuration = durations.some(
-      duration =>
-        duration.startTerm > duration.endTerm ||
-        duration.startTerm < activityD.startTerm ||
-        duration.endTerm > activityD.endTerm,
+  ): ActivityDurationValidationError | null {
+    return getActivityDurationValidationError(
+      durations,
+      activityD,
+      this.clockService.now(),
     );
-
-    if (hasOutOfTargetDuration) {
-      return ACTIVITY_DURATION_OUT_OF_TARGET_ERROR;
-    }
-
-    const todayEndTerm = getKstEndOfToday(this.clockService.now());
-    const hasFutureDuration = durations.some(
-      duration => duration.endTerm > todayEndTerm,
-    );
-
-    return hasFutureDuration ? ACTIVITY_DURATION_FUTURE_ERROR : null;
-  }
-
-  assertSubmittable(
-    durations: ActivityDurationRange[],
-    activityD: ActivityDurationRange,
-  ): void {
-    const errorMessage = this.getValidationError(durations, activityD);
-
-    if (errorMessage !== null) {
-      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
-    }
   }
 }

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -594,10 +594,13 @@ export default class ActivityService {
       deadlineEnum: RegistrationDeadlineEnum.ClubRegistrationApplication,
     });
 
-    const activityDId = await this.activityDurationPublicService.loadId({
+    const activityD = await this.activityDurationPublicService.load({
       date: new Date(),
       activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
     });
+    const activityDId = activityD.id;
+    this.assertActivityDurationsAreSubmittable(body.durations, activityD);
+
     // 현재학기에 동아리원이 아니였던 참가자가 있는지 검사합니다.
     const participantIds = await Promise.all(
       body.participants.map(
@@ -668,7 +671,11 @@ export default class ActivityService {
     // 오늘이 활동보고서 작성기간이거나, 예외적 작성기간인지 확인하지 않습니다.
     // 해당 활동이 지난 활동기간에 대한 활동인지 확인하지 않습니다.
 
-    // 제출한 활동 기간들이 지난 활동기간 이내인지 확인하지 않습니다.
+    // 제출한 활동 기간들이 활동기간 이내이며 작성일 이후를 포함하지 않는지 확인합니다.
+    const activityD = await this.activityDurationPublicService.getById(
+      activity.activityDuration.id,
+    );
+    this.assertActivityDurationsAreSubmittable(body.durations, activityD);
 
     // 파일 uuid의 유효성을 검사합니다.
     const evidenceFiles = await Promise.all(

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -65,6 +65,7 @@ import UserPublicService from "@sparcs-clubs/api/feature/user/service/user.publi
 import { OperationCommitteeService } from "../../operation-committee/service/operation-committee.service";
 import { MActivityClubChargedExecutive } from "../model/activity-club-charged-executive.model";
 import { ActivityCommentRepository } from "../repository/activity-comment.repository";
+import { assertActivityDurationsAreSubmittable } from "./activity-duration.validator";
 
 @Injectable()
 export default class ActivityService {
@@ -289,18 +290,7 @@ export default class ActivityService {
     const participants = await Promise.all(
       body.participants.map(async e => e.studentId),
     );
-    body.duration.forEach(duration => {
-      if (
-        activityD.startTerm <= duration.startTerm &&
-        duration.endTerm <= activityD.endTerm
-      ) {
-        return;
-      }
-      throw new HttpException(
-        "Some duration is not in the last activity duration",
-        HttpStatus.BAD_REQUEST,
-      );
-    });
+    assertActivityDurationsAreSubmittable(body.duration, activityD);
 
     // TODO: 해당 학기에 활동한 인원인지 검사하는 로직
     // TODO: 파일 유효한지 검사하는 로직도 필요해요! 이건 파일 모듈 구성되면 public할듯
@@ -351,18 +341,7 @@ export default class ActivityService {
         HttpStatus.BAD_REQUEST,
       );
     // 제출한 활동 기간들이 지난 활동기간 이내인지 확인합니다.
-    body.durations.forEach(duration => {
-      if (
-        activityD.startTerm <= duration.startTerm &&
-        duration.endTerm <= activityD.endTerm
-      ) {
-        return duration;
-      }
-      throw new HttpException(
-        "Some duration is not in the last activity duration",
-        HttpStatus.BAD_REQUEST,
-      );
-    });
+    assertActivityDurationsAreSubmittable(body.durations, activityD);
     // 파일 uuid의 유효성을 검사하지 않습니다.
     // 참여 학생이 지난 활동기간 동아리의 소속원이였는지 확인합니다.
     const activityDStartSemesterId = await this.semesterPublicService.loadId({

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -65,7 +65,7 @@ import UserPublicService from "@sparcs-clubs/api/feature/user/service/user.publi
 import { OperationCommitteeService } from "../../operation-committee/service/operation-committee.service";
 import { MActivityClubChargedExecutive } from "../model/activity-club-charged-executive.model";
 import { ActivityCommentRepository } from "../repository/activity-comment.repository";
-import { assertActivityDurationsAreSubmittable } from "./activity-duration.validator";
+import { ActivityDurationValidatorService } from "./activity-duration.validator";
 
 @Injectable()
 export default class ActivityService {
@@ -82,6 +82,7 @@ export default class ActivityService {
     private readonly registrationDeadlinePublicService: RegistrationDeadlinePublicService,
     private readonly operationCommitteeService: OperationCommitteeService,
     private readonly userPublicService: UserPublicService,
+    private readonly activityDurationValidatorService: ActivityDurationValidatorService,
   ) {}
 
   /**
@@ -290,7 +291,10 @@ export default class ActivityService {
     const participants = await Promise.all(
       body.participants.map(async e => e.studentId),
     );
-    assertActivityDurationsAreSubmittable(body.duration, activityD);
+    this.activityDurationValidatorService.assertSubmittable(
+      body.duration,
+      activityD,
+    );
 
     // TODO: 해당 학기에 활동한 인원인지 검사하는 로직
     // TODO: 파일 유효한지 검사하는 로직도 필요해요! 이건 파일 모듈 구성되면 public할듯
@@ -341,7 +345,10 @@ export default class ActivityService {
         HttpStatus.BAD_REQUEST,
       );
     // 제출한 활동 기간들이 지난 활동기간 이내인지 확인합니다.
-    assertActivityDurationsAreSubmittable(body.durations, activityD);
+    this.activityDurationValidatorService.assertSubmittable(
+      body.durations,
+      activityD,
+    );
     // 파일 uuid의 유효성을 검사하지 않습니다.
     // 참여 학생이 지난 활동기간 동아리의 소속원이였는지 확인합니다.
     const activityDStartSemesterId = await this.semesterPublicService.loadId({

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -65,7 +65,10 @@ import UserPublicService from "@sparcs-clubs/api/feature/user/service/user.publi
 import { OperationCommitteeService } from "../../operation-committee/service/operation-committee.service";
 import { MActivityClubChargedExecutive } from "../model/activity-club-charged-executive.model";
 import { ActivityCommentRepository } from "../repository/activity-comment.repository";
-import { ActivityDurationValidatorService } from "./activity-duration.validator";
+import {
+  type ActivityDurationRange,
+  ActivityDurationValidatorService,
+} from "./activity-duration.validator";
 
 @Injectable()
 export default class ActivityService {
@@ -84,6 +87,21 @@ export default class ActivityService {
     private readonly userPublicService: UserPublicService,
     private readonly activityDurationValidatorService: ActivityDurationValidatorService,
   ) {}
+
+  private assertActivityDurationsAreSubmittable(
+    durations: ActivityDurationRange[],
+    activityD: ActivityDurationRange,
+  ): void {
+    const errorMessage =
+      this.activityDurationValidatorService.getValidationError(
+        durations,
+        activityD,
+      );
+
+    if (errorMessage !== null) {
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
+    }
+  }
 
   /**
    * @param activityDId 조회하고 싶은 활동기간 id, 없을 경우 직전 활동기간의 id를 사용합니다.
@@ -291,10 +309,7 @@ export default class ActivityService {
     const participants = await Promise.all(
       body.participants.map(async e => e.studentId),
     );
-    this.activityDurationValidatorService.assertSubmittable(
-      body.duration,
-      activityD,
-    );
+    this.assertActivityDurationsAreSubmittable(body.duration, activityD);
 
     // TODO: 해당 학기에 활동한 인원인지 검사하는 로직
     // TODO: 파일 유효한지 검사하는 로직도 필요해요! 이건 파일 모듈 구성되면 public할듯
@@ -345,10 +360,7 @@ export default class ActivityService {
         HttpStatus.BAD_REQUEST,
       );
     // 제출한 활동 기간들이 지난 활동기간 이내인지 확인합니다.
-    this.activityDurationValidatorService.assertSubmittable(
-      body.durations,
-      activityD,
-    );
+    this.assertActivityDurationsAreSubmittable(body.durations, activityD);
     // 파일 uuid의 유효성을 검사하지 않습니다.
     // 참여 학생이 지난 활동기간 동아리의 소속원이였는지 확인합니다.
     const activityDStartSemesterId = await this.semesterPublicService.loadId({

--- a/packages/web/src/common/services/getApiErrorMessage.ts
+++ b/packages/web/src/common/services/getApiErrorMessage.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+type ApiErrorResponse = {
+  message?: string | string[];
+};
+
+const getApiErrorMessage = (error: Error, fallbackMessage: string) => {
+  if (!axios.isAxiosError<ApiErrorResponse>(error)) {
+    return fallbackMessage;
+  }
+
+  const message = error.response?.data?.message;
+
+  if (Array.isArray(message)) {
+    return message.join("\n");
+  }
+
+  return message || fallbackMessage;
+};
+
+export default getApiErrorMessage;

--- a/packages/web/src/features/register-club/components/activity-report/CreateActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/CreateActivityReportModal.tsx
@@ -7,6 +7,7 @@ import Modal from "@sparcs-clubs/web/common/components/Modal";
 import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import RestoreDraftModal from "@sparcs-clubs/web/common/components/Modal/RestoreDraftModal";
 import useTemporaryStorage from "@sparcs-clubs/web/common/hooks/useTemporaryStorage";
+import getApiErrorMessage from "@sparcs-clubs/web/common/services/getApiErrorMessage";
 import LocalStorageUtil from "@sparcs-clubs/web/common/services/localStorageUtil";
 import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
 import { ActivityReportFormData } from "@sparcs-clubs/web/features/activity-report/types/form";
@@ -63,7 +64,11 @@ const CreateActivityReportModal: React.FC<CreateActivityReportModalProps> = ({
             queryClient.invalidateQueries({ queryKey: [apiAct011.url()] });
             close();
           },
-          onError: () => errorHandler("생성에 실패하였습니다"),
+          onError: error => {
+            errorHandler(
+              getApiErrorMessage(error, "활동보고서 생성에 실패하였습니다"),
+            );
+          },
         },
       );
     },

--- a/packages/web/src/features/register-club/components/activity-report/EditActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/EditActivityReportModal.tsx
@@ -8,7 +8,9 @@ import apiAct011 from "@clubs/interface/api/activity/endpoint/apiAct011";
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
+import { errorHandler } from "@sparcs-clubs/web/common/components/Modal/ErrorModal";
 import CommentToast from "@sparcs-clubs/web/common/components/Toast/CommentToast";
+import getApiErrorMessage from "@sparcs-clubs/web/common/services/getApiErrorMessage";
 import {
   activityReportDetailQueryKey,
   useGetActivityReport,
@@ -68,6 +70,11 @@ const EditActivityReportModal: React.FC<EditActivityReportModalProps> = ({
             });
             queryClient.invalidateQueries({ queryKey: [apiAct011.url()] });
             close();
+          },
+          onError: error => {
+            errorHandler(
+              getApiErrorMessage(error, "활동보고서 수정에 실패하였습니다"),
+            );
           },
         },
       );

--- a/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
@@ -52,6 +52,18 @@ const EditActivityTermModal: React.FC<EditActivityTermModalProps> = ({
   );
 
   const isEmpty = useMemo(() => fields.length === 0, [fields]);
+  const maxSelectableEndTerm = useMemo(() => {
+    const today = getLocalDateOnly(new Date());
+    const activityEndTerm = deadline?.targetTerm?.endTerm;
+
+    if (activityEndTerm == null) {
+      return today;
+    }
+
+    const activityEndDate = getLocalDateOnly(activityEndTerm);
+
+    return activityEndDate < today ? activityEndDate : today;
+  }, [deadline?.targetTerm?.endTerm]);
 
   const isSomethingEmpty = useMemo(() => {
     if (fields.length === 0) {
@@ -104,7 +116,7 @@ const EditActivityTermModal: React.FC<EditActivityTermModalProps> = ({
                     <DateInput
                       selectsRange
                       minDate={deadline?.targetTerm?.startTerm ?? undefined}
-                      maxDate={deadline?.targetTerm?.endTerm ?? undefined}
+                      maxDate={maxSelectableEndTerm}
                       startDate={value?.startTerm}
                       endDate={value?.endTerm}
                       onChange={(dates: [Date, Date] | null) => {


### PR DESCRIPTION
## Summary
- 활동보고서 활동 기간 선택 최대일을 `min(ActivityD.endTerm, today)`로 제한
- 전역 `Clock` token/interface와 `SystemClock` 구현체를 추가해 유틸 provider와 Service naming을 분리
- `Clock.endOfToday()`가 UTC 런타임에서 서비스 기준 오늘 종료시각을 계산하도록 이동
- 활동 기간 validator는 날짜 경계 계산을 하지 않고, pure function은 검증 에러 값만 반환
- `ActivityService`에서 validator 결과를 `HttpException`으로 변환
- 정규 활동보고서 작성/수정 및 신규등록 예외 활동보고서 `ACT-007`/`ACT-008` 작성/수정 서버 검증에 모두 적용
- 서버 생성/수정 검증에서 활동기간 범위 초과와 작성일 이후 기간 포함 에러 메시지 분리
- 활동보고서 validation 에러 메시지를 한국어로 변경
- 활동보고서 생성/수정 실패 시 클라이언트 ErrorModal에서 서버 에러 메시지를 표시
- 오늘 종료시각은 허용하고 익일부터는 거절하는 단위 테스트 및 `SystemClock` 서비스 날짜 경계 테스트 추가

## Task
- https://www.notion.so/362c25603b0b819e870ad299d9425c3b

## Tests
- `pnpm exec prettier --check packages/api/src/feature/activity/service/activity.service.new.ts`
- `pnpm exec prettier --check packages/api/src/feature/activity/service/activity-duration.validator.ts packages/web/src/common/services/getApiErrorMessage.ts packages/web/src/features/register-club/components/activity-report/CreateActivityReportModal.tsx packages/web/src/features/register-club/components/activity-report/EditActivityReportModal.tsx`
- `NODE_PATH=/Users/gerberasmacmini/developer/sparcs/clubs-worktrees/TU-412/node_modules/.pnpm/dotenv@16.4.7/node_modules pnpm --filter api exec jest --config ./test/jest-unit.json --runTestsByPath src/feature/activity/service/activity-duration.validator.spec.ts src/common/clock/system-clock.spec.ts`
- `pnpm --filter api lint` (existing warning: `packages/api/src/feature/auth/util/sparcs-sso.ts:146 no-console`)
- `pnpm --filter web lint` (existing warnings: no-alert/no-console in unrelated files)
- `pnpm exec turbo run build --filter=api`
- `pnpm exec turbo run build --filter=api --filter=web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced activity duration validation with specific error messages for invalid or future-dated submissions.

* **Bug Fixes**
  * Activity term date selection now properly constrains the maximum selectable end date based on the current date and activity configuration.
  * Activity report creation and modification now display detailed error messages instead of generic fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->