### PR TITLE
[TU-398] 집행부 회원등록 상세 통계 집계 기준 수정

### DIFF
--- a/packages/api/src/feature/registration/service/member-registration-statistics.spec.ts
+++ b/packages/api/src/feature/registration/service/member-registration-statistics.spec.ts
@@ -1,0 +1,47 @@
+import { getMemberRegistrationStatistics } from "./member-registration-statistics";
+
+describe("getMemberRegistrationStatistics", () => {
+  it("calculates statistics from the whole registration list", () => {
+    const registrations = [
+      {
+        registrationApplicationStudentEnum: 1,
+        student: { id: 101 },
+      },
+      {
+        registrationApplicationStudentEnum: 2,
+        student: { id: 102 },
+      },
+      {
+        registrationApplicationStudentEnum: 3,
+        student: { id: 103 },
+      },
+    ];
+    const studentEnumByStudentId = new Map([
+      [101, 1],
+      [102, 1],
+      [103, 2],
+    ]);
+
+    expect(
+      getMemberRegistrationStatistics({
+        registrations,
+        studentEnumByStudentId,
+        statusEnumIds: {
+          pending: 1,
+          approved: 2,
+          rejected: 3,
+          regularStudent: 1,
+        },
+      }),
+    ).toEqual({
+      totalRegistrations: 3,
+      totalWaitings: 1,
+      totalApprovals: 1,
+      totalRejections: 1,
+      regularMemberRegistrations: 2,
+      regularMemberWaitings: 1,
+      regularMemberApprovals: 1,
+      regularMemberRejections: 0,
+    });
+  });
+});

--- a/packages/api/src/feature/registration/service/member-registration-statistics.ts
+++ b/packages/api/src/feature/registration/service/member-registration-statistics.ts
@@ -29,6 +29,9 @@ export type MemberRegistrationStatistics = {
   regularMemberRejections: number;
 };
 
