### PR TITLE
[TU-417] fix release PR workflow repo lookup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+- 
+
+## Test
+
+- 
+
+## Patch Note
+
+<!-- clubs:patch-note:start -->
+category: none
+text:
+<!-- clubs:patch-note:end -->

--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: dev
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -46,6 +46,22 @@ jobs:
       - name: Fetch release refs
         run: git fetch origin main dev --prune
 
+      - name: Determine version bump
+        id: bump
+        env:
+          PR_TITLE: "${{ github.event.pull_request.title || 'PATCH Release: dev -> main' }}"
+        run: |
+          title="${PR_TITLE}"
+          bump="patch"
+
+          case "${title}" in
+            MAJOR\ *|major\ *) bump="major" ;;
+            MINOR\ *|minor\ *) bump="minor" ;;
+            PATCH\ *|patch\ *) bump="patch" ;;
+          esac
+
+          echo "bump=${bump}" >> "${GITHUB_OUTPUT}"
+
       - name: Generate release patch note
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -53,11 +69,21 @@ jobs:
           node scripts/release/prepare-patch-note.mjs
           --base origin/main
           --head HEAD
+          --bump ${{ steps.bump.outputs.bump }}
           --file packages/web/src/constants/patchNote.ts
 
       - name: Format generated patch note
         if: ${{ hashFiles('packages/web/src/constants/patchNote.ts') != '' }}
         run: pnpm exec prettier --write packages/web/src/constants/patchNote.ts
+
+      - name: Validate generated files
+        run: |
+          unexpected="$(git diff --name-only | grep -Ev '^packages/web/src/constants/patchNote\.ts$' || true)"
+          if [ -n "${unexpected}" ]; then
+            echo "Unexpected generated files:"
+            echo "${unexpected}"
+            exit 1
+          fi
 
       - name: Validate web package
         run: |
@@ -65,8 +91,6 @@ jobs:
           pnpm --filter web build
 
       - name: Commit patch note
-        env:
-          PUSH_TOKEN_KIND: ${{ secrets.RELEASE_BOT_TOKEN != '' && 'RELEASE_BOT_TOKEN' || 'GITHUB_TOKEN' }}
         run: |
           if git diff --quiet -- packages/web/src/constants/patchNote.ts; then
             echo "No patch note changes to commit."
@@ -79,6 +103,4 @@ jobs:
           git commit -m "chore: update release patch note"
           git push origin HEAD:dev
 
-          if [ "${PUSH_TOKEN_KIND}" = "GITHUB_TOKEN" ]; then
-            echo "::notice::Patch note commit was pushed with GITHUB_TOKEN, so dev push workflows will not be triggered by GitHub. Set RELEASE_BOT_TOKEN when CI and stage deploy should run from this generated commit."
-          fi
+          echo "::notice::Patch note commit was pushed with GITHUB_TOKEN. GitHub will not trigger follow-up dev push workflows from this generated commit by design."

--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -1,0 +1,84 @@
+name: Prepare Release Patch Note
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: prepare-release-patch-note
+  cancel-in-progress: false
+
+jobs:
+  prepare-patch-note:
+    name: Prepare patch note commit
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.ref == 'dev'
+      )
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.22.1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: true
+
+      - name: Fetch release refs
+        run: git fetch origin main dev --prune
+
+      - name: Generate release patch note
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >
+          node scripts/release/prepare-patch-note.mjs
+          --base origin/main
+          --head HEAD
+          --file packages/web/src/constants/patchNote.ts
+
+      - name: Format generated patch note
+        if: ${{ hashFiles('packages/web/src/constants/patchNote.ts') != '' }}
+        run: pnpm exec prettier --write packages/web/src/constants/patchNote.ts
+
+      - name: Validate web package
+        run: |
+          pnpm --filter web lint
+          pnpm --filter web build
+
+      - name: Commit patch note
+        env:
+          PUSH_TOKEN_KIND: ${{ secrets.RELEASE_BOT_TOKEN != '' && 'RELEASE_BOT_TOKEN' || 'GITHUB_TOKEN' }}
+        run: |
+          if git diff --quiet -- packages/web/src/constants/patchNote.ts; then
+            echo "No patch note changes to commit."
+            exit 0
+          fi
+
+          git config user.name "clubs-release-bot"
+          git config user.email "clubs-release-bot@users.noreply.github.com"
+          git add packages/web/src/constants/patchNote.ts
+          git commit -m "chore: update release patch note"
+          git push origin HEAD:dev
+
+          if [ "${PUSH_TOKEN_KIND}" = "GITHUB_TOKEN" ]; then
+            echo "::notice::Patch note commit was pushed with GITHUB_TOKEN, so dev push workflows will not be triggered by GitHub. Set RELEASE_BOT_TOKEN when CI and stage deploy should run from this generated commit."
+          fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          number="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"
+          number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base main --head dev --state open --json number --jq '.[0].number // ""')"
           echo "number=${number}" >> "${GITHUB_OUTPUT}"
 
       - name: Create draft release PR
