### PR TITLE
[TU-413] 집행부원 대시보드 테이블 액션 버튼 개선

### DIFF
--- a/packages/web/src/common/components/Table/TableActionButton.tsx
+++ b/packages/web/src/common/components/Table/TableActionButton.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import styled from "styled-components";
+
+export type TableActionButtonVariant = "edit" | "delete";
+
+interface TableActionButtonProps {
+  variant: TableActionButtonVariant;
+  disabled?: boolean;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+
+const actionMeta = {
+  edit: {
+    emoji: "✏️",
+    label: "수정",
+  },
+  delete: {
+    emoji: "🗑️",
+    label: "삭제",
+  },
+};
+
+const TableActionButtonInner = styled.button<{
+  $variant: TableActionButtonVariant;
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 32px;
+  min-width: 64px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid
+    ${({ $variant, theme }) =>
+      $variant === "edit" ? theme.colors.MINT[300] : theme.colors.RED[600]};
+  background: ${({ $variant, theme }) =>
+    $variant === "edit" ? theme.colors.MINT[100] : theme.colors.RED[100]};
+  color: ${({ $variant, theme }) =>
+    $variant === "edit" ? theme.colors.PRIMARY : theme.colors.RED[600]};
+  font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ $variant, theme }) =>
+      $variant === "edit" ? theme.colors.PRIMARY : theme.colors.RED[600]};
+    background: ${({ theme }) => theme.colors.WHITE};
+  }
+
+  &:focus-visible {
+    outline: 2px solid
+      ${({ $variant, theme }) =>
+        $variant === "edit" ? theme.colors.MINT[300] : theme.colors.RED[600]};
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    border-color: ${({ theme }) => theme.colors.GRAY[300]};
+    background: ${({ theme }) => theme.colors.GRAY[100]};
+    color: ${({ theme }) => theme.colors.GRAY[300]};
+    cursor: not-allowed;
+  }
+`;
+
+const ButtonEmoji = styled.span`
+  display: inline-flex;
+  width: 16px;
+  justify-content: center;
+  font-size: 14px;
+  line-height: 16px;
+`;
+
+export const TableActionButtonGroup = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: max-content;
+`;
+
+const TableActionButton = ({
+  variant,
+  disabled = false,
+  onClick = () => {},
+  children = undefined,
+}: TableActionButtonProps) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!disabled) {
+      onClick();
+    }
+  };
+  const { emoji, label } = actionMeta[variant];
+
+  return (
+    <TableActionButtonInner
+      type="button"
+      $variant={variant}
+      disabled={disabled}
+      aria-label={label}
+      onClick={handleClick}
+    >
+      <ButtonEmoji aria-hidden="true">{emoji}</ButtonEmoji>
+      {children ?? label}
+    </TableActionButtonInner>
+  );
+};
+
+export default TableActionButton;

