### PR TITLE
[TU-419] 활동보고서 과거 활동반기 대시보드 추가

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -1,7 +1,10 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
-import { ActivityDurationTypeEnum } from "@clubs/domain/semester/activity-duration";
+import {
+  ActivityDurationTypeEnum,
+  IActivityDuration,
+} from "@clubs/domain/semester/activity-duration";
 import {
   ActivityDeadlineEnum,
   RegistrationDeadlineEnum,
@@ -920,9 +923,12 @@ export default class ActivityService {
       throw new HttpException("No such club", HttpStatus.NOT_FOUND);
     }
 
-    const activityDId =
-      param.query.activityDurationId ??
-      (await this.activityDurationPublicService.loadId());
+    const activityDuration = param.query.activityDurationId
+      ? await this.activityDurationPublicService.getById(
+          param.query.activityDurationId,
+        )
+      : await this.activityDurationPublicService.load();
+    const activityDId = activityDuration.id;
 
     const activities = await this.getActivities({
       clubId: param.query.clubId,
@@ -1026,10 +1032,49 @@ export default class ActivityService {
       }),
     );
 
+    const pastActivityDurations =
+      param.query.activityDurationId === undefined
+        ? await this.getPastActivityDurationsWithActivities(
+            activityDuration,
+            param.query.clubId,
+          )
+        : undefined;
+
     return {
+      activityDuration,
+      ...(pastActivityDurations ? { pastActivityDurations } : {}),
       chargedExecutive: clubChargedExecutive,
       items,
     };
+  }
+
+  private async getPastActivityDurationsWithActivities(
+    targetDuration: IActivityDuration,
+    clubId: number,
+  ): Promise<IActivityDuration[]> {
+    const activityDurations = await this.activityDurationPublicService.search({
+      activityDurationTypeEnum: ActivityDurationTypeEnum.Regular,
+    });
+
+    const pastActivityDurations = activityDurations.filter(
+      activityDuration =>
+        activityDuration.id !== targetDuration.id &&
+        activityDuration.semester.id !== targetDuration.semester.id &&
+        activityDuration.endTerm <= targetDuration.endTerm,
+    );
+
+    const activityCounts = await Promise.all(
+      pastActivityDurations.map(activityDuration =>
+        this.getActivities({
+          clubId,
+          activityDId: activityDuration.id,
+        }).then(activities => activities.length),
+      ),
+    );
+
+    return pastActivityDurations
+      .filter((_, index) => activityCounts[index] > 0)
+      .sort((a, b) => b.endTerm.getTime() - a.endTerm.getTime());
   }
 
   /**

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -923,10 +923,10 @@ export default class ActivityService {
       throw new HttpException("No such club", HttpStatus.NOT_FOUND);
     }
 
-    const activityDuration = param.query.activityDurationId
-      ? await this.activityDurationPublicService.getById(
-          param.query.activityDurationId,
-        )
+    const activityDuration = param.query.semesterId
+      ? await this.activityDurationPublicService.load({
+          semesterId: param.query.semesterId,
+        })
       : await this.activityDurationPublicService.load();
     const activityDId = activityDuration.id;
 
@@ -1033,7 +1033,7 @@ export default class ActivityService {
     );
 
     const pastActivityDurations =
-      param.query.activityDurationId === undefined
+      param.query.semesterId === undefined
         ? await this.getPastActivityDurationsWithActivities(
             activityDuration,
             param.query.clubId,

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -229,12 +229,12 @@ export default class ActivityOldService {
   async getExecutiveActivitiesClubs(
     query: ApiAct023RequestQuery,
   ): Promise<ApiAct023ResponseOk> {
-    const activityDuration = query.activityDurationId
-      ? await this.activityDurationPublicService.getById(
-          query.activityDurationId,
-        )
+    const activityDuration = query.semesterId
+      ? await this.activityDurationPublicService.load({
+          semesterId: query.semesterId,
+        })
       : await this.activityDurationPublicService.load();
-    const date = await this.getClubSnapshotDate(activityDuration);
+    const date = this.getClubSnapshotDate(activityDuration);
     const activityDId = activityDuration.id;
     // console.log(`QUERY: ${JSON.stringify(query)}`);
     // console.log(`${Boolean(query.clubName)}`);
@@ -242,6 +242,7 @@ export default class ActivityOldService {
       await Promise.all([
         this.clubPublicService.searchClubDetailByDate({
           date,
+          semesterId: activityDuration.semester.id,
           excludedClubTypeEnum: ClubTypeEnum.RegistrationCanceled,
           // name: query.clubName,
         }),
@@ -280,7 +281,7 @@ export default class ActivityOldService {
     );
 
     const executives =
-      query.activityDurationId === undefined
+      query.semesterId === undefined
         ? await this.userPublicService.getCurrentExecutives().then(items =>
             items.map(item => ({
               id: item.executive.id,
@@ -437,7 +438,7 @@ export default class ActivityOldService {
     // console.log(`SemesterId: ${semester.id}`);
     // console.log(`Date: ${date}`);
     const pastActivityDurations =
-      query.activityDurationId === undefined
+      query.semesterId === undefined
         ? await this.getPastActivityDurationsWithActivities(activityDuration)
         : undefined;
 
@@ -451,19 +452,14 @@ export default class ActivityOldService {
     };
   }
 
-  private async getClubSnapshotDate(
-    activityDuration: IActivityDuration,
-  ): Promise<Date> {
-    const semester = await this.semesterPublicService.getById(
-      activityDuration.semester.id,
-    );
+  private getClubSnapshotDate(activityDuration: IActivityDuration): Date {
     const now = new Date();
 
-    if (semester.startTerm <= now && now < semester.endTerm) {
+    if (activityDuration.startTerm <= now && now < activityDuration.endTerm) {
       return now;
     }
 
-    return new Date(semester.endTerm.getTime() - 1);
+    return new Date(activityDuration.endTerm.getTime() - 1);
   }
 
   private async getPastActivityDurationsWithActivities(

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -1,5 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 
+import { IActivityDuration } from "@clubs/domain/semester/activity-duration";
+
 import {
   ApiAct009RequestQuery,
   ApiAct009ResponseOk,
@@ -22,6 +24,7 @@ import {
 } from "@clubs/interface/api/activity/endpoint/apiAct029";
 import {
   ActivityDeadlineEnum,
+  ActivityDurationTypeEnum,
   ActivityStatusEnum,
 } from "@clubs/interface/common/enum/activity.enum";
 import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
@@ -226,32 +229,27 @@ export default class ActivityOldService {
   async getExecutiveActivitiesClubs(
     query: ApiAct023RequestQuery,
   ): Promise<ApiAct023ResponseOk> {
-    const date = new Date(); //new Date("2025-01-05");
-    const semesterId = await this.semesterPublicService.loadId({
-      date,
-    });
-    const activityDId = await this.activityDurationPublicService.loadId({
-      semesterId,
-    });
+    const activityDuration = query.activityDurationId
+      ? await this.activityDurationPublicService.getById(
+          query.activityDurationId,
+        )
+      : await this.activityDurationPublicService.load();
+    const date = await this.getClubSnapshotDate(activityDuration);
+    const activityDId = activityDuration.id;
     // console.log(`QUERY: ${JSON.stringify(query)}`);
     // console.log(`${Boolean(query.clubName)}`);
-    const [
-      clubs,
-      activityClubChargedExecutiveList,
-      activitiesOnActivityD,
-      executives,
-    ] = await Promise.all([
-      this.clubPublicService.searchClubDetailByDate({
-        date,
-        clubTypeEnum: ClubTypeEnum.Regular,
-        // name: query.clubName,
-      }),
-      this.activityClubChargedExecutiveRepository.find({
-        activityDId,
-      }),
-      this.activityRepository.selectActivityByActivityDId(activityDId),
-      this.userPublicService.getCurrentExecutives(),
-    ]);
+    const [clubs, activityClubChargedExecutiveList, activitiesOnActivityD] =
+      await Promise.all([
+        this.clubPublicService.searchClubDetailByDate({
+          date,
+          excludedClubTypeEnum: ClubTypeEnum.RegistrationCanceled,
+          // name: query.clubName,
+        }),
+        this.activityClubChargedExecutiveRepository.find({
+          activityDId,
+        }),
+        this.activityRepository.selectActivityByActivityDId(activityDId),
+      ]);
 
     // console.log(
     //   `RESULT1: ${JSON.stringify([
@@ -272,11 +270,32 @@ export default class ActivityOldService {
       )?.executive.id,
     }));
 
+    const chargedExecutiveIds = Array.from(
+      new Set(
+        [
+          ...activityClubChargedExecutiveList.map(e => e.executive.id),
+          ...activitiesOnActivityD.map(e => e.chargedExecutiveId),
+        ].filter((id): id is number => id != null),
+      ),
+    );
+
+    const executives =
+      query.activityDurationId === undefined
+        ? await this.userPublicService.getCurrentExecutives().then(items =>
+            items.map(item => ({
+              id: item.executive.id,
+              name: item.executive.name,
+            })),
+          )
+        : await this.userPublicService.fetchExecutiveSummaries(
+            chargedExecutiveIds,
+          );
+
     const executiveMap = new Map<number, { id: number; name: string }>();
-    executives.forEach(e => {
-      executiveMap.set(e.executive.id, {
-        id: e.executive.id,
-        name: e.executive.name,
+    executives.forEach(executive => {
+      executiveMap.set(executive.id, {
+        id: executive.id,
+        name: executive.name,
       });
     });
 
@@ -320,7 +339,7 @@ export default class ActivityOldService {
     const executiveProgresses: ApiAct023ResponseOk["executiveProgresses"] =
       executives.map(executive => {
         const chargedActivities = activitiesOnActivityD.filter(
-          e => e.chargedExecutiveId === executive.executive.id,
+          e => e.chargedExecutiveId === executive.id && clubMap.has(e.clubId),
         );
         const chargedClubIds = chargedActivities.reduce(
           (acc: Array<number>, val) => {
@@ -350,6 +369,12 @@ export default class ActivityOldService {
             ).length;
 
             const clubInfo = clubMap.get(clubId);
+            if (!clubInfo) {
+              throw new HttpException(
+                "Club not found in activity dashboard",
+                HttpStatus.INTERNAL_SERVER_ERROR,
+              );
+            }
 
             return {
               clubId,
@@ -364,8 +389,8 @@ export default class ActivityOldService {
           });
 
         return {
-          executiveId: executive.executive.id,
-          executiveName: executive.executive.name,
+          executiveId: executive.id,
+          executiveName: executive.name,
           chargedClubsAndProgresses,
         };
       });
@@ -411,12 +436,61 @@ export default class ActivityOldService {
     // });
     // console.log(`SemesterId: ${semester.id}`);
     // console.log(`Date: ${date}`);
+    const pastActivityDurations =
+      query.activityDurationId === undefined
+        ? await this.getPastActivityDurationsWithActivities(activityDuration)
+        : undefined;
+
     return {
+      activityDuration,
+      ...(pastActivityDurations ? { pastActivityDurations } : {}),
       items: paginatedItems,
       executiveProgresses: executiveNameFilteredExecutiveProgresses,
       total,
       offset: query.pageOffset,
     };
+  }
+
+  private async getClubSnapshotDate(
+    activityDuration: IActivityDuration,
+  ): Promise<Date> {
+    const semester = await this.semesterPublicService.getById(
+      activityDuration.semester.id,
+    );
+    const now = new Date();
+
+    if (semester.startTerm <= now && now < semester.endTerm) {
+      return now;
+    }
+
+    return new Date(semester.endTerm.getTime() - 1);
+  }
+
+  private async getPastActivityDurationsWithActivities(
+    targetDuration: IActivityDuration,
+  ): Promise<IActivityDuration[]> {
+    const activityDurations = await this.activityDurationPublicService.search({
+      activityDurationTypeEnum: ActivityDurationTypeEnum.Regular,
+    });
+
+    const pastActivityDurations = activityDurations.filter(
+      activityDuration =>
+        activityDuration.id !== targetDuration.id &&
+        activityDuration.semester.id !== targetDuration.semester.id &&
+        activityDuration.endTerm <= targetDuration.endTerm,
+    );
+
+    const activityCounts = await Promise.all(
+      pastActivityDurations.map(activityDuration =>
+        this.activityRepository
+          .selectActivityByActivityDId(activityDuration.id)
+          .then(activities => activities.length),
+      ),
+    );
+
+    return pastActivityDurations
+      .filter((_, index) => activityCounts[index] > 0)
+      .sort((a, b) => b.endTerm.getTime() - a.endTerm.getTime());
   }
 
   async getExecutiveActivitiesClubChargeAvailableExecutives(

--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -466,14 +466,18 @@ export default class ClubPublicService {
 
   async searchClubDetailByDate(query: {
     date: Date;
+    semesterId?: number;
     clubId?: number | number[];
     name?: string;
     clubTypeEnum?: ClubTypeEnum | ClubTypeEnum[];
     excludedClubTypeEnum?: ClubTypeEnum | ClubTypeEnum[];
   }): Promise<RMClub[]> {
-    const semester = await this.semesterPublicService.load({
-      date: query.date,
-    });
+    const semester =
+      query.semesterId === undefined
+        ? await this.semesterPublicService.load({
+            date: query.date,
+          })
+        : await this.semesterPublicService.getById(query.semesterId);
     const [clubs, clubSemesters, divisions, clubDivisions, clubDelegates] =
       await Promise.all([
         this.clubRepository.find({
@@ -500,17 +504,6 @@ export default class ClubPublicService {
         }),
       ]);
 
-    const [students, professors] = await Promise.all([
-      this.userPublicService.getStudentsByIds(
-        clubDelegates.map(c => c.student.id),
-      ),
-      this.userPublicService.getProfessorsByIds(
-        clubSemesters
-          .filter(c => c.professor?.id != null)
-          .map(c => c.professor.id),
-      ),
-    ]);
-
     const excludedClubTypeEnums = new Set(
       (Array.isArray(query.excludedClubTypeEnum)
         ? query.excludedClubTypeEnum
@@ -524,6 +517,17 @@ export default class ClubPublicService {
             clubSemester =>
               !excludedClubTypeEnums.has(clubSemester.clubTypeEnum),
           );
+
+    const [students, professors] = await Promise.all([
+      this.userPublicService.getStudentsByIds(
+        clubDelegates.map(c => c.student.id),
+      ),
+      this.userPublicService.getProfessorsByIds(
+        filteredClubSemesters
+          .filter(c => c.professor?.id != null)
+          .map(c => c.professor.id),
+      ),
+    ]);
 
     const clubSemesterMap = new Map(
       filteredClubSemesters.map(c => [c.club.id, c]),

--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -469,6 +469,7 @@ export default class ClubPublicService {
     clubId?: number | number[];
     name?: string;
     clubTypeEnum?: ClubTypeEnum | ClubTypeEnum[];
+    excludedClubTypeEnum?: ClubTypeEnum | ClubTypeEnum[];
   }): Promise<RMClub[]> {
     const semester = await this.semesterPublicService.load({
       date: query.date,
@@ -486,6 +487,7 @@ export default class ClubPublicService {
         this.clubSemesterRepository.find({
           semesterId: semester.id,
           clubId: query.clubId,
+          clubTypeEnum: query.clubTypeEnum,
         }),
         this.divisionPublicService.search({ date: query.date }),
         this.clubDivisionHistoryRepository.find({
@@ -509,7 +511,23 @@ export default class ClubPublicService {
       ),
     ]);
 
-    const clubSemesterMap = new Map(clubSemesters.map(c => [c.club.id, c]));
+    const excludedClubTypeEnums = new Set(
+      (Array.isArray(query.excludedClubTypeEnum)
+        ? query.excludedClubTypeEnum
+        : [query.excludedClubTypeEnum]
+      ).filter((typeEnum): typeEnum is ClubTypeEnum => typeEnum != null),
+    );
+    const filteredClubSemesters =
+      excludedClubTypeEnums.size === 0
+        ? clubSemesters
+        : clubSemesters.filter(
+            clubSemester =>
+              !excludedClubTypeEnums.has(clubSemester.clubTypeEnum),
+          );
+
+    const clubSemesterMap = new Map(
+      filteredClubSemesters.map(c => [c.club.id, c]),
+    );
     const divisionMap = new Map(divisions.map(d => [d.id, d]));
     const clubDivisionMap = new Map(clubDivisions.map(c => [c.club.id, c]));
     const clubRepresentativeMap = new Map(

--- a/packages/domain/src/club/club-semester.ts
+++ b/packages/domain/src/club/club-semester.ts
@@ -13,6 +13,9 @@ extendZodWithOpenApi(z);
 export enum ClubTypeEnum {
   Regular = 1, // 정동아리
   Provisional, // 가동아리
+  RegistrationCanceled, // 등록취소
+  Special, // 특수등록
+  Unregistered, // 미등록
 }
 
 export enum ClubBuildingEnum {
@@ -68,7 +71,8 @@ export const zClubSemester = z.object({
   club: zExtractId(zClub),
   semester: zExtractId(zSemester),
   clubTypeEnum: z.nativeEnum(ClubTypeEnum).openapi({
-    description: "동아리 지위 1: 정동아리 2: 가동아리",
+    description:
+      "동아리 지위 1: 정동아리 2: 가동아리 3: 등록취소 4: 특수등록 5: 미등록",
     examples: [ClubTypeEnum.Regular, ClubTypeEnum.Provisional],
   }),
   characteristicKr: z

--- a/packages/interface/src/api/activity/endpoint/apiAct023.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct023.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
+
 import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 import { zId } from "@clubs/interface/common/type/id.type";
 
@@ -19,6 +21,7 @@ const requestQuery = z.object({
   itemCount: z.coerce.number().int().min(1),
   clubName: z.string().optional(), // 검색 키워드: 동아리 이름
   executiveName: z.string().optional(), // 검색 키워드: 담당자 이름
+  activityDurationId: zActivityDuration.shape.id.optional(),
 });
 
 const requestBody = z.object({});
@@ -26,6 +29,8 @@ const requestBody = z.object({});
 // items 와 executiveProgresses는 각각 정렬해서 보내주기!
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
+    activityDuration: zActivityDuration,
+    pastActivityDurations: z.array(zActivityDuration).optional(),
     items: z.array(
       z.object({
         clubId: zId,
@@ -63,7 +68,7 @@ const responseBodyMap = {
         ),
       }),
     ),
-    total: z.coerce.number().min(1),
+    total: z.coerce.number().min(0),
     offset: z.coerce.number().min(1),
   }),
 };

--- a/packages/interface/src/api/activity/endpoint/apiAct023.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct023.ts
@@ -21,7 +21,7 @@ const requestQuery = z.object({
   itemCount: z.coerce.number().int().min(1),
   clubName: z.string().optional(), // 검색 키워드: 동아리 이름
   executiveName: z.string().optional(), // 검색 키워드: 담당자 이름
-  activityDurationId: zActivityDuration.shape.id.optional(),
+  semesterId: zId.optional(),
 });
 
 const requestBody = z.object({});

--- a/packages/interface/src/api/activity/endpoint/apiAct024.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct024.ts
@@ -25,6 +25,8 @@ const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
+    activityDuration: zActivityDuration,
+    pastActivityDurations: z.array(zActivityDuration).optional(),
     chargedExecutive: z
       .object({
         id: zId,

--- a/packages/interface/src/api/activity/endpoint/apiAct024.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct024.ts
@@ -18,7 +18,7 @@ const requestParam = z.object({});
 
 const requestQuery = z.object({
   clubId: zId,
-  activityDurationId: zActivityDuration.shape.id.optional(),
+  semesterId: zId.optional(),
 });
 
 const requestBody = z.object({});

--- a/packages/interface/src/common/enum/club.enum.ts
+++ b/packages/interface/src/common/enum/club.enum.ts
@@ -1,6 +1,9 @@
 export enum ClubTypeEnum {
   Regular = 1, // 정동아리
   Provisional, // 가동아리
+  RegistrationCanceled, // 등록취소
+  Special, // 특수등록
+  Unregistered, // 미등록
 }
 
 export enum ClubDelegateEnum {

--- a/packages/web/src/app/executive/activity-report/activity-duration/[id]/page.tsx
+++ b/packages/web/src/app/executive/activity-report/activity-duration/[id]/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
+
+import NotFound from "@sparcs-clubs/web/app/not-found";
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
+import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
+import {
+  defaultExecutiveActivityReportData,
+  ExecutiveActivityReportContent,
+} from "@sparcs-clubs/web/features/activity-report/frames/executive/ExecutiveActivityReportFrame";
+import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveActivities";
+import formatActivityDurationName from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
+
+interface ExecutiveActivityReportDurationContentProps {
+  activityDurationId: number;
+}
+
+const ExecutiveActivityReportDurationContent = ({
+  activityDurationId,
+}: ExecutiveActivityReportDurationContentProps) => {
+  const {
+    data: activitiesData,
+    isLoading: isActivitiesLoading,
+    isError: isActivitiesError,
+  } = useGetExecutiveActivities({
+    pageOffset: 1,
+    itemCount: 150,
+    activityDurationId,
+  });
+
+  if (isActivitiesError) {
+    return <NotFound />;
+  }
+
+  return (
+    <AsyncBoundary isLoading={isActivitiesLoading} isError={isActivitiesError}>
+      <FlexWrapper direction="column" gap={60}>
+        <PageHead
+          items={[
+            { name: "집행부원 대시보드", path: "/executive" },
+            {
+              name: "활동 보고서 작성 내역",
+              path: "/executive/activity-report",
+            },
+          ]}
+          title={`활동 보고서 작성 내역 (${formatActivityDurationName(activitiesData?.activityDuration)})`}
+          enableLast
+        />
+        <ExecutiveActivityReportContent
+          data={activitiesData ?? defaultExecutiveActivityReportData}
+        />
+      </FlexWrapper>
+    </AsyncBoundary>
+  );
+};
+
+const ExecutiveActivityReportDuration = () => {
+  const { isLoggedIn, login, profile } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const { id } = useParams<{ id: string }>();
+
+  const parsedActivityDurationId = Number(id);
+  const isValidActivityDurationId =
+    Number.isInteger(parsedActivityDurationId) && parsedActivityDurationId > 0;
+
+  useEffect(() => {
+    if (isLoggedIn !== undefined || profile !== undefined) {
+      setLoading(false);
+    }
+  }, [isLoggedIn, profile]);
+
+  if (loading) {
+    return <AsyncBoundary isLoading={loading} isError />;
+  }
+
+  if (!isLoggedIn) {
+    return <LoginRequired login={login} />;
+  }
+
+  if (profile?.type !== UserTypeEnum.Executive || !isValidActivityDurationId) {
+    return <NotFound />;
+  }
+
+  return (
+    <ExecutiveActivityReportDurationContent
+      activityDurationId={parsedActivityDurationId}
+    />
+  );
+};
+
+export default ExecutiveActivityReportDuration;

--- a/packages/web/src/app/executive/activity-report/page.tsx
+++ b/packages/web/src/app/executive/activity-report/page.tsx
@@ -10,7 +10,34 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
-import ExecutiveActivityReportFrame from "@sparcs-clubs/web/features/activity-report/frames/executive/ExecutiveActivityReportFrame";
+import ExecutivePastActivityReportDashboardSection from "@sparcs-clubs/web/features/activity-report/components/executive/ExecutivePastActivityReportDashboardSection";
+import {
+  defaultExecutiveActivityReportData,
+  ExecutiveActivityReportContent,
+} from "@sparcs-clubs/web/features/activity-report/frames/executive/ExecutiveActivityReportFrame";
+import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveActivities";
+
+const ExecutiveActivityReportPageContent = () => {
+  const {
+    data: activitiesData,
+    isLoading: isActivitiesLoading,
+    isError: isActivitiesError,
+  } = useGetExecutiveActivities({
+    pageOffset: 1,
+    itemCount: 150,
+  });
+
+  return (
+    <AsyncBoundary isLoading={isActivitiesLoading} isError={isActivitiesError}>
+      <ExecutiveActivityReportContent
+        data={activitiesData ?? defaultExecutiveActivityReportData}
+      />
+      <ExecutivePastActivityReportDashboardSection
+        activityDurations={activitiesData?.pastActivityDurations ?? []}
+      />
+    </AsyncBoundary>
+  );
+};
 
 const ExecutiveActivityReport = () => {
   const { isLoggedIn, login, profile } = useAuth();
@@ -35,7 +62,7 @@ const ExecutiveActivityReport = () => {
   }
 
   return (
-    <FlexWrapper direction="column" gap={20}>
+    <FlexWrapper direction="column" gap={60}>
       <PageHead
         items={[
           { name: "집행부원 대시보드", path: "/executive" },
@@ -43,7 +70,7 @@ const ExecutiveActivityReport = () => {
         ]}
         title="활동 보고서 작성 내역"
       />
-      <ExecutiveActivityReportFrame />
+      <ExecutiveActivityReportPageContent />
     </FlexWrapper>
   );
 };

--- a/packages/web/src/app/executive/activity-report/semester/[id]/page.tsx
+++ b/packages/web/src/app/executive/activity-report/semester/[id]/page.tsx
@@ -18,13 +18,13 @@ import {
 import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveActivities";
 import formatActivityDurationName from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
 
-interface ExecutiveActivityReportDurationContentProps {
-  activityDurationId: number;
+interface ExecutiveActivityReportSemesterContentProps {
+  semesterId: number;
 }
 
-const ExecutiveActivityReportDurationContent = ({
-  activityDurationId,
-}: ExecutiveActivityReportDurationContentProps) => {
+const ExecutiveActivityReportSemesterContent = ({
+  semesterId,
+}: ExecutiveActivityReportSemesterContentProps) => {
   const {
     data: activitiesData,
     isLoading: isActivitiesLoading,
@@ -32,7 +32,7 @@ const ExecutiveActivityReportDurationContent = ({
   } = useGetExecutiveActivities({
     pageOffset: 1,
     itemCount: 150,
-    activityDurationId,
+    semesterId,
   });
 
   if (isActivitiesError) {
@@ -61,14 +61,14 @@ const ExecutiveActivityReportDurationContent = ({
   );
 };
 
-const ExecutiveActivityReportDuration = () => {
+const ExecutiveActivityReportSemester = () => {
   const { isLoggedIn, login, profile } = useAuth();
   const [loading, setLoading] = useState(true);
   const { id } = useParams<{ id: string }>();
 
-  const parsedActivityDurationId = Number(id);
-  const isValidActivityDurationId =
-    Number.isInteger(parsedActivityDurationId) && parsedActivityDurationId > 0;
+  const parsedSemesterId = Number(id);
+  const isValidSemesterId =
+    Number.isInteger(parsedSemesterId) && parsedSemesterId > 0;
 
   useEffect(() => {
     if (isLoggedIn !== undefined || profile !== undefined) {
@@ -84,15 +84,13 @@ const ExecutiveActivityReportDuration = () => {
     return <LoginRequired login={login} />;
   }
 
-  if (profile?.type !== UserTypeEnum.Executive || !isValidActivityDurationId) {
+  if (profile?.type !== UserTypeEnum.Executive || !isValidSemesterId) {
     return <NotFound />;
   }
 
   return (
-    <ExecutiveActivityReportDurationContent
-      activityDurationId={parsedActivityDurationId}
-    />
+    <ExecutiveActivityReportSemesterContent semesterId={parsedSemesterId} />
   );
 };
 
-export default ExecutiveActivityReportDuration;
+export default ExecutiveActivityReportSemester;

--- a/packages/web/src/common/components/Table.tsx
+++ b/packages/web/src/common/components/Table.tsx
@@ -64,8 +64,14 @@ const ContentRow = styled.tr.withConfig({
   background-color: ${({ selected, theme }) =>
     selected ? theme.colors.MINT[100] : "transparent"};
 `;
-const EmptyCenterPlacer = styled.div`
+const EmptyCenterRow = styled.tr`
+  width: 100%;
   height: 100%;
+  display: flex;
+  flex: 1;
+`;
+const EmptyCenterCell = styled.td`
+  width: 100%;
   display: flex;
   flex: 1;
   padding: 12px 8px 12px 8px;
@@ -196,17 +202,19 @@ const Table = <T,>({
                 </ContentRow>
               ))
             ) : (
-              <EmptyCenterPlacer>
-                <Typography
-                  fs={16}
-                  lh={24}
-                  color="GRAY.300"
-                  ff="PRETENDARD"
-                  fw="REGULAR"
-                >
-                  {emptyMessage}
-                </Typography>
-              </EmptyCenterPlacer>
+              <EmptyCenterRow>
+                <EmptyCenterCell colSpan={table.getAllLeafColumns().length}>
+                  <Typography
+                    fs={16}
+                    lh={24}
+                    color="GRAY.300"
+                    ff="PRETENDARD"
+                    fw="REGULAR"
+                  >
+                    {emptyMessage}
+                  </Typography>
+                </EmptyCenterCell>
+              </EmptyCenterRow>
             )}
             {footer}
           </Content>

--- a/packages/web/src/common/providers/store/useFeatureFlagStore.ts
+++ b/packages/web/src/common/providers/store/useFeatureFlagStore.ts
@@ -46,29 +46,40 @@ export const parsedFeatureFlagState: FeatureFlagState = {
 
 logger.debug("Feature Flag State", parsedFeatureFlagState);
 
+const isFeatureFlagStateCurrent = (
+  state: FeatureFlagState | undefined,
+): boolean =>
+  state != null &&
+  state.FLAGS != null &&
+  state.FLAGS.REGISTER_CLUB === parsedFeatureFlagState.FLAGS.REGISTER_CLUB &&
+  state.FLAGS.REGISTER_MEMBER ===
+    parsedFeatureFlagState.FLAGS.REGISTER_MEMBER &&
+  state.FLAGS.NO_RELEASE === parsedFeatureFlagState.FLAGS.NO_RELEASE &&
+  state.DEV_MODE === parsedFeatureFlagState.DEV_MODE &&
+  state.VERSION === parsedFeatureFlagState.VERSION;
+
 const useFeatureFlagStore = create(
   persist(
     immer<FeatureFlagState>(() => parsedFeatureFlagState),
     {
       name: "INTERNAL--feature-flag-state",
       storage: createJSONStorage(() => localStorage),
+      merge: persistedState => {
+        const state = persistedState as FeatureFlagState | undefined;
+
+        if (isFeatureFlagStateCurrent(state)) {
+          return state as FeatureFlagState;
+        }
+        return parsedFeatureFlagState;
+      },
       onRehydrateStorage: () => state => {
-        if (
-          !state ||
-          state.FLAGS.REGISTER_CLUB !==
-            parsedFeatureFlagState.FLAGS.REGISTER_CLUB ||
-          state.FLAGS.REGISTER_MEMBER !==
-            parsedFeatureFlagState.FLAGS.REGISTER_MEMBER ||
-          state.FLAGS.NO_RELEASE !== parsedFeatureFlagState.FLAGS.NO_RELEASE ||
-          state.DEV_MODE !== parsedFeatureFlagState.DEV_MODE
-        ) {
-          logger.debug("Feature Flag values changed, clearing cache", {
-            cached: state?.FLAGS,
+        const cachedState = state as FeatureFlagState | undefined;
+        if (!isFeatureFlagStateCurrent(cachedState)) {
+          logger.debug("Feature Flag values changed, using env flags", {
+            cached: cachedState?.FLAGS,
             current: parsedFeatureFlagState.FLAGS,
           });
-          return parsedFeatureFlagState;
         }
-        return state;
       },
     },
   ),

--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -173,6 +173,9 @@ const ClubTypeTagList: {
 } = {
   [ClubTypeEnum.Regular]: { text: "정동아리", color: "BLUE" },
   [ClubTypeEnum.Provisional]: { text: "가동아리", color: "ORANGE" },
+  [ClubTypeEnum.RegistrationCanceled]: { text: "등록취소", color: "GRAY" },
+  [ClubTypeEnum.Special]: { text: "특수등록", color: "PURPLE" },
+  [ClubTypeEnum.Unregistered]: { text: "미등록", color: "GRAY" },
 };
 
 const getDivisionTagColor = (name: string): TagColor => {

--- a/packages/web/src/features/activity-report/components/executive/ActivityReportStatistic.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ActivityReportStatistic.tsx
@@ -42,6 +42,8 @@ const ActivityReportStatistic: React.FC<ActivityReportStatisticProps> = ({
   const reviewedTotalCount = approvedTotalCount + rejectedTotalCount;
   const totalCount =
     pendingTotalCount + approvedTotalCount + rejectedTotalCount;
+  const reviewRate = totalCount ? (reviewedTotalCount / totalCount) * 100 : 0;
+  const approvedRate = totalCount ? (approvedTotalCount / totalCount) * 100 : 0;
 
   return (
     <Card gap={16} padding="16px" outline>
@@ -67,8 +69,8 @@ const ActivityReportStatistic: React.FC<ActivityReportStatisticProps> = ({
                 검토율
               </Typography>
               <Typography fs={16} lh={20}>
-                {reviewedTotalCount}개 / {totalCount}개 (
-                {((reviewedTotalCount / totalCount) * 100).toFixed(1)}%)
+                {reviewedTotalCount}개 / {totalCount}개 ({reviewRate.toFixed(1)}
+                %)
               </Typography>
             </FlexWrapper>
             {withApprovedRate && (
@@ -78,7 +80,7 @@ const ActivityReportStatistic: React.FC<ActivityReportStatisticProps> = ({
                 </Typography>
                 <Typography fs={16} lh={20}>
                   {approvedTotalCount}개 / {totalCount}개 (
-                  {((approvedTotalCount / totalCount) * 100).toFixed(1)}%)
+                  {approvedRate.toFixed(1)}%)
                 </Typography>
               </FlexWrapper>
             )}

--- a/packages/web/src/features/activity-report/components/executive/ExecutiveCurrentActivityReportSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutiveCurrentActivityReportSection.tsx
@@ -9,6 +9,7 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import useGetExecutiveClubActivitiesForDuration from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveClubActivitiesForDuration";
+import { defaultActivityDuration } from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
 
 import ActivityReportStatistic from "./ActivityReportStatistic";
 import ChargedChangeActivityModalContent from "./ChargedChangeActivityModalContent";
@@ -106,7 +107,11 @@ const ExecutiveCurrentActivityReportSection: React.FC<
             </>
           )}
           <ExecutiveClubActivitiesTable
-            data={data?.items ? data : { items: [] }}
+            data={
+              data?.items
+                ? data
+                : { activityDuration: defaultActivityDuration, items: [] }
+            }
             searchText={searchText}
             selectedActivityIds={selectedActivityIds}
             setSelectedActivityIds={setSelectedActivityIds}

--- a/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportDashboardSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportDashboardSection.tsx
@@ -59,7 +59,7 @@ const ExecutivePastActivityReportDashboardSection = ({
           minWidth={820}
           emptyMessage="과거 활동보고서 대시보드가 없습니다"
           rowLink={row =>
-            `/executive/activity-report/activity-duration/${row.id}`
+            `/executive/activity-report/semester/${row.semester.id}`
           }
         />
       </FlexWrapper>

--- a/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportDashboardSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportDashboardSection.tsx
@@ -1,0 +1,70 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import { ApiAct023ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct023";
+
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import Table from "@sparcs-clubs/web/common/components/Table";
+import formatActivityDurationName from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
+import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+
+type ActivityDuration = NonNullable<
+  ApiAct023ResponseOk["pastActivityDurations"]
+>[number];
+
+interface ExecutivePastActivityReportDashboardSectionProps {
+  activityDurations: ActivityDuration[];
+}
+
+const columnHelper = createColumnHelper<ActivityDuration>();
+
+const columns = [
+  columnHelper.accessor(row => formatActivityDurationName(row), {
+    id: "activityDuration",
+    header: "활동 반기",
+    cell: info => info.getValue(),
+    size: 220,
+  }),
+  columnHelper.accessor(
+    row =>
+      `${formatDate(new Date(row.startTerm))} ~ ${formatDate(new Date(row.endTerm))}`,
+    {
+      id: "duration",
+      header: "활동 기간",
+      cell: info => info.getValue(),
+      size: 420,
+    },
+  ),
+];
+
+const ExecutivePastActivityReportDashboardSection = ({
+  activityDurations,
+}: ExecutivePastActivityReportDashboardSectionProps) => {
+  const table = useReactTable({
+    data: activityDurations,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return (
+    <FoldableSectionTitle title="과거 활동보고서 대시보드">
+      <FlexWrapper direction="column" gap={20}>
+        <Table
+          table={table}
+          minWidth={820}
+          emptyMessage="과거 활동보고서 대시보드가 없습니다"
+          rowLink={row =>
+            `/executive/activity-report/activity-duration/${row.id}`
+          }
+        />
+      </FlexWrapper>
+    </FoldableSectionTitle>
+  );
+};
+
+export default ExecutivePastActivityReportDashboardSection;

--- a/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportSection.tsx
@@ -4,7 +4,11 @@ import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
 import useGetExecutiveClubActivities from "@sparcs-clubs/web/features/activity-report/hooks/useGetExecutiveClubActivities";
+import formatActivityDurationName, {
+  defaultActivityDuration,
+} from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
 
 import ExecutiveClubActivitiesTable from "./ExecutiveClubActivitiesTable";
 
@@ -25,17 +29,26 @@ const ExecutivePastActivityReportSection: React.FC<
     <FoldableSectionTitle title="과거 활동 보고서" childrenMargin="30px">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper direction="column" gap={30}>
+          {dataList.length === 0 && (
+            <Typography color="GRAY.300" fs={16} lh={24}>
+              과거 활동 보고서 내역이 없습니다
+            </Typography>
+          )}
           {dataList.map(data => (
             <FoldableSection
-              key={data.term.id}
-              title={`${data.term.year}년 ${data.term.name}학기 (총 ${data.activities?.items ? data.activities.items.length : 0}개)`}
+              key={data.activityDuration.id}
+              title={`${formatActivityDurationName(data.activities?.activityDuration ?? data.activityDuration)} (총 ${data.activities?.items ? data.activities.items.length : 0}개)`}
               childrenMargin="20px"
             >
               {data.activities == null ? (
                 <AsyncBoundary isLoading={false} isError />
               ) : (
                 <ExecutiveClubActivitiesTable
-                  data={data?.activities ? data.activities : { items: [] }}
+                  data={
+                    data?.activities
+                      ? data.activities
+                      : { activityDuration: defaultActivityDuration, items: [] }
+                  }
                   isPast
                 />
               )}

--- a/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
@@ -1,6 +1,8 @@
 import { overlay } from "overlay-kit";
 import { useCallback, useEffect, useState } from "react";
 
+import { ApiAct023ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct023";
+
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
@@ -11,8 +13,27 @@ import { ChargedChangeClubProps } from "@sparcs-clubs/web/features/activity-repo
 import ExecutiveActivityChargedTable from "@sparcs-clubs/web/features/activity-report/components/executive/ExecutiveActivityChargedTable";
 import ExecutiveActivityClubTable from "@sparcs-clubs/web/features/activity-report/components/executive/ExecutiveActivityClubTable";
 import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveActivities";
+import { defaultActivityDuration } from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
 
-const ExecutiveActivityReportFrame = () => {
+interface ExecutiveActivityReportFrameProps {
+  activityDurationId?: number;
+}
+
+const defaultExecutiveActivityReportData: ApiAct023ResponseOk = {
+  activityDuration: defaultActivityDuration,
+  items: [],
+  executiveProgresses: [],
+  total: 0,
+  offset: 1,
+};
+
+interface ExecutiveActivityReportContentProps {
+  data: ApiAct023ResponseOk;
+}
+
+export const ExecutiveActivityReportContent = ({
+  data,
+}: ExecutiveActivityReportContentProps) => {
   const [isClubView, setIsClubView] = useState<boolean>(
     window.history.state.isClubView ?? true,
   );
@@ -23,29 +44,21 @@ const ExecutiveActivityReportFrame = () => {
     ChargedChangeClubProps[]
   >([]);
 
-  // TODO. 우선 급한대로 야매로 처리함 (추후에 페이지네이션 백에서 삭제하기)
-  const { data, isLoading, isError } = useGetExecutiveActivities({
-    pageOffset: 1,
-    itemCount: 150,
-  });
-
   useEffect(() => {
     window.history.replaceState({ isClubView }, "");
   }, [isClubView]);
 
   useEffect(() => {
-    if (data) {
-      setSelectedClubInfos(
-        data.items
-          .filter(item => selectedClubIds.includes(item.clubId))
-          .map(item => ({
-            clubId: item.clubId,
-            clubNameKr: item.clubNameKr,
-            clubNameEn: item.clubNameEn,
-            prevExecutiveName: item.chargedExecutive?.name ?? "",
-          })),
-      );
-    }
+    setSelectedClubInfos(
+      data.items
+        .filter(item => selectedClubIds.includes(item.clubId))
+        .map(item => ({
+          clubId: item.clubId,
+          clubNameKr: item.clubNameKr,
+          clubNameEn: item.clubNameEn,
+          prevExecutiveName: item.chargedExecutive?.name ?? "",
+        })),
+    );
   }, [data, selectedClubIds]);
 
   const openChargedChangeModal = useCallback(() => {
@@ -63,26 +76,20 @@ const ExecutiveActivityReportFrame = () => {
   }, [selectedClubIds, selectedClubInfos]);
 
   return (
-    <AsyncBoundary isLoading={isLoading} isError={isError}>
+    <>
       <ActivityReportStatistic
-        pendingTotalCount={
-          data?.items.reduce(
-            (acc, item) => acc + item.pendingActivitiesCount,
-            0,
-          ) ?? 0
-        }
-        approvedTotalCount={
-          data?.items.reduce(
-            (acc, item) => acc + item.approvedActivitiesCount,
-            0,
-          ) ?? 0
-        }
-        rejectedTotalCount={
-          data?.items.reduce(
-            (acc, item) => acc + item.rejectedActivitiesCount,
-            0,
-          ) ?? 0
-        }
+        pendingTotalCount={data.items.reduce(
+          (acc, item) => acc + item.pendingActivitiesCount,
+          0,
+        )}
+        approvedTotalCount={data.items.reduce(
+          (acc, item) => acc + item.approvedActivitiesCount,
+          0,
+        )}
+        rejectedTotalCount={data.items.reduce(
+          (acc, item) => acc + item.rejectedActivitiesCount,
+          0,
+        )}
       />
       <FlexWrapper direction="row" gap={12}>
         <Button
@@ -121,19 +128,40 @@ const ExecutiveActivityReportFrame = () => {
       </FlexWrapper>
       {isClubView ? (
         <ExecutiveActivityClubTable
-          activities={data?.items}
+          activities={data.items}
           searchText={searchText}
           selectedClubIds={selectedClubIds}
           setSelectedClubIds={setSelectedClubIds}
         />
       ) : (
         <ExecutiveActivityChargedTable
-          executives={data?.executiveProgresses}
+          executives={data.executiveProgresses}
           searchText={searchText}
         />
       )}
+    </>
+  );
+};
+
+const ExecutiveActivityReportFrame = ({
+  activityDurationId,
+}: ExecutiveActivityReportFrameProps) => {
+  // TODO. 우선 급한대로 야매로 처리함 (추후에 페이지네이션 백에서 삭제하기)
+  const { data, isLoading, isError } = useGetExecutiveActivities({
+    pageOffset: 1,
+    itemCount: 150,
+    activityDurationId,
+  });
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <ExecutiveActivityReportContent
+        data={data ?? defaultExecutiveActivityReportData}
+      />
     </AsyncBoundary>
   );
 };
+
+export { defaultExecutiveActivityReportData };
 
 export default ExecutiveActivityReportFrame;

--- a/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
@@ -16,7 +16,7 @@ import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-repor
 import { defaultActivityDuration } from "@sparcs-clubs/web/features/activity-report/utils/formatActivityDurationName";
 
 interface ExecutiveActivityReportFrameProps {
-  activityDurationId?: number;
+  semesterId?: number;
 }
 
 const defaultExecutiveActivityReportData: ApiAct023ResponseOk = {
@@ -144,13 +144,13 @@ export const ExecutiveActivityReportContent = ({
 };
 
 const ExecutiveActivityReportFrame = ({
-  activityDurationId,
+  semesterId,
 }: ExecutiveActivityReportFrameProps) => {
   // TODO. 우선 급한대로 야매로 처리함 (추후에 페이지네이션 백에서 삭제하기)
   const { data, isLoading, isError } = useGetExecutiveActivities({
     pageOffset: 1,
     itemCount: 150,
-    activityDurationId,
+    semesterId,
   });
 
   return (

--- a/packages/web/src/features/activity-report/hooks/useGetExecutiveClubActivities.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetExecutiveClubActivities.ts
@@ -28,11 +28,15 @@ const useGetExecutiveClubActivities = (
 
   const queries = useQueries({
     queries: pastActivityDurations.map(activityDuration => ({
-      queryKey: ["getExecutiveClubActivities", clubId, activityDuration.id],
+      queryKey: [
+        "getExecutiveClubActivities",
+        clubId,
+        activityDuration.semester.id,
+      ],
       queryFn: () =>
         executiveClubActivitiesForDurationQueryFn({
           clubId: Number(clubId),
-          activityDurationId: activityDuration.id,
+          semesterId: activityDuration.semester.id,
         }),
       retry: false,
       enabled: !!currentActivities,

--- a/packages/web/src/features/activity-report/hooks/useGetExecutiveClubActivities.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetExecutiveClubActivities.ts
@@ -1,58 +1,41 @@
 import { useQueries } from "@tanstack/react-query";
 
-import { ApiAct009ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct009";
 import { ApiAct024ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct024";
 
-import { executiveClubActivitiesForDurationQueryFn } from "../services/executive/useGetExecutiveClubActivitiesForDuration";
-import useGetActivityDeadline from "../services/useGetActivityDeadline";
-import useGetActivityTerms from "../services/useGetActivityTerms";
+import useGetExecutiveClubActivitiesForDuration, {
+  executiveClubActivitiesForDurationQueryFn,
+} from "../services/executive/useGetExecutiveClubActivitiesForDuration";
 
 const useGetExecutiveClubActivities = (
   clubId: number,
 ): {
   data: {
-    term: ApiAct009ResponseOk["terms"][number];
+    activityDuration: ApiAct024ResponseOk["activityDuration"];
     activities: ApiAct024ResponseOk | null;
   }[];
   isLoading: boolean;
   isError: boolean;
 } => {
   const {
-    data: activityTerms,
-    isLoading,
-    isError,
-  } = useGetActivityTerms({
+    data: currentActivities,
+    isLoading: isCurrentActivitiesLoading,
+    isError: isCurrentActivitiesError,
+  } = useGetExecutiveClubActivitiesForDuration({
     clubId,
   });
 
-  const {
-    data: deadline,
-    isLoading: isLoadingDeadline,
-    isError: isErrorDeadline,
-  } = useGetActivityDeadline();
-
-  const pastActivityTerms = activityTerms?.terms.toReversed().filter(term => {
-    if (!deadline) return true;
-
-    // 신규 활동 보고서는 빼고, 과거 활동 보고서만 보여주기
-    return (
-      new Date(term.startTerm).getTime() !==
-        new Date(deadline.targetTerm.startTerm).getTime() &&
-      new Date(term.endTerm).getTime() !==
-        new Date(deadline.targetTerm.endTerm).getTime()
-    );
-  });
+  const pastActivityDurations = currentActivities?.pastActivityDurations ?? [];
 
   const queries = useQueries({
-    queries: (pastActivityTerms ?? []).map(activityTerm => ({
-      queryKey: ["getExecutiveClubActivities", clubId, activityTerm.id],
+    queries: pastActivityDurations.map(activityDuration => ({
+      queryKey: ["getExecutiveClubActivities", clubId, activityDuration.id],
       queryFn: () =>
         executiveClubActivitiesForDurationQueryFn({
           clubId: Number(clubId),
-          activityDurationId: activityTerm.id,
+          activityDurationId: activityDuration.id,
         }),
       retry: false,
-      enabled: !!activityTerms,
+      enabled: !!currentActivities,
     })),
   });
 
@@ -61,15 +44,20 @@ const useGetExecutiveClubActivities = (
   );
 
   return {
-    data:
-      pastActivityTerms?.map((term, index) => ({
-        term,
+    data: pastActivityDurations
+      .map((activityDuration, index) => ({
+        activityDuration:
+          successDataList[index]?.activityDuration ?? activityDuration,
         activities: successDataList[index],
-      })) ?? [],
+      }))
+      .filter(
+        data => data.activities == null || data.activities.items.length > 0,
+      ),
     isLoading:
-      isLoading || isLoadingDeadline || queries.some(query => query.isLoading),
+      isCurrentActivitiesLoading || queries.some(query => query.isLoading),
     isError:
-      isError || isErrorDeadline || queries.every(query => query.isError),
+      isCurrentActivitiesError ||
+      (queries.length > 0 && queries.every(query => query.isError)),
   };
 };
 

--- a/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
+++ b/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
@@ -20,7 +20,7 @@ const useGetExecutiveActivities = (query: ApiAct023RequestQuery) =>
       query.itemCount,
       query.clubName,
       query.executiveName,
-      query.activityDurationId,
+      query.semesterId,
     ],
     queryFn: async (): Promise<ApiAct023ResponseOk> => {
       const { data } = await axiosClientWithAuth.get(apiAct023.url(), {

--- a/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
+++ b/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
@@ -4,6 +4,7 @@ import apiAct023, {
   ApiAct023RequestQuery,
   ApiAct023ResponseOk,
 } from "@clubs/interface/api/activity/endpoint/apiAct023";
+import { ActivityDurationTypeEnum } from "@clubs/interface/common/enum/activity.enum";
 import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 
 import {
@@ -19,6 +20,7 @@ const useGetExecutiveActivities = (query: ApiAct023RequestQuery) =>
       query.itemCount,
       query.clubName,
       query.executiveName,
+      query.activityDurationId,
     ],
     queryFn: async (): Promise<ApiAct023ResponseOk> => {
       const { data } = await axiosClientWithAuth.get(apiAct023.url(), {
@@ -35,6 +37,15 @@ defineAxiosMock(mock => {
   mock.onGet(apiAct023.url()).reply(() => [
     200,
     {
+      activityDuration: {
+        id: 1,
+        semester: { id: 1 },
+        activityDurationTypeEnum: ActivityDurationTypeEnum.Regular,
+        year: 2026,
+        name: "겨울-봄",
+        startTerm: new Date("2025-12-20T00:00:00Z"),
+        endTerm: new Date("2026-06-19T23:59:00Z"),
+      },
       items: [
         {
           clubId: 1,

--- a/packages/web/src/features/activity-report/services/executive/useGetExecutiveClubActivitiesForDuration.ts
+++ b/packages/web/src/features/activity-report/services/executive/useGetExecutiveClubActivitiesForDuration.ts
@@ -32,7 +32,7 @@ const useGetExecutiveClubActivitiesForDuration = (
   query: ApiAct024RequestQuery,
 ) =>
   useQuery<ApiAct024ResponseOk, Error>({
-    queryKey: [apiAct024.url(), query.clubId, query.activityDurationId],
+    queryKey: [apiAct024.url(), query.clubId, query.semesterId],
     queryFn: () => executiveClubActivitiesForDurationQueryFn(query),
   });
 

--- a/packages/web/src/features/activity-report/services/executive/useGetExecutiveClubActivitiesForDuration.ts
+++ b/packages/web/src/features/activity-report/services/executive/useGetExecutiveClubActivitiesForDuration.ts
@@ -4,7 +4,10 @@ import apiAct024, {
   ApiAct024RequestQuery,
   ApiAct024ResponseOk,
 } from "@clubs/interface/api/activity/endpoint/apiAct024";
-import { ActivityStatusEnum } from "@clubs/interface/common/enum/activity.enum";
+import {
+  ActivityDurationTypeEnum,
+  ActivityStatusEnum,
+} from "@clubs/interface/common/enum/activity.enum";
 
 import {
   axiosClientWithAuth,
@@ -36,6 +39,15 @@ const useGetExecutiveClubActivitiesForDuration = (
 export default useGetExecutiveClubActivitiesForDuration;
 
 export const mockExecutiveClubActivitiesData: ApiAct024ResponseOk = {
+  activityDuration: {
+    id: 1,
+    semester: { id: 1 },
+    activityDurationTypeEnum: ActivityDurationTypeEnum.Regular,
+    year: 2026,
+    name: "겨울-봄",
+    startTerm: new Date("2025-12-20T00:00:00Z"),
+    endTerm: new Date("2026-06-19T23:59:00Z"),
+  },
   items: [
     {
       activityId: 1,

--- a/packages/web/src/features/activity-report/utils/formatActivityDurationName.ts
+++ b/packages/web/src/features/activity-report/utils/formatActivityDurationName.ts
@@ -1,0 +1,25 @@
+import { ActivityDurationTypeEnum } from "@clubs/domain/semester/activity-duration";
+
+interface ActivityDurationNameSource {
+  year: number;
+  name: string;
+}
+
+const formatActivityDurationName = (
+  activityDuration?: ActivityDurationNameSource | null,
+) =>
+  activityDuration
+    ? `${activityDuration.year}년 ${activityDuration.name}`
+    : "-";
+
+export const defaultActivityDuration = {
+  id: 0,
+  semester: { id: 0 },
+  activityDurationTypeEnum: ActivityDurationTypeEnum.Regular,
+  year: 0,
+  name: "",
+  startTerm: new Date(0),
+  endTerm: new Date(0),
+};
+
+export default formatActivityDurationName;

--- a/packages/web/src/features/overview/_atomic/OverviewCommonColumns.tsx
+++ b/packages/web/src/features/overview/_atomic/OverviewCommonColumns.tsx
@@ -31,10 +31,7 @@ export default function OverviewCommonColumns<
       size: 100,
       filterFn: (row, _, value: string[]) =>
         value.includes(
-          {
-            [ClubTypeEnum.Regular]: "정동아리",
-            [ClubTypeEnum.Provisional]: "가동아리",
-          }[row.original.clubTypeEnum as ClubTypeEnum],
+          getTagDetail(row.original.clubTypeEnum, ClubTypeTagList).text,
         ),
     }),
     columnHelper.accessor(row => row.district, {

--- a/packages/web/src/features/overview/frames/OverviewFrame.tsx
+++ b/packages/web/src/features/overview/frames/OverviewFrame.tsx
@@ -1,8 +1,6 @@
 import { ColumnFiltersState } from "@tanstack/react-table";
 import React, { useEffect, useState } from "react";
 
-import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
-
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
@@ -10,12 +8,14 @@ import MultiFilter from "@sparcs-clubs/web/common/components/MultiFilter/Index";
 import { CategoryProps } from "@sparcs-clubs/web/common/components/MultiFilter/types/FilterCategories";
 import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import useGetDivisions from "@sparcs-clubs/web/common/services/getDivisions";
+import { ClubTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { OverviewFilteredRow } from "@sparcs-clubs/web/features/overview/_atomic/OverviewCommonColumns";
 import ClubInfoKROverviewTable from "@sparcs-clubs/web/features/overview/components/ClubIntoKROverviewTable";
 import DelegatesOverviewTable from "@sparcs-clubs/web/features/overview/components/DelegatesOverviewTable";
 import useGetClubInfoKROverview from "@sparcs-clubs/web/features/overview/services/useGetClubInfoKROverview";
 import useGetDelegatesOverview from "@sparcs-clubs/web/features/overview/services/useGetDelegatesOverview";
 import { downloadDelegateOverviewExcel } from "@sparcs-clubs/web/features/overview/utils/downloadOverviewExcel";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface OverviewFrameProps {
   year: number;
@@ -44,10 +44,7 @@ function overviewFilter(columnFilters: ColumnFiltersState) {
   return (row: OverviewFilteredRow) =>
     row.clubNameKr.includes(columnFilters[0].value as string) &&
     (columnFilters[1].value as string[]).includes(
-      {
-        [ClubTypeEnum.Regular]: "정동아리",
-        [ClubTypeEnum.Provisional]: "가동아리",
-      }[row.clubTypeEnum as ClubTypeEnum],
+      getTagDetail(row.clubTypeEnum, ClubTypeTagList).text,
     ) &&
     (columnFilters[2].value as string[]).includes(row.divisionName);
 }


### PR DESCRIPTION
## Summary
- 활동보고서 집행부 대시보드에 과거 활동반기 목록과 활동반기 상세 대시보드 route를 추가
- ACT-023/ACT-024 응답에 activityDuration 및 pastActivityDurations를 추가
- 등록취소(club_status_enum_id=3) 동아리만 활동보고서 대시보드에서 제외하고 특수등록 등 다른 enum은 보존

## Task Context
- Task ID: TU-419
- Notion: https://www.notion.so/363c25603b0b8135889bff54405e191f

## Patch Note

<!-- clubs:patch-note:start -->
category: feature
text: 집행부 활동보고서 대시보드에서 과거 활동반기 대시보드를 확인할 수 있습니다.
<!-- clubs:patch-note:end -->