@@ -41,6 +41,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
             --base main \
             --head dev \
             --draft \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,68 @@
+name: Release PR
+
+on:
+  push:
+    branches: ["dev"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: release-pr-dev-main
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    name: Create dev to main draft PR
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Check release diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ahead="$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...dev" --jq '.ahead_by')"
+          echo "ahead=${ahead}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check existing release PR
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          number="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"
+          echo "number=${number}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create draft release PR
+        if: steps.diff.outputs.ahead != '0' && steps.existing.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head dev \
+            --draft \
+            --title "Release: dev -> main" \
+            --body "$(cat <<'BODY'
+          ## Release Flow
+
+          This draft PR was created automatically after `dev` received changes not yet in `main`.
+
+          To prepare the release patch note:
+
+          1. Make sure merged feature PRs have a `clubs:patch-note` block in their PR body.
+          2. Mark this PR as **Ready for review**.
+          3. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev`.
+
+          ## Patch Note Commit Trigger
+
+          The generated patch note commit changes the web bundle, so it should normally trigger the existing `dev` push workflows:
+
+          - `AR-002 PR CI`
+          - `AR-002 Dev Push Stage`
+
+          GitHub does not trigger follow-up workflows from commits pushed with `GITHUB_TOKEN`. Configure `RELEASE_BOT_TOKEN` as a GitHub App token or fine-grained PAT when the patch note commit should trigger CI and staging deploys automatically.
+          BODY
+          )"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -44,7 +44,7 @@ jobs:
             --base main \
             --head dev \
             --draft \
-            --title "Release: dev -> main" \
+            --title "PATCH Release: dev -> main" \
             --body "$(cat <<'BODY'
           ## Release Flow
 
@@ -53,16 +53,12 @@ jobs:
           To prepare the release patch note:
 
           1. Make sure merged feature PRs have a `clubs:patch-note` block in their PR body.
-          2. Mark this PR as **Ready for review**.
-          3. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev`.
+          2. Keep the title prefix as `PATCH`, or change it to `MINOR` or `MAJOR` before marking this PR as ready.
+          3. Mark this PR as **Ready for review**.
+          4. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev`.
 
           ## Patch Note Commit Trigger
 
-          The generated patch note commit changes the web bundle, so it should normally trigger the existing `dev` push workflows:
-
-          - `AR-002 PR CI`
-          - `AR-002 Dev Push Stage`
-
-          GitHub does not trigger follow-up workflows from commits pushed with `GITHUB_TOKEN`. Configure `RELEASE_BOT_TOKEN` as a GitHub App token or fine-grained PAT when the patch note commit should trigger CI and staging deploys automatically.
+          The generated patch note commit intentionally uses `GITHUB_TOKEN`, so GitHub will not trigger follow-up `dev` push workflows from that commit. The prepare workflow validates the generated file before pushing.
           BODY
           )"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ text: 사용자에게 보여도 자연스러운 한국어 패치노트 문장
 <!-- clubs:patch-note:end -->
 ```
 