--- a/packages/web/src/common/components/Table/TableActionButton.tsx
+++ b/packages/web/src/common/components/Table/TableActionButton.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
+import Icon from "../Icon";
+
 export type TableActionButtonVariant = "edit" | "delete";
 
 interface TableActionButtonProps {
@@ -12,11 +14,11 @@ interface TableActionButtonProps {
 
 const actionMeta = {
   edit: {
-    emoji: "✏️",
+    icon: "edit",
     label: "수정",
   },
   delete: {
-    emoji: "🗑️",
+    icon: "delete_outline",
     label: "삭제",
   },
 };
@@ -70,14 +72,6 @@ const TableActionButtonInner = styled.button<{
   }
 `;
 
-const ButtonEmoji = styled.span`
-  display: inline-flex;
-  width: 16px;
-  justify-content: center;
-  font-size: 14px;
-  line-height: 16px;
-`;
-
 export const TableActionButtonGroup = styled.div`
   display: inline-flex;
   flex-direction: row;
@@ -100,7 +94,7 @@ const TableActionButton = ({
       onClick();
     }
   };
-  const { emoji, label } = actionMeta[variant];
+  const { icon, label } = actionMeta[variant];
 
   return (
     <TableActionButtonInner
@@ -110,7 +104,7 @@ const TableActionButton = ({
       aria-label={label}
       onClick={handleClick}
     >
-      <ButtonEmoji aria-hidden="true">{emoji}</ButtonEmoji>
+      <Icon type={icon} size={16} color="inherit" />
       {children ?? label}
     </TableActionButtonInner>
   );

--- a/packages/web/src/features/executive/activity-duration/components/ActivityDurationTable.tsx
+++ b/packages/web/src/features/executive/activity-duration/components/ActivityDurationTable.tsx
@@ -11,9 +11,11 @@ import { ActivityDurationTypeEnum } from "@clubs/domain/semester/activity-durati
 
 import { ApiSem012ResponseOK } from "@clubs/interface/api/semester/apiSem012";
 
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton, {
+  TableActionButtonGroup,
+} from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 import useDeleteActivityDuration from "@sparcs-clubs/web/features/executive/services/useDeleteActivityDuration";
 
 import ActivityDurationEditModal from "./ActivityDurationEditModal";
@@ -60,14 +62,17 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
   };
 
   const actionsCellRenderer = (duration: ActivityDurationItem) => (
-    <FlexWrapper direction="row" gap={8}>
-      <TextButton text="수정" onClick={() => setEditingDuration(duration)} />
-      <TextButton
-        text="삭제"
+    <TableActionButtonGroup>
+      <TableActionButton
+        variant="edit"
+        onClick={() => setEditingDuration(duration)}
+      />
+      <TableActionButton
+        variant="delete"
         onClick={() => handleDelete(duration.id)}
         disabled={isDeletingActivityDuration}
       />
-    </FlexWrapper>
+    </TableActionButtonGroup>
   );
 
   const columnHelper = createColumnHelper<ActivityDurationItem>();
@@ -119,7 +124,7 @@ const ActivityDurationTable = ({ durations }: ActivityDurationTableProps) => {
       id: "actions",
       header: "관리",
       cell: ({ row }) => actionsCellRenderer(row.original),
-      size: 140,
+      size: 160,
     }),
   ];
 

--- a/packages/web/src/features/executive/components/ActivityDeadlineTable.tsx
+++ b/packages/web/src/features/executive/components/ActivityDeadlineTable.tsx
@@ -10,8 +10,8 @@ import React, { useCallback, useMemo } from "react";
 import { ApiSem007ResponseOK } from "@clubs/interface/api/semester/apiSem007";
 import { ActivityDeadlineEnum } from "@clubs/interface/common/enum/activity.enum";
 
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 
 import useDeleteActivityDeadline from "../services/useDeleteActivityDeadline";
 
@@ -56,7 +56,10 @@ const ActivityDeadlineTable: React.FC<ActivityDeadlineTableProps> = ({
   );
 
   const actionsCellRenderer = (deadlineId: number) => (
-    <TextButton text="삭제" onClick={() => handleDelete(deadlineId)} />
+    <TableActionButton
+      variant="delete"
+      onClick={() => handleDelete(deadlineId)}
+    />
   );
 
   const columnHelper = createColumnHelper<ActivityDeadlineData>();
@@ -87,9 +90,9 @@ const ActivityDeadlineTable: React.FC<ActivityDeadlineTableProps> = ({
       enableSorting: false,
     }),
     columnHelper.accessor("id", {
-      header: "삭제",
+      header: "관리",
       cell: info => actionsCellRenderer(info.getValue()),
-      size: 80,
+      size: 96,
       enableSorting: false,
     }),
   ];

--- a/packages/web/src/features/executive/components/ActivityDeadlineTable.tsx
+++ b/packages/web/src/features/executive/components/ActivityDeadlineTable.tsx
@@ -39,7 +39,10 @@ const getDeadlineTypeText = (deadlineEnum: ActivityDeadlineEnum): string => {
 const ActivityDeadlineTable: React.FC<ActivityDeadlineTableProps> = ({
   deadlines,
 }) => {
-  const { mutate: deleteActivityDeadline } = useDeleteActivityDeadline();
+  const {
+    mutate: deleteActivityDeadline,
+    isPending: isDeletingActivityDeadline,
+  } = useDeleteActivityDeadline();
 
   const sortedDeadlines = useMemo(() => {
     if (!deadlines) return [];
@@ -59,6 +62,7 @@ const ActivityDeadlineTable: React.FC<ActivityDeadlineTableProps> = ({
     <TableActionButton
       variant="delete"
       onClick={() => handleDelete(deadlineId)}
+      disabled={isDeletingActivityDeadline}
     />
   );
 

--- a/packages/web/src/features/executive/frames/ManageMemberFrame.tsx
+++ b/packages/web/src/features/executive/frames/ManageMemberFrame.tsx
@@ -13,6 +13,9 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton, {
+  TableActionButtonGroup,
+} from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 
 import ExecutiveMemberFormModal, {
   ExecutiveMemberData,
@@ -89,30 +92,22 @@ const ManageMemberFrame = () => {
   const columnHelper = createColumnHelper<ExecutiveMemberData>();
 
   const actionsCellRenderer = (member: ExecutiveMemberData) => (
-    <FlexWrapper direction="row" gap={8}>
-      <Button
-        type={putExecutiveMember.isPending ? "disabled" : "outlined"}
-        style={{ padding: "6px 10px", fontSize: 14, lineHeight: "18px" }}
-        onClick={event => {
-          event.preventDefault();
-          event.stopPropagation();
+    <TableActionButtonGroup>
+      <TableActionButton
+        variant="edit"
+        disabled={putExecutiveMember.isPending}
+        onClick={() => {
           openExecutiveMemberModal(handleEditExecutiveMember, member);
         }}
-      >
-        수정
-      </Button>
-      <Button
-        type={deleteExecutiveMember.isPending ? "disabled" : "outlined"}
-        style={{ padding: "6px 10px", fontSize: 14, lineHeight: "18px" }}
-        onClick={event => {
-          event.preventDefault();
-          event.stopPropagation();
+      />
+      <TableActionButton
+        variant="delete"
+        disabled={deleteExecutiveMember.isPending}
+        onClick={() => {
           handleDeleteExecutiveMember(member.id);
         }}
-      >
-        삭제
-      </Button>
-    </FlexWrapper>
+      />
+    </TableActionButtonGroup>
   );
 
   const columns = [
@@ -159,7 +154,7 @@ const ManageMemberFrame = () => {
       id: "actions",
       header: "관리",
       cell: ({ row }) => actionsCellRenderer(row.original),
-      size: 140,
+      size: 160,
     }),
   ];
 

--- a/packages/web/src/features/executive/frames/ManageSemesterFrame.tsx
+++ b/packages/web/src/features/executive/frames/ManageSemesterFrame.tsx
@@ -10,10 +10,12 @@ import { useMemo } from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton, {
+  TableActionButtonGroup,
+} from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import useDeleteSemester from "@sparcs-clubs/web/features/executive/services/deleteSemester";
 import usePostSemester from "@sparcs-clubs/web/features/executive/services/postSemester";
@@ -59,14 +61,18 @@ const SemesterActionButtons = ({
   const handleDelete = () => onDelete(semesterId);
 
   return (
-    <FlexWrapper direction="row" gap={8}>
-      <TextButton text="수정" onClick={handleEdit} disabled={editDisabled} />
-      <TextButton
-        text="삭제"
+    <TableActionButtonGroup>
+      <TableActionButton
+        variant="edit"
+        onClick={handleEdit}
+        disabled={editDisabled}
+      />
+      <TableActionButton
+        variant="delete"
         onClick={handleDelete}
         disabled={deleteDisabled}
       />
-    </FlexWrapper>
+    </TableActionButtonGroup>
   );
 };
 
@@ -178,7 +184,7 @@ const ManageSemesterFrame = () => {
       id: "actions",
       header: "관리",
       cell: ({ row }) => actionsCellRenderer(row.original.id),
-      size: 120,
+      size: 160,
     }),
   ];
 

--- a/packages/web/src/features/executive/funding/components/FundingDeadlineTable.tsx
+++ b/packages/web/src/features/executive/funding/components/FundingDeadlineTable.tsx
@@ -9,9 +9,9 @@ import { useMemo } from "react";
 
 import { ApiSem016ResponseOk } from "@clubs/interface/api/semester/apiSem016";
 
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 import { fundingDeadlineEnumToString } from "@sparcs-clubs/web/features/manage-club/funding/constants/fundingDeadlineEnumToString";
 
 import useDeleteFundingDeadline from "../services/useDeleteFundingDeadline";
@@ -45,8 +45,8 @@ const FundingDeadlineTable = ({
   };
 
   const actionsCellRenderer = (id: number) => (
-    <TextButton
-      text="삭제"
+    <TableActionButton
+      variant="delete"
       onClick={() => handleDeleteFundingDeadline(id)}
       disabled={isDeletingFundingDeadline}
     />
@@ -92,7 +92,7 @@ const FundingDeadlineTable = ({
       id: "actions",
       header: "관리",
       cell: ({ row }) => actionsCellRenderer(row.original.id),
-      size: 120,
+      size: 96,
     }),
   ];
 

--- a/packages/web/src/features/executive/registration/components/RegistrationDeadlineTable.tsx
+++ b/packages/web/src/features/executive/registration/components/RegistrationDeadlineTable.tsx
@@ -10,9 +10,9 @@ import { useMemo } from "react";
 import { ApiSem019ResponseOk } from "@clubs/interface/api/semester/apiSem019";
 import { RegistrationDeadlineEnum } from "@clubs/interface/common/enum/registration.enum";
 
-import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import Table from "@sparcs-clubs/web/common/components/Table";
+import TableActionButton from "@sparcs-clubs/web/common/components/Table/TableActionButton";
 
 import useDeleteRegistrationDeadline from "../services/useDeleteRegistrationDeadline";
 
@@ -60,8 +60,8 @@ const RegistrationDeadlineTable = ({
   };
 
   const actionsCellRenderer = (id: number) => (
-    <TextButton
-      text="삭제"
+    <TableActionButton
+      variant="delete"
       onClick={() => handleDelete(id)}
       disabled={isDeletingRegistrationDeadline}
     />
@@ -107,7 +107,7 @@ const RegistrationDeadlineTable = ({
       id: "actions",
       header: "관리",
       cell: ({ row }) => actionsCellRenderer(row.original.id),
-      size: 120,
+      size: 96,
     }),
   ];
 


### PR DESCRIPTION
## Summary
- 집행부원 대시보드 하위 테이블의 수정/삭제 액션을 공용 아이콘 버튼으로 교체
- 활동기간, 제출 기한, 지원금 기한, 등록 마감일, 학기, 집행부원 관리 테이블의 액션 UI를 통일
- 활동보고서 제출 기한 삭제 버튼에 pending disabled 상태를 연결

## Task Context
- Task ID: TU-413
- Notion: https://www.notion.so/363c25603b0b81f3b3bbf2baa051e90d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized action button styling across table components (Activity Duration, Member Management, Semester, Funding Deadline, Registration Deadline, and Activity Deadline tables) with a new unified `TableActionButton` component for consistent edit and delete actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
