### PR TITLE
[TU-417] 자동패치노트 추가 수정

### DIFF
--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: prepare-release-patch-note
@@ -49,20 +49,25 @@ jobs:
       - name: Determine version bump
         id: bump
         env:
-          PR_TITLE: "${{ github.event.pull_request.title || 'PATCH Release: dev -> main' }}"
+          PR_TITLE: "${{ github.event.pull_request.title || '[PATCH] Release' }}"
         run: |
           title="${PR_TITLE}"
+          label="PATCH"
           bump="patch"
 
-          case "${title}" in
-            MAJOR\ *|major\ *) bump="major" ;;
-            MINOR\ *|minor\ *) bump="minor" ;;
-            PATCH\ *|patch\ *) bump="patch" ;;
-          esac
+          if [[ "${title}" =~ ^\[([Mm][Aa][Jj][Oo][Rr]|[Mm][Ii][Nn][Oo][Rr]|[Pp][Aa][Tt][Cc][Hh])\] ]]; then
+            label="$(printf "%s" "${BASH_REMATCH[1]}" | tr "[:lower:]" "[:upper:]")"
+          elif [[ "${title}" =~ ^([Mm][Aa][Jj][Oo][Rr]|[Mm][Ii][Nn][Oo][Rr]|[Pp][Aa][Tt][Cc][Hh])[[:space:]] ]]; then
+            label="$(printf "%s" "${BASH_REMATCH[1]}" | tr "[:lower:]" "[:upper:]")"
+          fi
+
+          bump="$(printf "%s" "${label}" | tr "[:upper:]" "[:lower:]")"
 
           echo "bump=${bump}" >> "${GITHUB_OUTPUT}"
+          echo "label=${label}" >> "${GITHUB_OUTPUT}"
 
       - name: Generate release patch note
+        id: generate
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >
@@ -104,3 +109,14 @@ jobs:
           git push origin HEAD:dev
 
           echo "::notice::Patch note commit was pushed with GITHUB_TOKEN. GitHub will not trigger follow-up dev push workflows from this generated commit by design."
+
+      - name: Update release PR title
+        if: github.event_name == 'pull_request' && steps.generate.outputs.display_version != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ${{ steps.bump.outputs.label }}
+          RELEASE_VERSION: ${{ steps.generate.outputs.display_version }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "[${RELEASE_TYPE}] Release: ${RELEASE_VERSION}"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,17 +35,28 @@ jobs:
           number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base main --head dev --state open --json number --jq '.[0].number // ""')"
           echo "number=${number}" >> "${GITHUB_OUTPUT}"
 
+      - name: Get current release version
+        id: version
+        if: steps.diff.outputs.ahead != '0' && steps.existing.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source="$(gh api "repos/${GITHUB_REPOSITORY}/contents/packages/web/src/constants/patchNote.ts?ref=main" --jq '.content' | base64 -d)"
+          version="$(printf "%s" "${source}" | node -e 'const fs = require("node:fs"); const source = fs.readFileSync(0, "utf8"); const versions = [...source.matchAll(/version:\s*"v\.(\d+)\.(\d+)\.(\d+)"/g)].map(match => match.slice(1).map(Number)); versions.sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2]); const latest = versions.at(-1); if (!latest) throw new Error("No patch note versions found"); console.log(latest.join("."));')"
+          echo "current=${version}" >> "${GITHUB_OUTPUT}"
+
       - name: Create draft release PR
         if: steps.diff.outputs.ahead != '0' && steps.existing.outputs.number == ''
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
         run: |
           gh pr create \
             --repo "${GITHUB_REPOSITORY}" \
             --base main \
             --head dev \
             --draft \
-            --title "PATCH Release: dev -> main" \
+            --title "[PATCH] Release: from ${CURRENT_VERSION}" \
             --body "$(cat <<'BODY'
           ## 릴리즈 흐름
 
@@ -54,9 +65,9 @@ jobs:
           릴리즈 패치노트를 준비하려면:
 
           1. 머지된 feature PR 본문에 `clubs:patch-note` block이 있는지 확인합니다.
-          2. 기본값은 `PATCH`입니다. 필요하면 이 PR을 ready 상태로 바꾸기 전에 제목 prefix를 `MINOR` 또는 `MAJOR`로 변경합니다.
+          2. 기본값은 `[PATCH]`입니다. 필요하면 이 PR을 ready 상태로 바꾸기 전에 제목 prefix를 `[MINOR]` 또는 `[MAJOR]`로 변경합니다.
           3. 이 PR을 **Ready for review**로 변경합니다.
-          4. `Prepare Release Patch Note` workflow가 `dev`에 패치노트 커밋을 하나 생성합니다.
+          4. `Prepare Release Patch Note` workflow가 `dev`에 패치노트 커밋을 하나 생성하고, PR 제목을 `[TYPE] Release: X.Y.Z` 형식으로 갱신합니다.
 
           ## 패치노트 커밋 트리거
 
