### PR TITLE
fix: 교통비 탑승자 표시 조회 수정

### DIFF
--- a/packages/api/src/feature/funding/repository/funding.repository.spec.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.spec.ts
@@ -1,0 +1,16 @@
+import { buildFundingTransportationPassengerWhere } from "./funding.repository.util";
+
+describe("buildFundingTransportationPassengerWhere", () => {
+  it("shows submitted transportation passengers without student_t filtering", () => {
+    expect(buildFundingTransportationPassengerWhere(4216)).toEqual({
+      fundingId: 4216,
+      deletedAt: null,
+      funding: {
+        deletedAt: null,
+      },
+      student: {
+        deletedAt: null,
+      },
+    });
+  });
+});

--- a/packages/api/src/feature/funding/repository/funding.repository.spec.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.spec.ts
@@ -1,15 +1,21 @@
-import { buildFundingTransportationPassengerWhere } from "./funding.repository.util";
+import { buildFundingTransportationPassengerFindManyArgs } from "./funding.repository.util";
 
-describe("buildFundingTransportationPassengerWhere", () => {
-  it("shows submitted transportation passengers without student_t filtering", () => {
-    expect(buildFundingTransportationPassengerWhere(4216)).toEqual({
-      fundingId: 4216,
-      deletedAt: null,
-      funding: {
+describe("buildFundingTransportationPassengerFindManyArgs", () => {
+  it("shows submitted distinct transportation passengers without student_t filtering", () => {
+    expect(buildFundingTransportationPassengerFindManyArgs(4216)).toEqual({
+      distinct: ["studentId"],
+      where: {
+        fundingId: 4216,
         deletedAt: null,
+        funding: {
+          deletedAt: null,
+        },
+        student: {
+          deletedAt: null,
+        },
       },
-      student: {
-        deletedAt: null,
+      select: {
+        studentId: true,
       },
     });
   });

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -16,7 +16,7 @@ import {
   FundingSummaryDBResult,
   VFundingSummary,
 } from "../model/funding.summary.model";
-import { buildFundingTransportationPassengerWhere } from "./funding.repository.util";
+import { buildFundingTransportationPassengerFindManyArgs } from "./funding.repository.util";
 
 @Injectable()
 export default class FundingRepository {
@@ -104,13 +104,9 @@ export default class FundingRepository {
       this.prisma.fundingEtcExpenseFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingTransportationPassenger.findMany({
-        distinct: ["studentId"],
-        where: buildFundingTransportationPassengerWhere(id),
-        select: {
-          studentId: true,
-        },
-      }),
+      this.prisma.fundingTransportationPassenger.findMany(
+        buildFundingTransportationPassengerFindManyArgs(id),
+      ),
     ]);
 
     return MFunding.fromDBResult({

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -16,6 +16,7 @@ import {
   FundingSummaryDBResult,
   VFundingSummary,
 } from "../model/funding.summary.model";
+import { buildFundingTransportationPassengerWhere } from "./funding.repository.util";
 
 @Injectable()
 export default class FundingRepository {
@@ -103,31 +104,13 @@ export default class FundingRepository {
       this.prisma.fundingEtcExpenseFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.$queryRaw<
-        Array<{
-          fundingId: number;
-          studentId: number;
-          studentNumber: number;
-          name: string;
-        }>
-      >(Prisma.sql`
-        SELECT
-          ftp.funding_id AS fundingId,
-          ftp.student_id AS studentId,
-          s.number AS studentNumber,
-          s.name AS name
-        FROM funding_transportation_passenger ftp
-        INNER JOIN student s
-          ON s.id = ftp.student_id
-          AND s.deleted_at IS NULL
-        INNER JOIN student_t st
-          ON st.student_id = s.id
-          AND st.start_term <= NOW()
-          AND (st.end_term >= NOW() OR st.end_term IS NULL)
-          AND st.deleted_at IS NULL
-        WHERE ftp.funding_id = ${id}
-          AND ftp.deleted_at IS NULL
-      `),
+      this.prisma.fundingTransportationPassenger.findMany({
+        distinct: ["studentId"],
+        where: buildFundingTransportationPassengerWhere(id),
+        select: {
+          studentId: true,
+        },
+      }),
     ]);
 
     return MFunding.fromDBResult({

--- a/packages/api/src/feature/funding/repository/funding.repository.util.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.util.ts
@@ -1,13 +1,21 @@
 import type { Prisma } from "@prisma/client";
 
-export const buildFundingTransportationPassengerWhere = (fundingId: number) =>
+export const buildFundingTransportationPassengerFindManyArgs = (
+  fundingId: number,
+) =>
   ({
-    fundingId,
-    deletedAt: null,
-    funding: {
+    distinct: ["studentId"],
+    where: {
+      fundingId,
       deletedAt: null,
+      funding: {
+        deletedAt: null,
+      },
+      student: {
+        deletedAt: null,
+      },
     },
-    student: {
-      deletedAt: null,
+    select: {
+      studentId: true,
     },
-  }) satisfies Prisma.FundingTransportationPassengerWhereInput;
+  }) satisfies Prisma.FundingTransportationPassengerFindManyArgs;

--- a/packages/api/src/feature/funding/repository/funding.repository.util.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.util.ts
@@ -1,0 +1,13 @@
+import type { Prisma } from "@prisma/client";
+
+export const buildFundingTransportationPassengerWhere = (fundingId: number) =>
+  ({
+    fundingId,
+    deletedAt: null,
+    funding: {
+      deletedAt: null,
+    },
+    student: {
+      deletedAt: null,
+    },
+  }) satisfies Prisma.FundingTransportationPassengerWhereInput;


### PR DESCRIPTION
## Summary
- 교통비 탑승자 표시 조회에서 `student_t` 현재 시점 필터를 제거했습니다.
- `funding_transportation_passenger`에 제출된 active 탑승자 row를 source of truth로 사용하고, `studentId` 기준 distinct만 적용했습니다.
- 회귀 테스트를 추가해 `student_t` 필터 없이 제출된 탑승자 조건만 사용하는지 확인합니다.

## Cause
`funding_transportation_passenger`에는 동아리가 제출한 탑승자 명단이 정상 저장되어 있었지만, funding 상세 표시 조회에서 `student_t`를 `NOW()` 기준으로 INNER JOIN하고 있었습니다. 이 때문에 활동 당시 기준으로 제출된 탑승자 중 현재/이후 학기 등록이 없는 인원이 UI에서 누락되었습니다.

## Test
- `pnpm --filter=api exec jest --config ./test/jest-unit.json src/feature/funding/repository/funding.repository.spec.ts --runInBand`
- `pnpm --filter=api lint src/feature/funding/repository/funding.repository.ts src/feature/funding/repository/funding.repository.util.ts src/feature/funding/repository/funding.repository.spec.ts`
- `pnpm --filter=api build`
- `git diff --check`