+릴리즈용 `dev -> main` PR 제목은 `PATCH Release: dev -> main`, `MINOR Release: dev -> main`, `MAJOR Release: dev -> main` 중 하나로 시작해야 합니다. 기본값은 `PATCH`입니다.
+
 - 사용자에게 보일 기능 추가는 `category: feature`를 사용합니다.
 - 사용자에게 보일 버그 수정은 `category: fix`를 사용합니다.
 - UI, 문구, 디자인 변경은 `category: design`을 사용합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,35 @@
    - Behavior에 들어갈 business logic을 정의합니다.
    - 동작성을 확인하기 위한 test를 정의합니다.
 
+## PR 작성 규칙
+
+Codex가 PR을 생성할 때는 PR description에 `## Patch Note` 섹션과 아래 machine-readable block을 반드시 포함합니다.
+
+```md
+<!-- clubs:patch-note:start -->
+category: feature | fix | design | docs | internal | none
+text: 사용자에게 보여도 자연스러운 한국어 패치노트 문장
+<!-- clubs:patch-note:end -->
+```
+
+- 사용자에게 보일 기능 추가는 `category: feature`를 사용합니다.
+- 사용자에게 보일 버그 수정은 `category: fix`를 사용합니다.
+- UI, 문구, 디자인 변경은 `category: design`을 사용합니다.
+- 문서 변경은 `category: docs`를 사용합니다.
+- 내부 리팩터링, 테스트, CI 등 사용자에게 직접 보이지 않는 변경은 `category: internal` 또는 `category: none`을 사용합니다.
+- `text`에는 구현 세부사항, 파일명, 함수명보다 사용자 관점의 변경사항을 씁니다.
+- 여러 항목이 필요하면 `text:` 아래에 bullet을 여러 개 작성합니다.
+- 릴리즈 패치노트 자동 생성기는 이 block만 신뢰하며, `internal`과 `none`은 앱 패치노트에서 제외합니다.
+
+예시:
+
+```md
+<!-- clubs:patch-note:start -->
+category: fix
+text: 활동보고서 상세 화면에서 반려 사유가 보이지 않던 문제를 수정했습니다.
+<!-- clubs:patch-note:end -->
+```
+
 ## Feature: Activity Report
 
 - 관련 경로: `packages/web/**/activity-report/**`, `packages/api/**/activity/**`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "create-branch-pr": "node plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs",
     "create-worktree": "node plugins/worktree-tools/skills/create-worktree/scripts/create_worktree.mjs",
+    "prepare-patch-note": "node scripts/release/prepare-patch-note.mjs",
     "delete-worktree": "node plugins/worktree-tools/skills/delete-worktree/scripts/delete_worktree.mjs",
     "dev": "turbo run dev:setup && turbo watch dev",
     "dev:api": "turbo run dev:setup && turbo watch dev --filter=api",

--- a/scripts/release/prepare-patch-note.mjs
+++ b/scripts/release/prepare-patch-note.mjs
@@ -21,6 +21,7 @@ function parseArgs(argv) {
     base: "origin/main",
     head: "HEAD",
     file: DEFAULT_FILE,
+    bump: "patch",
     dryRun: false,
   };
 
