### PR TITLE
[TU-417] 패치노트 생성 PR 방식으로 변경

### DIFF
--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -94,19 +94,77 @@ jobs:
         run: pnpm build
 
       - name: Commit patch note
+        id: commit
+        env:
+          RELEASE_PR_NUMBER: ${{ github.event.pull_request.number || github.run_id }}
         run: |
           if git diff --quiet -- packages/web/src/constants/patchNote.ts; then
             echo "No patch note changes to commit."
+            echo "created=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
+          branch="release/patch-note-${RELEASE_PR_NUMBER}"
+          git switch -c "${branch}"
           git config user.name "clubs-release-bot"
           git config user.email "clubs-release-bot@users.noreply.github.com"
           git add packages/web/src/constants/patchNote.ts
-          git commit -m "chore: update release patch note"
-          git push origin HEAD:dev
+          HUSKY=0 git commit -m "chore: update release patch note"
+          git push --force origin "HEAD:${branch}"
 
-          echo "::notice::Patch note commit was pushed with GITHUB_TOKEN. GitHub will not trigger follow-up dev push workflows from this generated commit by design."
+          echo "created=true" >> "${GITHUB_OUTPUT}"
+          echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create patch note PR
+        id: patch-pr
+        if: steps.commit.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PATCH_NOTE_BRANCH: ${{ steps.commit.outputs.branch }}
+          RELEASE_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          RELEASE_TYPE: ${{ steps.bump.outputs.label }}
+          RELEASE_VERSION: ${{ steps.generate.outputs.display_version }}
+        run: |
+          title="chore: update release patch note"
+          release_ref="manual workflow run"
+          if [ -n "${RELEASE_PR_NUMBER}" ]; then
+            title="chore: update release patch note for #${RELEASE_PR_NUMBER}"
+            release_ref="release PR #${RELEASE_PR_NUMBER}"
+          fi
+
+          body="$(cat <<BODY
+          ## 릴리즈 패치노트
+
+          이 PR은 ${release_ref}에서 생성된 패치노트 커밋입니다.
+
+          - Release type: [${RELEASE_TYPE}]
+          - Release version: ${RELEASE_VERSION}
+          - Generated file: \`packages/web/src/constants/patchNote.ts\`
+
+          생성 전에 \`pnpm build\`로 검증했습니다. 이 PR을 \`dev\`에 머지하면 열려 있는 \`dev -> main\` release PR에 패치노트가 포함됩니다.
+
+          ## Release Patch Note
+
+          This PR contains the generated patch note commit for ${release_ref}.
+
+          - Release type: [${RELEASE_TYPE}]
+          - Release version: ${RELEASE_VERSION}
+          - Generated file: \`packages/web/src/constants/patchNote.ts\`
+
+          The generated file was validated with \`pnpm build\` before this PR was opened. Merge this PR into \`dev\` to include the patch note in the open \`dev -> main\` release PR.
+          BODY
+          )"
+
+          existing="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base dev --head "${PATCH_NOTE_BRANCH}" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" --repo "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}"
+            url="$(gh pr view "${existing}" --repo "${GITHUB_REPOSITORY}" --json url --jq '.url')"
+          else
+            url="$(gh pr create --repo "${GITHUB_REPOSITORY}" --base dev --head "${PATCH_NOTE_BRANCH}" --title "${title}" --body "${body}")"
+          fi
+
+          echo "url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "::notice::Patch note PR: ${url}"
 
       - name: Update release PR title
         if: github.event_name == 'pull_request' && steps.generate.outputs.display_version != ''

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -67,11 +67,12 @@ jobs:
           1. 머지된 feature PR 본문에 `clubs:patch-note` block이 있는지 확인합니다.
           2. 기본값은 `[PATCH]`입니다. 필요하면 이 PR을 ready 상태로 바꾸기 전에 제목 prefix를 `[MINOR]` 또는 `[MAJOR]`로 변경합니다.
           3. 이 PR을 **Ready for review**로 변경합니다.
-          4. `Prepare Release Patch Note` workflow가 `dev`에 패치노트 커밋을 하나 생성하고, PR 제목을 `[TYPE] Release: X.Y.Z` 형식으로 갱신합니다.
+          4. `Prepare Release Patch Note` workflow가 패치노트 PR을 `dev` 대상으로 생성하고, 이 PR 제목을 `[TYPE] Release: X.Y.Z` 형식으로 갱신합니다.
+          5. 생성된 패치노트 PR을 확인한 뒤 `dev`에 머지합니다. 그러면 이 release PR에 패치노트 커밋이 포함됩니다.
 
           ## 패치노트 커밋 트리거
 
-          생성된 패치노트 커밋은 의도적으로 `GITHUB_TOKEN`을 사용합니다. 따라서 GitHub는 해당 커밋으로 인한 후속 `dev` push workflow를 실행하지 않습니다. prepare workflow가 push 전에 생성 파일을 검증합니다.
+          `dev`는 보호 브랜치이므로 생성된 패치노트는 직접 push하지 않고 별도 PR로 생성합니다. prepare workflow가 PR 생성 전에 생성 파일을 검증합니다.
 
           ## Release Flow
 
@@ -82,10 +83,11 @@ jobs:
           1. Make sure merged feature PRs have a `clubs:patch-note` block in their PR body.
           2. Keep the title prefix as `[PATCH]`, or change it to `[MINOR]` or `[MAJOR]` before marking this PR as ready.
           3. Mark this PR as **Ready for review**.
-          4. The `Prepare Release Patch Note` workflow will create one patch note commit on `dev` and rename this PR to `[TYPE] Release: X.Y.Z`.
+          4. The `Prepare Release Patch Note` workflow will create a patch note PR targeting `dev` and rename this PR to `[TYPE] Release: X.Y.Z`.
+          5. Review and merge the generated patch note PR into `dev`. This release PR will then include the patch note commit.
 
           ## Patch Note Commit Trigger
 
-          The generated patch note commit intentionally uses `GITHUB_TOKEN`, so GitHub will not trigger follow-up `dev` push workflows from that commit. The prepare workflow validates the generated file before pushing.
+          `dev` is a protected branch, so the generated patch note is opened as a separate PR instead of being pushed directly. The prepare workflow validates the generated file before creating the PR.
           BODY
           )"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ text: 사용자에게 보여도 자연스러운 한국어 패치노트 문장
 <!-- clubs:patch-note:end -->
 ```
 
