### PR TITLE
[TU-402] 지원금 과거 학기 대시보드 추가

### DIFF
--- a/packages/api/src/feature/funding/controller/funding.controller.ts
+++ b/packages/api/src/feature/funding/controller/funding.controller.ts
@@ -38,6 +38,7 @@ import apiFnd007, {
   type ApiFnd007ResponseOk,
 } from "@clubs/interface/api/funding/endpoint/apiFnd007";
 import apiFnd008, {
+  type ApiFnd008RequestQuery,
   ApiFnd008RequestUrl,
   type ApiFnd008ResponseOk,
 } from "@clubs/interface/api/funding/endpoint/apiFnd008";
@@ -218,8 +219,12 @@ export default class FundingController {
   @UsePipes(new ZodPipe(apiFnd008))
   async getExecutiveFundings(
     @GetExecutive() executive: GetExecutive,
+    @Query() query: ApiFnd008RequestQuery,
   ): Promise<ApiFnd008ResponseOk> {
-    return this.fundingService.getExecutiveFundings(executive.executiveId);
+    return this.fundingService.getExecutiveFundings(
+      executive.executiveId,
+      query,
+    );
   }
 
   @Executive()

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -30,7 +30,10 @@ import {
   ApiFnd006ResponseOk,
 } from "@clubs/interface/api/funding/endpoint/apiFnd006";
 import { ApiFnd007ResponseOk } from "@clubs/interface/api/funding/endpoint/apiFnd007";
-import { ApiFnd008ResponseOk } from "@clubs/interface/api/funding/endpoint/apiFnd008";
+import {
+  ApiFnd008RequestQuery,
+  ApiFnd008ResponseOk,
+} from "@clubs/interface/api/funding/endpoint/apiFnd008";
 import {
   type ApiFnd009RequestParam,
   type ApiFnd009RequestQuery,
@@ -567,10 +570,12 @@ export default class FundingService {
 
   async getExecutiveFundings(
     executiveId: IExecutive["id"],
+    query: ApiFnd008RequestQuery = {},
   ): Promise<ApiFnd008ResponseOk> {
     await this.userPublicService.checkCurrentExecutive(executiveId);
 
-    const semesterId = await this.semesterPublicService.loadId();
+    const semesterId =
+      query.semesterId ?? (await this.semesterPublicService.loadId());
     const activityDId = await this.activityDurationPublicService.loadId({
       semesterId,
     });
@@ -587,8 +592,20 @@ export default class FundingService {
     const devisions = await this.clubPublicService.fetchDivisionSummaries(
       clubs.map(club => club.division.id),
     );
+    const chargedExecutiveIds = Array.from(
+      new Set(
+        fundings
+          .map(funding => funding.chargedExecutive?.id)
+          .filter((id): id is number => id !== undefined),
+      ),
+    );
+
     const executives =
-      await this.userPublicService.fetchCurrentExecutiveSummaries();
+      query.semesterId === undefined
+        ? await this.userPublicService.fetchCurrentExecutiveSummaries()
+        : await this.userPublicService.fetchExecutiveSummaries(
+            chargedExecutiveIds,
+          );
 
     const clubsWithCounts = clubs.map(club => ({
       ...club,
@@ -646,31 +663,31 @@ export default class FundingService {
     const executivesWithCounts = executives.map(executive => ({
       ...executive,
       totalCount: fundings.filter(
-        funding => funding.chargedExecutive.id === executive.id,
+        funding => funding.chargedExecutive?.id === executive.id,
       ).length,
       appliedCount: fundings.filter(
         funding =>
-          funding.chargedExecutive.id === executive.id &&
+          funding.chargedExecutive?.id === executive.id &&
           funding.fundingStatusEnum === FundingStatusEnum.Applied,
       ).length,
       approvedCount: fundings.filter(
         funding =>
-          funding.chargedExecutive.id === executive.id &&
+          funding.chargedExecutive?.id === executive.id &&
           funding.fundingStatusEnum === FundingStatusEnum.Approved,
       ).length,
       partialCount: fundings.filter(
         funding =>
-          funding.chargedExecutive.id === executive.id &&
+          funding.chargedExecutive?.id === executive.id &&
           funding.fundingStatusEnum === FundingStatusEnum.Partial,
       ).length,
       rejectedCount: fundings.filter(
         funding =>
-          funding.chargedExecutive.id === executive.id &&
+          funding.chargedExecutive?.id === executive.id &&
           funding.fundingStatusEnum === FundingStatusEnum.Rejected,
       ).length,
       committeeCount: fundings.filter(
         funding =>
-          funding.chargedExecutive.id === executive.id &&
+          funding.chargedExecutive?.id === executive.id &&
           funding.fundingStatusEnum === FundingStatusEnum.Committee,
       ).length,
       chargedClubs: clubs
@@ -753,15 +770,12 @@ export default class FundingService {
     query: ApiFnd009RequestQuery,
   ): Promise<ApiFnd009ResponseOk> {
     await this.userPublicService.checkCurrentExecutive(executiveId);
-    const semesterId = await this.semesterPublicService.loadId();
-    const activityDId =
-      query.activityDurationId === undefined
-        ? await this.activityDurationPublicService.loadId({
-            semesterId,
-          })
-        : query.activityDurationId;
+    const semesterId =
+      query.semesterId ?? (await this.semesterPublicService.loadId());
+    const activityDId = await this.activityDurationPublicService.loadId({
+      semesterId,
+    });
 
-    // TODO: 지난 지원금 신청 기간을 조회하도록 임시 ㅅ수정해 두었으니 복구할 것
     const fundings = await this.fundingRepository.fetchSummaries(
       param.clubId,
       activityDId,

--- a/packages/interface/src/api/funding/endpoint/apiFnd008.ts
+++ b/packages/interface/src/api/funding/endpoint/apiFnd008.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClubSummaryResponse } from "@clubs/interface/api/club/type/club.type";
 import { zExecutiveSummary } from "@clubs/interface/api/user/type/user.type";
 
@@ -17,7 +19,9 @@ export const ApiFnd008RequestUrl = "/executive/fundings";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({});
+const requestQuery = z.object({
+  semesterId: zSemester.shape.id.optional(),
+});
 
 const requestBody = z.object({});
 

--- a/packages/interface/src/api/funding/endpoint/apiFnd009.ts
+++ b/packages/interface/src/api/funding/endpoint/apiFnd009.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
-import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
+import { zSemester } from "@clubs/domain/semester/semester";
 
 import { zClubSummary } from "@clubs/interface/api/club/type/club.type";
 import { zExecutiveSummary } from "@clubs/interface/api/user/type/user.type";
@@ -24,7 +24,7 @@ const requestParam = z.object({
 });
 
 const requestQuery = z.object({
-  activityDurationId: zActivityDuration.shape.id.optional(),
+  semesterId: zSemester.shape.id.optional(),
 });
 
 const requestBody = z.object({});

--- a/packages/web/src/app/executive/funding/page.tsx
+++ b/packages/web/src/app/executive/funding/page.tsx
@@ -10,6 +10,7 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
+import ExecutivePastFundingDashboardSection from "@sparcs-clubs/web/features/executive/funding/components/ExecutivePastFundingDashboardSection";
 import ExecutiveFundingFrame from "@sparcs-clubs/web/features/executive/funding/frames/ExecutiveFundingFrame";
 
 const ExecutiveFunding = () => {
@@ -35,7 +36,7 @@ const ExecutiveFunding = () => {
   }
 
   return (
-    <FlexWrapper direction="column" gap={20}>
+    <FlexWrapper direction="column" gap={60}>
       <PageHead
         items={[
           { name: "집행부원 대시보드", path: "/executive" },
@@ -44,6 +45,7 @@ const ExecutiveFunding = () => {
         title="지원금 신청 내역"
       />
       <ExecutiveFundingFrame />
+      <ExecutivePastFundingDashboardSection />
     </FlexWrapper>
   );
 };

--- a/packages/web/src/app/executive/funding/semester/[id]/page.tsx
+++ b/packages/web/src/app/executive/funding/semester/[id]/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
+
+import NotFound from "@sparcs-clubs/web/app/not-found";
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
+import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
+import ExecutiveFundingFrame from "@sparcs-clubs/web/features/executive/funding/frames/ExecutiveFundingFrame";
+
+const ExecutiveFundingSemester = () => {
+  const { isLoggedIn, login, profile } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const { id } = useParams<{ id: string }>();
+
+  const parsedSemesterId = Number(id);
+  const isValidSemesterId =
+    Number.isInteger(parsedSemesterId) && parsedSemesterId > 0;
+
+  const {
+    data: semestersData,
+    isLoading: isSemestersLoading,
+    isError: isSemestersError,
+  } = useGetSemesters({ pageOffset: 1, itemCount: 100 });
+
+  const semester = useMemo(
+    () =>
+      semestersData?.semesters.find(
+        semesterItem => semesterItem.id === parsedSemesterId,
+      ),
+    [parsedSemesterId, semestersData?.semesters],
+  );
+
+  useEffect(() => {
+    if (isLoggedIn !== undefined || profile !== undefined) {
+      setLoading(false);
+    }
+  }, [isLoggedIn, profile]);
+
+  if (loading) {
+    return <AsyncBoundary isLoading={loading} isError />;
+  }
+
+  if (!isLoggedIn) {
+    return <LoginRequired login={login} />;
+  }
+
+  if (profile?.type !== UserTypeEnum.Executive || !isValidSemesterId) {
+    return <NotFound />;
+  }
+
+  if (isSemestersError) {
+    return <NotFound />;
+  }
+
+  if (!isSemestersLoading && !semester) {
+    return <NotFound />;
+  }
+
+  return (
+    <AsyncBoundary isLoading={isSemestersLoading} isError={isSemestersError}>
+      <FlexWrapper direction="column" gap={60}>
+        <PageHead
+          items={[
+            { name: "집행부원 대시보드", path: "/executive" },
+            { name: "지원금 신청 내역", path: "/executive/funding" },
+          ]}
+          title={`지원금 신청 내역 (${semester?.year}년 ${semester?.name}학기)`}
+          enableLast
+        />
+        <ExecutiveFundingFrame semesterId={parsedSemesterId} />
+      </FlexWrapper>
+    </AsyncBoundary>
+  );
+};
+
+export default ExecutiveFundingSemester;

--- a/packages/web/src/features/executive/frames/ExecutiveDashboardFrame.tsx
+++ b/packages/web/src/features/executive/frames/ExecutiveDashboardFrame.tsx
@@ -177,8 +177,7 @@ const ExecutiveDashboardFrame = () => {
               />
               <DashboardButton
                 text="지원금 신청 내역"
-                link=""
-                // TODO: 지원금 신청 내역 링크 추가
+                link="/executive/funding"
               />
             </FlexWrapper>
           </DashboardSectionInner>

--- a/packages/web/src/features/executive/funding/components/ExecutivePastFundingDashboardSection.tsx
+++ b/packages/web/src/features/executive/funding/components/ExecutivePastFundingDashboardSection.tsx
@@ -1,0 +1,102 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useMemo } from "react";
+
+import { ApiSem001ResponseOK } from "@clubs/interface/api/semester/apiSem001";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import Table from "@sparcs-clubs/web/common/components/Table";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
+import useGetFundingDeadline from "@sparcs-clubs/web/features/manage-club/funding/services/useGetFundingDeadline";
+import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+
+type Semester = ApiSem001ResponseOK["semesters"][number];
+
+const columnHelper = createColumnHelper<Semester>();
+
+const columns = [
+  columnHelper.accessor(row => `${row.year}년 ${row.name}학기`, {
+    id: "term",
+    header: "학기",
+    cell: info => info.getValue(),
+    size: 220,
+  }),
+  columnHelper.accessor(
+    row =>
+      `${formatDate(new Date(row.startTerm))} ~ ${formatDate(new Date(row.endTerm))}`,
+    {
+      id: "duration",
+      header: "활동 기간",
+      cell: info => info.getValue(),
+      size: 420,
+    },
+  ),
+];
+
+const ExecutivePastFundingDashboardSection = () => {
+  const {
+    data: semestersData,
+    isLoading: isSemestersLoading,
+    isError: isSemestersError,
+  } = useGetSemesters({ pageOffset: 1, itemCount: 100 });
+
+  const {
+    data: fundingDeadline,
+    isLoading: isFundingDeadlineLoading,
+    isError: isFundingDeadlineError,
+  } = useGetFundingDeadline();
+
+  const pastSemesters = useMemo(() => {
+    const targetSemesterId = fundingDeadline?.targetDuration.semester.id;
+    const targetSemester = semestersData?.semesters.find(
+      semester => semester.id === targetSemesterId,
+    );
+
+    return (semestersData?.semesters ?? [])
+      .filter(semester => {
+        if (!targetSemesterId) return true;
+        if (semester.id === targetSemesterId) return false;
+        if (!targetSemester) return true;
+
+        return (
+          new Date(semester.endTerm).getTime() <=
+          new Date(targetSemester.startTerm).getTime()
+        );
+      })
+      .sort(
+        (a, b) => new Date(b.endTerm).getTime() - new Date(a.endTerm).getTime(),
+      );
+  }, [fundingDeadline, semestersData?.semesters]);
+
+  const table = useReactTable({
+    data: pastSemesters,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return (
+    <FoldableSectionTitle title="과거 지원금 대시보드">
+      <AsyncBoundary
+        isLoading={isSemestersLoading || isFundingDeadlineLoading}
+        isError={isSemestersError || isFundingDeadlineError}
+      >
+        <FlexWrapper direction="column" gap={20}>
+          <Table
+            table={table}
+            minWidth={820}
+            emptyMessage="과거 지원금 대시보드가 없습니다"
+            rowLink={row => `/executive/funding/semester/${row.id}`}
+          />
+        </FlexWrapper>
+      </AsyncBoundary>
+    </FoldableSectionTitle>
+  );
+};
+
+export default ExecutivePastFundingDashboardSection;

--- a/packages/web/src/features/executive/funding/components/ExecutivePastFundingSection.tsx
+++ b/packages/web/src/features/executive/funding/components/ExecutivePastFundingSection.tsx
@@ -6,6 +6,7 @@ import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 
 import useGetExecutiveClubFunding from "../hooks/useGetExecutiveClubFunding";
 import ExecutiveClubFundingsTable from "./ExecutiveClubFundingsTable";
@@ -50,10 +51,15 @@ const ExecutivePastFundingSection: React.FC<
     <FoldableSectionTitle title="과거 지원금" childrenMargin="30px">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper direction="column" gap={30}>
+          {dataList.length === 0 && (
+            <Typography color="GRAY.300" fs={16} lh={24}>
+              과거 지원금 신청 내역이 없습니다
+            </Typography>
+          )}
           {dataList.map(data => (
             <FoldableSection
-              key={data.term.id}
-              title={`${data.term.year}년 ${data.term.name}학기 (총 ${data.items?.fundings ? data.items.fundings.length : 0}개)`}
+              key={data.semester.id}
+              title={`${data.semester.year}년 ${data.semester.name}학기 (총 ${data.items?.fundings ? data.items.fundings.length : 0}개)`}
               childrenMargin="20px"
             >
               {data.items == null ? (

--- a/packages/web/src/features/executive/funding/frames/ExecutiveFundingFrame.tsx
+++ b/packages/web/src/features/executive/funding/frames/ExecutiveFundingFrame.tsx
@@ -13,12 +13,18 @@ import ExecutiveFundingClubTable from "../components/ExecutiveFundingClubTable";
 import FundingStatistic from "../components/FundingStatistic";
 import useGetExecutiveFundings from "../services/useGetExecutiveFundings";
 
-const ExecutiveFundingFrame = () => {
+interface ExecutiveFundingFrameProps {
+  semesterId?: number;
+}
+
+const ExecutiveFundingFrame = ({ semesterId }: ExecutiveFundingFrameProps) => {
   const [isClubView, setIsClubView] = useState<boolean>(
     window.history.state.isClubView ?? true,
   );
   const [searchText, setSearchText] = useState<string>("");
-  const { data, isLoading, isError } = useGetExecutiveFundings();
+  const { data, isLoading, isError } = useGetExecutiveFundings({
+    semesterId,
+  });
 
   const [selectedClubIds, setSelectedClubIds] = useState<number[]>([]);
   const [selectedClubInfos, setSelectedClubInfos] = useState<

--- a/packages/web/src/features/executive/funding/hooks/useGetExecutiveClubFunding.ts
+++ b/packages/web/src/features/executive/funding/hooks/useGetExecutiveClubFunding.ts
@@ -1,9 +1,9 @@
 import { useQueries } from "@tanstack/react-query";
 
-import { ApiAct009ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct009";
 import { ApiFnd009ResponseOk } from "@clubs/interface/api/funding/endpoint/apiFnd009";
+import { ApiSem001ResponseOK } from "@clubs/interface/api/semester/apiSem001";
 
-import useGetActivityTerms from "@sparcs-clubs/web/features/activity-report/services/useGetActivityTerms";
+import useGetSemesters from "@sparcs-clubs/web/common/services/getSemesters";
 import useGetFundingDeadline from "@sparcs-clubs/web/features/manage-club/funding/services/useGetFundingDeadline";
 
 import { executiveClubFundingForDurationQueryFn } from "../services/useGetExecutiveClubFundingForDuration";
@@ -12,19 +12,17 @@ const useGetExecutiveClubFunding = (
   clubId: number,
 ): {
   data: {
-    term: ApiAct009ResponseOk["terms"][number];
+    semester: ApiSem001ResponseOK["semesters"][number];
     items: ApiFnd009ResponseOk | null;
   }[];
   isLoading: boolean;
   isError: boolean;
 } => {
   const {
-    data: activityTerms,
+    data: semestersData,
     isLoading,
     isError,
-  } = useGetActivityTerms({
-    clubId,
-  });
+  } = useGetSemesters({ pageOffset: 1, itemCount: 100 });
 
   const {
     data: deadline,
@@ -32,27 +30,31 @@ const useGetExecutiveClubFunding = (
     isError: isErrorDeadline,
   } = useGetFundingDeadline();
 
-  const pastActivityTerms = activityTerms?.terms.toReversed().filter(term => {
-    if (!deadline) return true;
+  const pastSemesters = semestersData?.semesters.filter(semester => {
+    const targetSemesterId = deadline?.targetDuration.semester.id;
+    const targetSemester = semestersData.semesters.find(
+      semesterItem => semesterItem.id === targetSemesterId,
+    );
 
-    // 신규 지원금(현재 신청 중인 활동 기간) 빼고, 과거 지원금(과거 활동 기간)만 보여주기
+    if (!targetSemesterId) return true;
+    if (semester.id === targetSemesterId) return false;
+    if (!targetSemester) return true;
+
     return (
-      new Date(term.startTerm).getTime() !==
-        new Date(deadline.targetDuration.startTerm).getTime() &&
-      new Date(term.endTerm).getTime() !==
-        new Date(deadline.targetDuration.endTerm).getTime()
+      new Date(semester.endTerm).getTime() <=
+      new Date(targetSemester.startTerm).getTime()
     );
   });
 
   const queries = useQueries({
-    queries: (pastActivityTerms ?? []).map(activityTerm => ({
-      queryKey: ["getExecutiveClubFunding", clubId, activityTerm.id],
+    queries: (pastSemesters ?? []).map(semester => ({
+      queryKey: ["getExecutiveClubFunding", clubId, semester.id],
       queryFn: () =>
         executiveClubFundingForDurationQueryFn(Number(clubId), {
-          activityDurationId: activityTerm.id,
+          semesterId: semester.id,
         }),
       retry: false,
-      enabled: !!activityTerms,
+      enabled: !!semestersData,
     })),
   });
 
@@ -62,14 +64,19 @@ const useGetExecutiveClubFunding = (
 
   return {
     data:
-      pastActivityTerms?.map((term, index) => ({
-        term,
-        items: successDataList[index],
-      })) ?? [],
+      pastSemesters
+        ?.map((semester, index) => ({
+          semester,
+          items: successDataList[index],
+        }))
+        .filter(data => data.items == null || data.items.fundings.length > 0) ??
+      [],
     isLoading:
       isLoading || isLoadingDeadline || queries.some(query => query.isLoading),
     isError:
-      isError || isErrorDeadline || queries.every(query => query.isError),
+      isError ||
+      isErrorDeadline ||
+      (queries.length > 0 && queries.every(query => query.isError)),
   };
 };
 

--- a/packages/web/src/features/executive/funding/services/useGetExecutiveClubFundingForDuration.ts
+++ b/packages/web/src/features/executive/funding/services/useGetExecutiveClubFundingForDuration.ts
@@ -30,7 +30,7 @@ const useGetExecutiveClubFundingForDuration = (
   query: ApiFnd009RequestQuery,
 ) =>
   useQuery<ApiFnd009ResponseOk, Error>({
-    queryKey: [apiFnd009.url(clubId), query.activityDurationId],
+    queryKey: [apiFnd009.url(clubId), query.semesterId],
     queryFn: () => executiveClubFundingForDurationQueryFn(clubId, query),
   });
 

--- a/packages/web/src/features/executive/funding/services/useGetExecutiveFundings.ts
+++ b/packages/web/src/features/executive/funding/services/useGetExecutiveFundings.ts
@@ -1,16 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 
 import apiFnd008, {
+  ApiFnd008RequestQuery,
   ApiFnd008ResponseOk,
 } from "@clubs/interface/api/funding/endpoint/apiFnd008";
 
 import { axiosClientWithAuth } from "@sparcs-clubs/web/lib/axios";
 
-const useGetExecutiveFundings = () =>
+const useGetExecutiveFundings = (query: ApiFnd008RequestQuery = {}) =>
   useQuery<ApiFnd008ResponseOk, Error>({
-    queryKey: [apiFnd008.url()],
+    queryKey: [apiFnd008.url(), query.semesterId],
     queryFn: async (): Promise<ApiFnd008ResponseOk> => {
-      const { data } = await axiosClientWithAuth.get(apiFnd008.url(), {});
+      const { data } = await axiosClientWithAuth.get(apiFnd008.url(), {
+        params: query,
+      });
 
       return data;
     },


### PR DESCRIPTION
## 작업 내용
- 집행부 지원금 페이지에 과거 학기 대시보드 목록을 추가했습니다.
- 학기별 지원금 대시보드 라우트 `/executive/funding/semester/[id]`를 추가했습니다.
- 동아리별 지원금 페이지에서 과거 지원금을 학기 기준으로 조회해 표시하도록 했습니다.
- FND-008/FND-009 조회 query를 `semesterId` 기준으로 확장했습니다.

## 검증
- `pnpm --filter interface build`
- `pnpm --filter api build`
- `pnpm --filter web build`
- `pnpm --filter interface lint`
- `pnpm --filter api lint`
- `pnpm --filter web lint`
- `curl -I http://localhost:3001/executive/funding/club/1`

Task: TU-402
Notion: https://www.notion.so/358c25603b0b80beae84cfc912e34ea7