@@ -41,6 +42,12 @@ function parseArgs(argv) {
 
     if (arg === "--file") {
       options.file = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--bump") {
+      options.bump = (argv[index + 1] ?? "").toLowerCase();
       index += 1;
       continue;
     }
@@ -309,7 +316,31 @@ function compareVersion(a, b) {
   return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
 }
 
-function nextVersionFromMain(base, file) {
+function bumpVersion(version, bump) {
+  if (bump === "major") {
+    return { major: version.major + 1, minor: 0, patch: 0 };
+  }
+
+  if (bump === "minor") {
+    return { major: version.major, minor: version.minor + 1, patch: 0 };
+  }
+
+  if (bump === "patch") {
+    return {
+      major: version.major,
+      minor: version.minor,
+      patch: version.patch + 1,
+    };
+  }
+
+  throw new Error(`Unsupported version bump: ${bump}`);
+}
+
+function formatVersion(version) {
+  return `v.${version.major}.${version.minor}.${version.patch}`;
+}
+
+function nextVersionFromMain(base, file, bump) {
   const mainSource = runGit(["show", `${base}:${file}`]);
   const versions = parseVersions(mainSource);
   if (versions.length === 0) {
@@ -317,7 +348,7 @@ function nextVersionFromMain(base, file) {
   }
 
   const latest = versions.sort(compareVersion).at(-1);
-  return `v.${latest.major}.${latest.minor}.${latest.patch + 1}`;
+  return formatVersion(bumpVersion(latest, bump));
 }
 
 function kstDateLiteral() {
@@ -413,7 +444,7 @@ async function main() {
     return;
   }
 
-  const version = nextVersionFromMain(options.base, options.file);
+  const version = nextVersionFromMain(options.base, options.file, options.bump);
   const sourceHash = createHash("sha256")
     .update(JSON.stringify({ version, notes }))
     .digest("hex")

--- a/scripts/release/prepare-patch-note.mjs
+++ b/scripts/release/prepare-patch-note.mjs
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const DEFAULT_FILE = "packages/web/src/constants/patchNote.ts";
+const PATCH_NOTE_START = "<!-- clubs:patch-note:start -->";
+const PATCH_NOTE_END = "<!-- clubs:patch-note:end -->";
+
+const CATEGORY_SECTIONS = [
+  ["feature", "신규 기능은 다음과 같습니다."],
+  ["fix", "오류 수정은 다음과 같습니다."],
+  ["design", "디자인 수정은 다음과 같습니다."],
+  ["docs", "문서 변경은 다음과 같습니다."],
+  ["etc", "기타 변경사항은 다음과 같습니다."],
+];
+
+function parseArgs(argv) {
+  const options = {
+    base: "origin/main",
+    head: "HEAD",
+    file: DEFAULT_FILE,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--base") {
+      options.base = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--head") {
+      options.head = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--file") {
+      options.file = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function runGit(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function parseRepository() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (repository) {
+    return repository;
+  }
+
+  const remoteUrl = runGit(["remote", "get-url", "origin"]);
+  const match = remoteUrl.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+  if (!match) {
+    throw new Error("Could not determine GitHub repository.");
+  }
+  return match[1];
+}
+
+async function githubApi(path) {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    return undefined;
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      "Accept": "application/vnd.github+json",
+      "Authorization": `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed (${response.status}): ${path}`);
+  }
+
+  return response.json();
+}
+
+function commitsInRange(base, head) {
+  const output = runGit([
+    "log",
+    "--reverse",
+    "--format=%H%x1f%s",
+    `${base}..${head}`,
+  ]);
+
+  if (!output) {
+    return [];
+  }
+
+  return output.split("\n").map(line => {
+    const [sha, subject] = line.split("\x1f");
+    return { sha, subject };
+  });
+}
+
+function extractPrNumbers(subject) {
+  const numbers = [];
+  const matcher = /\(#(\d+)\)/g;
+  let match = matcher.exec(subject);
+  while (match) {
+    numbers.push(Number(match[1]));
+    match = matcher.exec(subject);
+  }
+  return numbers;
+}
+
+async function collectPullRequests(commits, repository) {
+  const byNumber = new Map();
+
+  for (const commit of commits) {
+    for (const number of extractPrNumbers(commit.subject)) {
+      if (!byNumber.has(number)) {
+        byNumber.set(number, { number });
+      }
+    }
+
+    const pulls = await githubApi(
+      `/repos/${repository}/commits/${commit.sha}/pulls`,
+    );
+    if (!pulls) {
+      continue;
+    }
+
+    for (const pull of pulls) {
+      if (!byNumber.has(pull.number)) {
+        byNumber.set(pull.number, { number: pull.number });
+      }
+    }
+  }
+
+  const result = [];
+  for (const { number } of byNumber.values()) {
+    const pull = await githubApi(`/repos/${repository}/pulls/${number}`);
+    if (pull) {
+      if (pull.base?.ref && pull.base.ref !== "dev") {
+        continue;
+      }
+      result.push(pull);
+      continue;
+    }
+
+    const fallbackCommit = commits.find(commit =>
+      extractPrNumbers(commit.subject).includes(number),
+    );
+    result.push({
+      number,
+      title: fallbackCommit?.subject.replace(/\s*\(#\d+\)\s*$/, "") ?? "",
+      body: "",
+      labels: [],
+    });
+  }
+
+  return result;
+}
+
+function inferCategoryFromPullRequest(pull) {
+  const labels = (pull.labels ?? []).map(label => label.name);
+
+  for (const category of ["feature", "fix", "design", "docs", "etc"]) {
+    if (labels.includes(`patch:${category}`)) {
+      return category;
+    }
+  }
+
+  const title = pull.title.toLowerCase();
+  if (/^(feat|feature)(\(.+\))?:/.test(title)) return "feature";
+  if (/^(fix|hotfix)(\(.+\))?:/.test(title)) return "fix";
+  if (/^(style|design)(\(.+\))?:/.test(title)) return "design";
+  if (/^docs(\(.+\))?:/.test(title)) return "docs";
+  return "etc";
+}
+
+function stripBullet(line) {
+  return line.replace(/^\s*[-*]\s+/, "").trim();
+}
+
+function sanitizeText(value) {
+  return value
+    .replace(/^\[[^\]]+]\s*/, "")
+    .replace(
+      /^(feat|feature|fix|hotfix|chore|docs|style|design|refactor|test)(\([^)]+\))?:\s*/i,
+      "",
+    )
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/@\w[\w-]*/g, " ")
+    .replace(/\$\{/g, "")
+    .replace(/[<>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}
+
+function parsePatchNoteBlock(body) {
+  const startIndex = body.indexOf(PATCH_NOTE_START);
+  const endIndex = body.indexOf(PATCH_NOTE_END);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    return undefined;
+  }
+
+  const block = body
+    .slice(startIndex + PATCH_NOTE_START.length, endIndex)
+    .trim();
+
+  if (/^none$/i.test(block)) {
+    return { category: "none", texts: [] };
+  }
+
+  const lines = block.split(/\r?\n/);
+  const categoryLine = lines.find(line => /^category\s*:/i.test(line));
+  const rawCategory = categoryLine?.split(":").slice(1).join(":").trim();
+  const category = rawCategory?.toLowerCase() || "etc";
+  const textIndex = lines.findIndex(line => /^text\s*:/i.test(line));
+  const texts = [];
+
+  if (textIndex !== -1) {
+    const afterText = lines[textIndex].split(":").slice(1).join(":").trim();
+    if (afterText) {
+      texts.push(afterText);
+    }
+
+    for (const line of lines.slice(textIndex + 1)) {
+      if (/^[a-z-]+\s*:/i.test(line)) {
+        break;
+      }
+
+      const text = stripBullet(line);
+      if (text) {
+        texts.push(text);
+      }
+    }
+  }
+
+  if (texts.length === 0) {
+    for (const line of lines) {
+      if (/^category\s*:/i.test(line)) {
+        continue;
+      }
+      const text = stripBullet(line);
+      if (text) {
+        texts.push(text);
+      }
+    }
+  }
+
+  return { category, texts: texts.map(sanitizeText).filter(Boolean) };
+}
+
+function normalizePullRequestNote(pull) {
+  const labels = (pull.labels ?? []).map(label => label.name);
+  if (labels.includes("patch:skip")) {
+    return [];
+  }
+
+  const explicit = parsePatchNoteBlock(pull.body ?? "");
+  const note = explicit ?? {
+    category: inferCategoryFromPullRequest(pull),
+    texts: [sanitizeText(pull.title)],
+  };
+
+  if (note.category === "none" || note.category === "internal") {
+    return [];
+  }
+
+  const allowed = new Set(CATEGORY_SECTIONS.map(([category]) => category));
+  const category = allowed.has(note.category) ? note.category : "etc";
+
+  return note.texts.map(text => ({
+    category,
+    text: `${text.replace(/[.。]\s*$/, "")}. (#${pull.number})`,
+  }));
+}
+
+function parseVersions(source) {
+  return [...source.matchAll(/version:\s*"v\.(\d+)\.(\d+)\.(\d+)"/g)].map(
+    match => ({
+      major: Number(match[1]),
+      minor: Number(match[2]),
+      patch: Number(match[3]),
+    }),
+  );
+}
+
+function compareVersion(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+function nextVersionFromMain(base, file) {
+  const mainSource = runGit(["show", `${base}:${file}`]);
+  const versions = parseVersions(mainSource);
+  if (versions.length === 0) {
+    throw new Error(`No patch note versions found in ${base}:${file}`);
+  }
+
+  const latest = versions.sort(compareVersion).at(-1);
+  return `v.${latest.major}.${latest.minor}.${latest.patch + 1}`;
+}
+
+function kstDateLiteral() {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+
+  const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
+  return `${values.year}.${values.month}.${values.day}`;
+}
+
+function escapeTemplateLiteral(value) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${");
+}
+
+function buildPatchNoteContent(version, notes) {
+  const contentVersion = version.replace(/^v\./, "v");
+  const grouped = new Map(
+    CATEGORY_SECTIONS.map(([category]) => [category, []]),
+  );
+
+  for (const note of notes) {
+    grouped.get(note.category)?.push(note.text);
+  }
+
+  const lines = [`Clubs ${contentVersion}`];
+  for (const [category, title] of CATEGORY_SECTIONS) {
+    const items = grouped.get(category) ?? [];
+    if (items.length === 0) {
+      continue;
+    }
+
+    lines.push(title);
+    for (const item of items) {
+      lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+function buildEntry(version, notes, sourceHash) {
+  const content = escapeTemplateLiteral(buildPatchNoteContent(version, notes));
+  return `  // clubs:auto-patch-note version=${version} source=${sourceHash}
+  {
+    version: "${version}",
+    date: new Date("${kstDateLiteral()}"),
+    patchNoteContent: \`${content}\`,
+  },
+`;
+}
+
+function replaceOrInsertEntry(source, version, entry) {
+  const versionPattern = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const existingEntry = new RegExp(
+    `\\s*(?:// clubs:auto-patch-note[^\\n]*\\n)?\\s*\\{\\n\\s*version: "${versionPattern}",[\\s\\S]*?\\n\\s*\\},\\n`,
+  );
+
+  if (existingEntry.test(source)) {
+    return source.replace(existingEntry, `\n${entry}`);
+  }
+
+  const listStart = "const patchNoteList: patchNote[] = [\n";
+  if (!source.includes(listStart)) {
+    throw new Error("Could not find patchNoteList declaration.");
+  }
+
+  return source.replace(listStart, `${listStart}${entry}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const repository = parseRepository();
+  const commits = commitsInRange(options.base, options.head);
+
+  if (commits.length === 0) {
+    console.log("No commits found in release range.");
+    return;
+  }
+
+  const pullRequests = await collectPullRequests(commits, repository);
+  const notes = pullRequests.flatMap(normalizePullRequestNote);
+
+  if (notes.length === 0) {
+    console.log("No user-facing patch note entries found.");
+    return;
+  }
+
+  const version = nextVersionFromMain(options.base, options.file);
+  const sourceHash = createHash("sha256")
+    .update(JSON.stringify({ version, notes }))
+    .digest("hex")
+    .slice(0, 12);
+  const source = readFileSync(options.file, "utf8");
+  const entry = buildEntry(version, notes, sourceHash);
+  const updated = replaceOrInsertEntry(source, version, entry);
+
+  if (options.dryRun) {
+    console.log(entry);
+    return;
+  }
+
+  if (updated === source) {
+    console.log(`Patch note ${version} is already up to date.`);
+    return;
+  }
+
+  writeFileSync(options.file, updated, "utf8");
+  console.log(`Prepared ${version} with ${notes.length} patch note entries.`);
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Pass `--repo "$GITHUB_REPOSITORY"` to `gh pr list` and `gh pr create` in the release PR workflow.
- This fixes `fatal: not a git repository` on runners because the workflow intentionally does not checkout the repo.

## Test

- `pnpm exec prettier --check .github/workflows/release-pr.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-pr.yml"); puts "ok"'`

## Task Context

- Task ID: TU-417
- Failed run: https://github.com/sparcs-kaist/clubs/actions/runs/25988388312/job/76389971380

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text:
<!-- clubs:patch-note:end -->
