### PR TITLE
[TU-421] lint 기존 경고 제거

### DIFF
--- a/packages/api/src/feature/auth/util/sparcs-sso.ts
+++ b/packages/api/src/feature/auth/util/sparcs-sso.ts
@@ -143,7 +143,7 @@ export class Client {
         try {
           result.kaist_v2_info = JSON.parse(result.kaist_v2_info);
         } catch (e) {
-          console.error("Failed to parse kaist_v2_info in SSO client:", e);
+          logger.error("Failed to parse kaist_v2_info in SSO client:", e);
           result.kaist_v2_info = null;
         }
       }

--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -62,6 +62,11 @@ export const baseConfig = tseslint.config(
         project: true,
       },
     },
+    settings: {
+      react: {
+        version: "18.2.0",
+      },
+    },
     rules: {
       "curly": "off",
       "import/extensions": "off",

--- a/packages/web/src/features/executive/components/SecretKey/OperationCommitteeSecretManager.tsx
+++ b/packages/web/src/features/executive/components/SecretKey/OperationCommitteeSecretManager.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import axios from "axios";
-import React, { useEffect, useMemo, useState } from "react";
+import { overlay } from "overlay-kit";
+import React, { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
 import SectionTitle from "@sparcs-clubs/web/common/components/SectionTitle";
 import { useOperationCommitteeSecret } from "@sparcs-clubs/web/features/executive/hooks/useOperationCommitteeSecret";
 
@@ -12,6 +16,40 @@ import AccessLinkSection from "./AccessLinkSection";
 import ErrorMessage from "./ErrorMessage";
 import HeaderButtons from "./HeaderButtons";
 import SecretKeySection from "./SecretKeySection";
+
+const openMessageModal = (message: ReactNode) => {
+  overlay.open(({ isOpen, close }) => (
+    <Modal isOpen={isOpen} onClose={close}>
+      <ConfirmModalContent onConfirm={close}>{message}</ConfirmModalContent>
+    </Modal>
+  ));
+};
+
+const openConfirmModal = (message: ReactNode) =>
+  new Promise<boolean>(resolve => {
+    overlay.open(({ isOpen, close }) => {
+      const handleClose = () => {
+        resolve(false);
+        close();
+      };
+
+      const handleConfirm = () => {
+        resolve(true);
+        close();
+      };
+
+      return (
+        <Modal isOpen={isOpen} onClose={handleClose}>
+          <CancellableModalContent
+            onClose={handleClose}
+            onConfirm={handleConfirm}
+          >
+            {message}
+          </CancellableModalContent>
+        </Modal>
+      );
+    });
+  });
 
 const OperationCommitteeSecretManager: React.FC = () => {
   const {
@@ -40,26 +78,28 @@ const OperationCommitteeSecretManager: React.FC = () => {
   }, [currentKey]);
 
   const handleCreateKey = async () => {
-    if (!window.confirm("새 비밀키를 생성하시겠습니까?")) return;
+    if (!(await openConfirmModal("새 비밀키를 생성하시겠습니까?"))) return;
 
     try {
       const response = await createSecretKey();
       if (response?.createdKey?.secretKey) {
         setCurrentKey(response.createdKey.secretKey);
       }
-      window.alert("새 비밀키가 생성되었습니다.");
-    } catch (e) {
-      if (process.env.NODE_ENV === "development")
-        console.error("비밀키 생성 실패:", e);
-      window.alert("비밀키 생성에 실패했습니다.");
+      openMessageModal("새 비밀키가 생성되었습니다.");
+    } catch {
+      openMessageModal("비밀키 생성에 실패했습니다.");
     }
   };
 
   const handleUpdateKey = async () => {
     if (
-      !window.confirm(
-        "기존 비밀키를 새로운 키로 교체하시겠습니까?\n기존 링크는 사용할 수 없게 됩니다.",
-      )
+      !(await openConfirmModal(
+        <>
+          기존 비밀키를 새로운 키로 교체하시겠습니까?
+          <br />
+          기존 링크는 사용할 수 없게 됩니다.
+        </>,
+      ))
     )
       return;
 
@@ -68,37 +108,37 @@ const OperationCommitteeSecretManager: React.FC = () => {
       if (response?.createdKey?.secretKey) {
         setCurrentKey(response.createdKey.secretKey);
       }
-      window.alert("비밀키가 갱신되었습니다.");
-    } catch (e) {
-      if (process.env.NODE_ENV === "development")
-        console.error("비밀키 갱신 실패:", e);
-      window.alert("비밀키 갱신에 실패했습니다.");
+      openMessageModal("비밀키가 갱신되었습니다.");
+    } catch {
+      openMessageModal("비밀키 갱신에 실패했습니다.");
     }
   };
 
   const handleDeleteKey = async () => {
     if (
-      !window.confirm(
-        "정말로 비밀키를 삭제하시겠습니까?\n운영위원들이 활동보고서에 접근할 수 없게 됩니다.",
-      )
+      !(await openConfirmModal(
+        <>
+          정말로 비밀키를 삭제하시겠습니까?
+          <br />
+          운영위원들이 활동보고서에 접근할 수 없게 됩니다.
+        </>,
+      ))
     )
       return;
 
     try {
       await deleteSecretKey();
       setCurrentKey(null);
-      window.alert("비밀키가 삭제되었습니다.");
-    } catch (e) {
-      if (process.env.NODE_ENV === "development")
-        console.error("비밀키 삭제 실패:", e);
-      window.alert("비밀키 삭제에 실패했습니다.");
+      openMessageModal("비밀키가 삭제되었습니다.");
+    } catch {
+      openMessageModal("비밀키 삭제에 실패했습니다.");
     }
   };
 
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      window.alert("복사되었습니다.");
+      openMessageModal("복사되었습니다.");
     } catch {
       const ta = document.createElement("textarea");
       ta.value = text;
@@ -106,7 +146,7 @@ const OperationCommitteeSecretManager: React.FC = () => {
       ta.select();
       document.execCommand("copy");
       document.body.removeChild(ta);
-      window.alert("복사되었습니다.");
+      openMessageModal("복사되었습니다.");
     }
   };
 

--- a/packages/web/src/features/executive/services/operationCommitteeSecret.ts
+++ b/packages/web/src/features/executive/services/operationCommitteeSecret.ts
@@ -10,8 +10,6 @@ import { axiosClientWithAuth } from "@sparcs-clubs/web/lib/axios";
 export const getOperationCommitteeSecret =
   async (): Promise<ApiOpC002ResponseOK> => {
     const url = apiOpC002.url();
-    console.log("🔍 GET URL:", url);
-    console.log("🔍 Base URL:", axiosClientWithAuth.defaults.baseURL);
 
     const { data } = await axiosClientWithAuth.get(url);
     return apiOpC002.responseBodyMap[200].parse(data);
@@ -20,7 +18,6 @@ export const getOperationCommitteeSecret =
 export const postOperationCommitteeSecret =
   async (): Promise<ApiOpC001ResponseOK> => {
     const url = apiOpC001.url();
-    console.log("🔍 POST URL:", url);
 
     const { data } = await axiosClientWithAuth.post(url);
     return apiOpC001.responseBodyMap[201].parse(data);
@@ -29,7 +26,6 @@ export const postOperationCommitteeSecret =
 export const deleteOperationCommitteeSecret =
   async (): Promise<ApiOpC003ResponseOK> => {
     const url = apiOpC003.url();
-    console.log("🔍 DELETE URL:", url);
 
     const { data } = await axiosClientWithAuth.delete(url);
     return apiOpC003.responseBodyMap[200].parse(data);

--- a/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
@@ -151,6 +151,29 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
     router.push(`/manage-club/activity-report/${activityId}`);
   };
 
+  const handleCopyActivityReportUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/manage-club/activity-report/${activityId}`,
+      );
+      overlay.open(({ isOpen: isOpenCopyModal, close: closeCopyModal }) => (
+        <Modal isOpen={isOpenCopyModal}>
+          <ConfirmModalContent onConfirm={closeCopyModal}>
+            활동보고서 주소가 클립보드에 복사 되었습니다.
+          </ConfirmModalContent>
+        </Modal>
+      ));
+    } catch {
+      overlay.open(({ isOpen: isOpenCopyModal, close: closeCopyModal }) => (
+        <Modal isOpen={isOpenCopyModal}>
+          <ConfirmModalContent onConfirm={closeCopyModal}>
+            활동보고서 주소 복사에 실패했습니다.
+          </ConfirmModalContent>
+        </Modal>
+      ));
+    }
+  };
+
   if (!data) return null;
 
   return (
@@ -167,12 +190,7 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
           >
             <Button
               style={{ padding: "8px" }}
-              onClick={() => {
-                navigator.clipboard.writeText(
-                  `${window.location.origin}/manage-club/activity-report/${activityId}`,
-                );
-                alert("활동보고서 주소가 클립보드에 복사 되었습니다!");
-              }}
+              onClick={handleCopyActivityReportUrl}
             >
               <Icon type="link_variant" size={16} color="white" />
             </Button>

--- a/packages/web/src/features/register-club/components/basic-info/_atomic/ClubNameField.tsx
+++ b/packages/web/src/features/register-club/components/basic-info/_atomic/ClubNameField.tsx
@@ -28,7 +28,6 @@ const ClubNameField: React.FC<ClubNameFieldProps> = ({
   editMode = false,
 }) => {
   const { control, setValue, watch } = useFormContext<RegisterClubModel>();
-  const formData = watch();
 
   const clubId = watch("clubId");
   const krName = watch("clubNameKr");
@@ -50,10 +49,6 @@ const ClubNameField: React.FC<ClubNameFieldProps> = ({
       ),
     [clubList],
   );
-
-  useEffect(() => {
-    console.log("formData changed:", formData);
-  }, [formData]);
 
   useEffect(() => {
     if (type !== RegistrationTypeEnum.NewProvisional && clubId != null) {


### PR DESCRIPTION
## Summary
- React 설정 경고와 console/alert/confirm lint warning을 제거했습니다.
- 운영위원 비밀키 관리와 활동보고서 링크 복사 안내를 공통 modal 기반으로 정리했습니다.
- SSO 파싱 실패 로그를 API logger로 전환하고 남은 디버그 로그를 제거했습니다.

## Task Context
- Task ID: TU-421
- Notion: https://www.notion.so/363c25603b0b81a68cf6c94de2c373f0

## Patch Note

<!-- clubs:patch-note:start -->
category: design
text: 운영위원 비밀키 관리와 활동보고서 링크 복사 안내를 서비스 내 확인창으로 표시하도록 정리했습니다.
<!-- clubs:patch-note:end -->