+/**
+ * Computes REG-020 statistics from the full, unpaginated club registration list.
+ */
 export function getMemberRegistrationStatistics({
   registrations,
   studentEnumByStudentId,

--- a/packages/api/src/feature/registration/service/member-registration-statistics.ts
+++ b/packages/api/src/feature/registration/service/member-registration-statistics.ts
@@ -1,0 +1,78 @@
+type MemberRegistrationStatisticSource = {
+  registrationApplicationStudentEnum: number;
+  student: {
+    id: number;
+  };
+};
+
+type MemberRegistrationStatisticStatusEnumIds = {
+  pending: number;
+  approved: number;
+  rejected: number;
+  regularStudent: number;
+};
+
+type GetMemberRegistrationStatisticsParam = {
+  registrations: MemberRegistrationStatisticSource[];
+  studentEnumByStudentId: Map<number, number>;
+  statusEnumIds: MemberRegistrationStatisticStatusEnumIds;
+};
+
+export type MemberRegistrationStatistics = {
+  totalRegistrations: number;
+  totalWaitings: number;
+  totalApprovals: number;
+  totalRejections: number;
+  regularMemberRegistrations: number;
+  regularMemberWaitings: number;
+  regularMemberApprovals: number;
+  regularMemberRejections: number;
+};
+
+export function getMemberRegistrationStatistics({
+  registrations,
+  studentEnumByStudentId,
+  statusEnumIds,
+}: GetMemberRegistrationStatisticsParam): MemberRegistrationStatistics {
+  const isRegularMemberRegistration = (
+    registration: MemberRegistrationStatisticSource,
+  ) =>
+    studentEnumByStudentId.get(registration.student.id) ===
+    statusEnumIds.regularStudent;
+
+  const hasStatus = (
+    registration: MemberRegistrationStatisticSource,
+    status: number,
+  ) => registration.registrationApplicationStudentEnum === status;
+
+  return {
+    totalRegistrations: registrations.length,
+    totalWaitings: registrations.filter(registration =>
+      hasStatus(registration, statusEnumIds.pending),
+    ).length,
+    totalApprovals: registrations.filter(registration =>
+      hasStatus(registration, statusEnumIds.approved),
+    ).length,
+    totalRejections: registrations.filter(registration =>
+      hasStatus(registration, statusEnumIds.rejected),
+    ).length,
+    regularMemberRegistrations: registrations.filter(
+      isRegularMemberRegistration,
+    ).length,
+    regularMemberWaitings: registrations.filter(
+      registration =>
+        isRegularMemberRegistration(registration) &&
+        hasStatus(registration, statusEnumIds.pending),
+    ).length,
+    regularMemberApprovals: registrations.filter(
+      registration =>
+        isRegularMemberRegistration(registration) &&
+        hasStatus(registration, statusEnumIds.approved),
+    ).length,
+    regularMemberRejections: registrations.filter(
+      registration =>
+        isRegularMemberRegistration(registration) &&
+        hasStatus(registration, statusEnumIds.rejected),
+    ).length,
+  };
+}

--- a/packages/api/src/feature/registration/service/registration.service.ts
+++ b/packages/api/src/feature/registration/service/registration.service.ts
@@ -1314,7 +1314,7 @@ export class RegistrationService {
   }): Promise<ApiReg020ResponseOk> {
     const semesterId = await this.semesterPublicService.loadId();
     // logger.debug(semesterId);
-    const [registrations, allRegistrations, total] = await Promise.all([
+    const [registrations, allRegistrations] = await Promise.all([
       this.memberRegistrationRepository.find({
         clubId: param.query.clubId,
         semesterId,
@@ -1330,11 +1330,8 @@ export class RegistrationService {
         clubId: param.query.clubId,
         semesterId,
       }),
-      this.memberRegistrationRepository.count({
-        clubId: param.query.clubId,
-        semesterId,
-      }),
     ]);
+    const total = allRegistrations.length;
     const studentEnums =
       await this.userPublicService.getStudentEnumsByIdsAndSemesterIdWithRollover(
         allRegistrations.map(registration => registration.student.id),

--- a/packages/api/src/feature/registration/service/registration.service.ts
+++ b/packages/api/src/feature/registration/service/registration.service.ts
@@ -66,6 +66,7 @@ import UserPublicService from "@sparcs-clubs/api/feature/user/service/user.publi
 import { MMemberRegistration } from "../model/member.registration.model";
 import { ClubRegistrationRepository } from "../repository/club-registration.repository";
 import { MemberRegistrationRepository } from "../repository/member-registration.repository";
+import { getMemberRegistrationStatistics } from "./member-registration-statistics";
 import { RegistrationPublicService } from "./registration.public.service";
 
 interface ApiReg006ResponseType {
@@ -1313,7 +1314,7 @@ export class RegistrationService {
   }): Promise<ApiReg020ResponseOk> {
     const semesterId = await this.semesterPublicService.loadId();
     // logger.debug(semesterId);
-    const [registrations, total] = await Promise.all([
+    const [registrations, allRegistrations, total] = await Promise.all([
       this.memberRegistrationRepository.find({
         clubId: param.query.clubId,
         semesterId,
@@ -1325,11 +1326,34 @@ export class RegistrationService {
           createdAt: OrderByTypeEnum.DESC,
         },
       }),
+      this.memberRegistrationRepository.find({
+        clubId: param.query.clubId,
+        semesterId,
+      }),
       this.memberRegistrationRepository.count({
         clubId: param.query.clubId,
         semesterId,
       }),
     ]);
+    const studentEnums =
+      await this.userPublicService.getStudentEnumsByIdsAndSemesterIdWithRollover(
+        allRegistrations.map(registration => registration.student.id),
+        semesterId,
+      );
+    const studentEnumByStudentId = new Map(
+      studentEnums.map(({ id, studentEnumId }) => [id, studentEnumId]),
+    );
+    const regularStudentEnumId = 1;
+    const registrationStatistics = getMemberRegistrationStatistics({
+      registrations: allRegistrations,
+      studentEnumByStudentId,
+      statusEnumIds: {
+        pending: RegistrationApplicationStudentStatusEnum.Pending,
+        approved: RegistrationApplicationStudentStatusEnum.Approved,
+        rejected: RegistrationApplicationStudentStatusEnum.Rejected,
+        regularStudent: regularStudentEnumId,
+      },
+    });
     const memberRegistrations = await Promise.all(
       registrations.map(async registration => ({
         id: registration.id,
@@ -1340,57 +1364,18 @@ export class RegistrationService {
           ...(await this.userPublicService.getStudentById(
             registration.student,
           )),
-          StudentEnumId:
-            await this.userPublicService.getStudentStatusEnumIdByStudentIdSemesterIdWithRollover(
-              registration.student.id,
-              semesterId,
-            ),
+          StudentEnumId: studentEnumByStudentId.get(registration.student.id),
         },
       })),
     );
     return {
-      totalRegistrations: memberRegistrations.length,
-      totalWaitings: memberRegistrations.filter(
-        e =>
-          e.registrationApplicationStudentEnum ===
-          RegistrationApplicationStudentStatusEnum.Pending,
-      ).length,
-      totalApprovals: memberRegistrations.filter(
-        e =>
-          e.registrationApplicationStudentEnum ===
-          RegistrationApplicationStudentStatusEnum.Approved,
-      ).length,
-      totalRejections: memberRegistrations.filter(
-        e =>
-          e.registrationApplicationStudentEnum ===
-          RegistrationApplicationStudentStatusEnum.Rejected,
-      ).length,
-      regularMemberRegistrations: memberRegistrations.filter(
-        e => e.student.StudentEnumId === 1,
-      ).length,
-      regularMemberApprovals: memberRegistrations.filter(
-        e =>
-          e.student.StudentEnumId === 1 &&
-          e.registrationApplicationStudentEnum ===
-            RegistrationApplicationStudentStatusEnum.Approved,
-      ).length,
-      regularMemberWaitings: memberRegistrations.filter(
-        e =>
-          e.student.StudentEnumId === 1 &&
-          e.registrationApplicationStudentEnum ===
-            RegistrationApplicationStudentStatusEnum.Pending,
-      ).length,
-      regularMemberRejections: memberRegistrations.filter(
-        e =>
-          e.student.StudentEnumId === 1 &&
-          e.registrationApplicationStudentEnum ===
-            RegistrationApplicationStudentStatusEnum.Rejected,
-      ).length,
+      ...registrationStatistics,
       items: memberRegistrations.map(e => ({
         memberRegistrationId: e.id,
         RegistrationApplicationStudentStatusEnumId:
           e.registrationApplicationStudentEnum,
-        isRegularMemberRegistration: e.student.StudentEnumId === 1,
+        isRegularMemberRegistration:
+          e.student.StudentEnumId === regularStudentEnumId,
         student: {
           id: e.student.id,
           studentNumber: e.student.number,


### PR DESCRIPTION
## Summary
- REG-020의 회원등록 상세 통계를 페이지네이션된 목록이 아닌 동아리/학기 전체 신청 기준으로 계산하도록 수정했습니다.
- 통계 계산 helper와 회귀 테스트를 추가했습니다.
- 집행부 동아리별 회원등록 화면 외 회원등록 관련 화면의 집계 흐름을 확인했습니다.

## Test
- pnpm exec dotenv -e ../../.env -- jest --config ./test/jest-unit.json src/feature/registration/service/member-registration-statistics.spec.ts --runInBand
- pnpm --filter api lint -- src/feature/registration/service/registration.service.ts src/feature/registration/service/member-registration-statistics.ts src/feature/registration/service/member-registration-statistics.spec.ts
- pnpm build:api

## Patch Note
<!-- clubs:patch-note:start -->
category: fix
text: 집행부 회원 등록 신청 상세 화면에서 페이지를 이동해도 동아리별 신청 통계가 전체 신청 기준으로 표시되도록 수정했습니다.
<!-- clubs:patch-note:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added member registration statistics with detailed breakdowns by application status (pending, approved, rejected) and member type classification.

* **Tests**
  * Added comprehensive test coverage for member registration statistics calculation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->