### PR TITLE
[TU-417] 패치노트 PR 생성 시 빌드 생략

### DIFF
--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -122,10 +122,13 @@ jobs:
           RELEASE_TYPE: ${{ steps.bump.outputs.label }}
           RELEASE_VERSION: ${{ steps.generate.outputs.display_version }}
         run: |
-          title="chore: update release patch note"
+          title="PATCH NOTE"
+          if [ -n "${RELEASE_VERSION}" ]; then
+            title="PATCH NOTE - ${RELEASE_VERSION}"
+          fi
+
           release_ref="manual workflow run"
           if [ -n "${RELEASE_PR_NUMBER}" ]; then
-            title="chore: update release patch note for #${RELEASE_PR_NUMBER}"
             release_ref="release PR #${RELEASE_PR_NUMBER}"
           fi
 

--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -90,9 +90,6 @@ jobs:
             exit 1
           fi
 
-      - name: Validate generated patch note
-        run: pnpm build
-
       - name: Commit patch note
         id: commit
         env:
@@ -141,7 +138,7 @@ jobs:
           - Release version: ${RELEASE_VERSION}
           - Generated file: \`packages/web/src/constants/patchNote.ts\`
 
-          생성 전에 \`pnpm build\`로 검증했습니다. 이 PR을 \`dev\`에 머지하면 열려 있는 \`dev -> main\` release PR에 패치노트가 포함됩니다.
+          이 PR을 \`dev\`에 머지하면 열려 있는 \`dev -> main\` release PR에 패치노트가 포함됩니다.
 
           ## Release Patch Note
 
@@ -151,7 +148,7 @@ jobs:
           - Release version: ${RELEASE_VERSION}
           - Generated file: \`packages/web/src/constants/patchNote.ts\`
 
-          The generated file was validated with \`pnpm build\` before this PR was opened. Merge this PR into \`dev\` to include the patch note in the open \`dev -> main\` release PR.
+          Merge this PR into \`dev\` to include the patch note in the open \`dev -> main\` release PR.
           BODY
           )"
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -72,7 +72,7 @@ jobs:
 
           ## 패치노트 커밋 트리거
 
-          `dev`는 보호 브랜치이므로 생성된 패치노트는 직접 push하지 않고 별도 PR로 생성합니다. prepare workflow가 PR 생성 전에 생성 파일을 검증합니다.
+          `dev`는 보호 브랜치이므로 생성된 패치노트는 직접 push하지 않고 별도 PR로 생성합니다. prepare workflow는 생성 파일 범위만 확인하고, 나머지 검증은 생성된 PR의 CI가 수행합니다.
 
           ## Release Flow
 
@@ -88,6 +88,6 @@ jobs:
 
           ## Patch Note Commit Trigger
 
-          `dev` is a protected branch, so the generated patch note is opened as a separate PR instead of being pushed directly. The prepare workflow validates the generated file before creating the PR.
+          `dev` is a protected branch, so the generated patch note is opened as a separate PR instead of being pushed directly. The prepare workflow only checks the generated file scope; the generated PR CI performs the remaining validation.
           BODY
           )"


### PR DESCRIPTION
## Summary
- 패치노트 생성 workflow에서 별도 PR을 만들기 전에 실행하던 `pnpm build` 단계를 제거합니다.
- 생성된 패치노트 PR의 CI가 검증을 수행하도록 release PR 안내 문구를 갱신합니다.
- 생성되는 패치노트 PR 제목을 `PATCH NOTE - {version}` 형식으로 변경합니다.

## Test
- `../TU-417/node_modules/.bin/prettier --check .github/workflows/prepare-release-patch-note.yml`
- `../TU-417/node_modules/.bin/prettier --check .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/prepare-release-patch-note.yml"); puts "yaml ok"'`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "yaml ok #{f}" }' .github/workflows/release-pr.yml .github/workflows/prepare-release-patch-note.yml`
- `git diff --check`

## Patch Note
<!-- clubs:patch-note:start -->
category: internal
text: 릴리즈 패치노트 PR 생성 workflow에서 중복 build 검증을 제거하고, 생성 PR 제목을 버전 중심으로 표시하도록 수정했습니다.
<!-- clubs:patch-note:end -->