@@ -69,9 +80,9 @@ jobs:
           To prepare the release patch note:
 
           1. Make sure merged feature PRs have a `clubs:patch-note` block in their PR body.
-          2. Keep the title prefix as `PATCH`, or change it to `MINOR` or `MAJOR` before marking this PR as ready.
+          2. Keep the title prefix as `[PATCH]`, or change it to `[MINOR]` or `[MAJOR]` before marking this PR as ready.
           3. Mark this PR as **Ready for review**.
-          4. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev`.
+          4. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev` and rename this PR to `[TYPE] Release: X.Y.Z`.
 
           ## Patch Note Commit Trigger
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -47,6 +47,21 @@ jobs:
             --draft \
             --title "PATCH Release: dev -> main" \
             --body "$(cat <<'BODY'
+          ## 릴리즈 흐름
+
+          이 draft PR은 `dev`에 `main`에 아직 반영되지 않은 변경사항이 생겼을 때 자동으로 생성됩니다.
+
+          릴리즈 패치노트를 준비하려면:
+
+          1. 머지된 feature PR 본문에 `clubs:patch-note` block이 있는지 확인합니다.
+          2. 기본값은 `PATCH`입니다. 필요하면 이 PR을 ready 상태로 바꾸기 전에 제목 prefix를 `MINOR` 또는 `MAJOR`로 변경합니다.
+          3. 이 PR을 **Ready for review**로 변경합니다.
+          4. `Prepare Release Patch Note` workflow가 `dev`에 패치노트 커밋을 하나 생성합니다.
+
+          ## 패치노트 커밋 트리거
+
+          생성된 패치노트 커밋은 의도적으로 `GITHUB_TOKEN`을 사용합니다. 따라서 GitHub는 해당 커밋으로 인한 후속 `dev` push workflow를 실행하지 않습니다. prepare workflow가 push 전에 생성 파일을 검증합니다.
+
           ## Release Flow
 
           This draft PR was created automatically after `dev` received changes not yet in `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ text: 사용자에게 보여도 자연스러운 한국어 패치노트 문장
 <!-- clubs:patch-note:end -->
 ```
 
-릴리즈용 `dev -> main` PR 제목은 `PATCH Release: dev -> main`, `MINOR Release: dev -> main`, `MAJOR Release: dev -> main` 중 하나로 시작해야 합니다. 기본값은 `PATCH`입니다.
+릴리즈용 `dev -> main` PR 제목은 `[PATCH] Release: from X.Y.Z`, `[MINOR] Release: from X.Y.Z`, `[MAJOR] Release: from X.Y.Z` 중 하나로 시작해야 합니다. 기본값은 `[PATCH]`입니다. 패치노트 생성 workflow가 완료되면 PR 제목은 `[TYPE] Release: X.Y.Z` 형식으로 갱신됩니다.
 
 - 사용자에게 보일 기능 추가는 `category: feature`를 사용합니다.
 - 사용자에게 보일 버그 수정은 `category: fix`를 사용합니다.

--- a/scripts/release/prepare-patch-note.mjs
+++ b/scripts/release/prepare-patch-note.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 const DEFAULT_FILE = "packages/web/src/constants/patchNote.ts";
 const PATCH_NOTE_START = "<!-- clubs:patch-note:start -->";
@@ -340,6 +340,23 @@ function formatVersion(version) {
   return `v.${version.major}.${version.minor}.${version.patch}`;
 }
 
+function displayVersion(version) {
+  return version.replace(/^v\./, "");
+}
+
+function writeGitHubOutput(values) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    Object.entries(values)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n") + "\n",
+  );
+}
+
 function nextVersionFromMain(base, file, bump) {
   const mainSource = runGit(["show", `${base}:${file}`]);
   const versions = parseVersions(mainSource);
@@ -445,6 +462,11 @@ async function main() {
   }
 
   const version = nextVersionFromMain(options.base, options.file, options.bump);
+  writeGitHubOutput({
+    version,
+    display_version: displayVersion(version),
+  });
+
   const sourceHash = createHash("sha256")
     .update(JSON.stringify({ version, notes }))
     .digest("hex")


### PR DESCRIPTION
## Summary

- Add Korean release instructions before the existing English instructions in the automatically generated `dev` -> `main` release PR body.
- Generate release PR titles as `[PATCH] Release: from X.Y.Z`, where `X.Y.Z` is the current release version.
- Allow changing the draft PR prefix to `[MINOR]` or `[MAJOR]` before marking it ready.
- Rename the release PR to `[TYPE] Release: X.Y.Z` after the patch note workflow generates the new version.

## Test

- `../TU-417/node_modules/.bin/prettier --check AGENTS.md .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml scripts/release/prepare-patch-note.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml`
- `node --check scripts/release/prepare-patch-note.mjs`
- bracket type parsing smoke test for `[PATCH]`, `[MINOR]`, `[MAJOR]`
- `GITHUB_OUTPUT` smoke test for `prepare-patch-note.mjs`

## Task Context

- Task ID: TU-417

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text:
<!-- clubs:patch-note:end -->
