### PR TITLE
[TU-417] fix release PR workflow repo lookup

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          number="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"
+          number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base main --head dev --state open --json number --jq '.[0].number // ""')"
           echo "number=${number}" >> "${GITHUB_OUTPUT}"
 
       - name: Create draft release PR
@@ -41,6 +41,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
             --base main \
             --head dev \
             --draft \


### PR DESCRIPTION
## Summary

- Pass `--repo "$GITHUB_REPOSITORY"` to `gh pr list` and `gh pr create` in the release PR workflow.
- This fixes `fatal: not a git repository` on runners because the workflow intentionally does not checkout the repo.

## Test

- `../TU-417/node_modules/.bin/prettier --check .github/workflows/release-pr.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-pr.yml"); puts "ok"'`

## Task Context

- Task ID: TU-417
- Failed run: https://github.com/sparcs-kaist/clubs/actions/runs/25988388312/job/76389971380
- Replaces closed PR: https://github.com/sparcs-kaist/clubs/pull/1798

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text:
<!-- clubs:patch-note:end -->
