### PR TITLE
[TU-414] GitHub Actions Node 20 deprecation warning 정리

### DIFF
--- a/.github/workflows/cd-demo.yml
+++ b/.github/workflows/cd-demo.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: "Log in to Github Container Registry"
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
@@ -44,13 +44,13 @@ jobs:
 
       - name: "Extract Metadata"
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ matrix.image }}
           labels: latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: "Log in to Github Container Registry"
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
@@ -44,13 +44,13 @@ jobs:
 
       - name: "Extract Metadata"
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ matrix.image }}
           labels: latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: true
       - name: Check coding styles and formatting
@@ -57,15 +57,15 @@ jobs:
           --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: true
 


### PR DESCRIPTION
## Summary
- update CI workflow actions to Node 24-compatible major versions
- update Docker publishing workflow actions to current major versions

## Task Context
- Task ID: TU-414
- Notion: https://www.notion.so/363c25603b0b815c91f4d4911e8628a8