-릴리즈용 `dev -> main` PR 제목은 `[PATCH] Release: from X.Y.Z`, `[MINOR] Release: from X.Y.Z`, `[MAJOR] Release: from X.Y.Z` 중 하나로 시작해야 합니다. 기본값은 `[PATCH]`입니다. 패치노트 생성 workflow가 완료되면 PR 제목은 `[TYPE] Release: X.Y.Z` 형식으로 갱신됩니다.
+릴리즈용 `dev -> main` PR 제목은 `[PATCH] Release: from X.Y.Z`, `[MINOR] Release: from X.Y.Z`, `[MAJOR] Release: from X.Y.Z` 중 하나로 시작해야 합니다. 기본값은 `[PATCH]`입니다. 패치노트 생성 workflow가 완료되면 PR 제목은 `[TYPE] Release: X.Y.Z` 형식으로 갱신되고, 생성된 패치노트 커밋은 별도 PR로 `dev`에 머지합니다.
 
 - 사용자에게 보일 기능 추가는 `category: feature`를 사용합니다.
 - 사용자에게 보일 버그 수정은 `category: fix`를 사용합니다.


### PR DESCRIPTION
## Summary
- `dev` 보호 브랜치에 직접 push하던 release patch note workflow를 별도 PR 생성 방식으로 변경합니다.
- 생성된 patch note PR은 `dev`를 대상으로 열리고, `pnpm build` 검증 후 `packages/web/src/constants/patchNote.ts`만 포함합니다.
- release PR 안내문과 Codex PR 작성 지침도 새 흐름에 맞게 갱신합니다.

## Test
- `../TU-417/node_modules/.bin/prettier --check AGENTS.md .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "yaml ok #{f}" }' .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml`
- `git diff --check`

## Patch Note
<!-- clubs:patch-note:start -->
category: internal
text: 보호 브랜치 규칙에 맞게 릴리즈 패치노트 자동 생성 workflow가 별도 PR을 만들도록 수정했습니다.
<!-- clubs:patch-note:end -->
