### PR TITLE
[TU-422] 동아리/회원 등록 과거 대시보드 추가

### DIFF
--- a/packages/api/src/feature/club/service/club.public.service.ts
+++ b/packages/api/src/feature/club/service/club.public.service.ts
@@ -352,8 +352,14 @@ export default class ClubPublicService {
     return result;
   }
 
-  async fetchSummaries(ids: number[]): Promise<IClubSummary[]> {
-    const results = await this.clubOldRepository.fetchSummaries(ids);
+  async fetchSummaries(
+    ids: number[],
+    semesterIds?: number[],
+  ): Promise<IClubSummary[]> {
+    const results = await this.clubOldRepository.fetchSummaries(
+      ids,
+      semesterIds,
+    );
     return results;
   }
 

--- a/packages/api/src/feature/registration/controller/registration.controller.ts
+++ b/packages/api/src/feature/registration/controller/registration.controller.ts
@@ -265,8 +265,7 @@ export class RegistrationController {
   ): Promise<ApiReg014ResponseOk> {
     const result =
       await this.registrationService.getExecutiveRegistrationsClubRegistrations(
-        query.pageOffset,
-        query.itemCount,
+        query,
       );
     return result;
   }

--- a/packages/api/src/feature/registration/repository/club-registration.repository.ts
+++ b/packages/api/src/feature/registration/repository/club-registration.repository.ts
@@ -28,6 +28,11 @@ import { takeOne } from "@sparcs-clubs/api/common/util/util";
 import { syncDelegateMemberRegistrations } from "@sparcs-clubs/api/feature/registration/util/sync-delegate-member-registrations";
 import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
+type ClubRegistrationListResponse = Pick<
+  ApiReg014ResponseOk,
+  "items" | "total" | "offset"
+>;
+
 @Injectable()
 export class ClubRegistrationRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -602,12 +607,17 @@ export class ClubRegistrationRepository {
   async getRegistrationsClubRegistrations(
     pageOffset: number,
     itemCount: number,
-  ): Promise<ApiReg014ResponseOk> {
+    semesterId?: number,
+  ): Promise<ClubRegistrationListResponse> {
     const numberOfClubRegistrations = await this.prisma.registration.count({
-      where: { deletedAt: null },
+      where: { deletedAt: null, ...(semesterId ? { semesterId } : {}) },
     });
 
     const startOffset = (pageOffset - 1) * itemCount;
+    const semesterCondition = semesterId
+      ? Prisma.sql`AND r.semester_d_id = ${semesterId}`
+      : Prisma.empty;
+
     const clubRegistrations = await this.prisma.$queryRaw<
       Array<{
         id: number;
@@ -642,6 +652,7 @@ export class ClubRegistrationRepository {
       INNER JOIN student s ON r.student_id = s.id AND s.deleted_at IS NULL
       LEFT JOIN professor p ON r.professor_id = p.id AND p.deleted_at IS NULL
       WHERE r.deleted_at IS NULL
+        ${semesterCondition}
       ORDER BY r.created_at DESC
       LIMIT ${itemCount}
       OFFSET ${startOffset}
@@ -652,6 +663,18 @@ export class ClubRegistrationRepository {
       total: numberOfClubRegistrations,
       offset: pageOffset,
     };
+  }
+
+  async getSemesterIdsWithClubRegistrations(): Promise<number[]> {
+    const rows = await this.prisma.registration.groupBy({
+      by: ["semesterId"],
+      where: {
+        deletedAt: null,
+        semesterId: { not: null },
+      },
+    });
+
+    return rows.flatMap(row => (row.semesterId ? [row.semesterId] : []));
   }
 
   async getExecutiveRegistrationsClubRegistration(

--- a/packages/api/src/feature/registration/repository/member-registration.repository.ts
+++ b/packages/api/src/feature/registration/repository/member-registration.repository.ts
@@ -92,4 +92,16 @@ export class MemberRegistrationRepository extends BaseSingleTableRepository<
 
     return fieldMappings[field as keyof typeof fieldMappings];
   }
+
+  async getSemesterIdsWithMemberRegistrations(): Promise<number[]> {
+    const rows = await this.prisma.registrationApplicationStudent.groupBy({
+      by: ["semesterId"],
+      where: {
+        deletedAt: null,
+        semesterId: { not: null },
+      },
+    });
+
+    return rows.flatMap(row => (row.semesterId ? [row.semesterId] : []));
+  }
 }

--- a/packages/api/src/feature/registration/service/registration.service.ts
+++ b/packages/api/src/feature/registration/service/registration.service.ts
@@ -1,5 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 
+import { ISemester } from "@clubs/domain/semester/semester";
+
 import type {
   ApiReg001RequestBody,
   ApiReg001ResponseCreated,
@@ -21,7 +23,10 @@ import type { ApiReg010ResponseOk } from "@clubs/interface/api/registration/endp
 import type { ApiReg011ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg011";
 import type { ApiReg012ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg012";
 import { ApiReg013ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg013";
-import type { ApiReg014ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg014";
+import type {
+  ApiReg014RequestQuery,
+  ApiReg014ResponseOk,
+} from "@clubs/interface/api/registration/endpoint/apiReg014";
 import type { ApiReg015ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg015";
 import type { ApiReg016ResponseOk } from "@clubs/interface/api/registration/endpoint/apiReg016";
 import type { ApiReg017ResponseCreated } from "@clubs/interface/api/registration/endpoint/apiReg017";
@@ -86,6 +91,45 @@ export class RegistrationService {
     private readonly semesterPublicService: SemesterPublicService,
     private readonly registrationDeadlinePublicService: RegistrationDeadlinePublicService,
   ) {}
+
+  private async getRegistrationTargetSemester(
+    semesterId?: number,
+  ): Promise<ISemester> {
+    return semesterId
+      ? this.semesterPublicService.getById(semesterId)
+      : this.semesterPublicService.load();
+  }
+
+  private async getPastSemestersWithRegistrations(
+    targetSemester: ISemester,
+    semesterIds: number[],
+  ): Promise<ISemester[]> {
+    const semesters = await this.semesterPublicService.getByIds([
+      ...new Set(semesterIds),
+    ]);
+
+    return semesters
+      .filter(semester => semester.id < targetSemester.id)
+      .sort((a, b) => b.id - a.id);
+  }
+
+  private async getPastSemestersWithClubRegistrations(
+    targetSemester: ISemester,
+  ): Promise<ISemester[]> {
+    const semesterIds =
+      await this.clubRegistrationRepository.getSemesterIdsWithClubRegistrations();
+
+    return this.getPastSemestersWithRegistrations(targetSemester, semesterIds);
+  }
+
+  private async getPastSemestersWithMemberRegistrations(
+    targetSemester: ISemester,
+  ): Promise<ISemester[]> {
+    const semesterIds =
+      await this.memberRegistrationRepository.getSemesterIdsWithMemberRegistrations();
+
+    return this.getPastSemestersWithRegistrations(targetSemester, semesterIds);
+  }
 
   /**
    * @description 동아리 대표자인지 검증하는 로직은 repository쪽에서 진행됩니다.
@@ -599,15 +643,25 @@ export class RegistrationService {
   }
 
   async getExecutiveRegistrationsClubRegistrations(
-    pageOffset: number,
-    itemCount: number,
+    query: ApiReg014RequestQuery,
   ): Promise<ApiReg014ResponseOk> {
+    const semester = await this.getRegistrationTargetSemester(query.semesterId);
     const result =
       await this.clubRegistrationRepository.getRegistrationsClubRegistrations(
-        pageOffset,
-        itemCount,
+        query.pageOffset,
+        query.itemCount,
+        semester.id,
       );
-    return result;
+    const pastSemesters =
+      query.semesterId === undefined
+        ? await this.getPastSemestersWithClubRegistrations(semester)
+        : undefined;
+
+    return {
+      semester,
+      ...(pastSemesters ? { pastSemesters } : {}),
+      ...result,
+    };
   }
 
   async getStudentRegistrationsClubRegistrations(
@@ -1311,7 +1365,8 @@ export class RegistrationService {
     executiveId: number;
     query: ApiReg020RequestQuery;
   }): Promise<ApiReg020ResponseOk> {
-    const semesterId = await this.semesterPublicService.loadId();
+    const semesterId =
+      param.query.semesterId ?? (await this.semesterPublicService.loadId());
     // logger.debug(semesterId);
     const [registrations, total] = await Promise.all([
       this.memberRegistrationRepository.find({
@@ -1414,19 +1469,14 @@ export class RegistrationService {
     executiveId: number;
     query: ApiReg019RequestQuery;
   }): Promise<ApiReg019ResponseOk> {
-    const semesterId = await this.semesterPublicService.loadId();
+    const semester = await this.getRegistrationTargetSemester(
+      param.query.semesterId,
+    );
+    const semesterId = semester.id;
     // logger.debug(semesterId);
     const registrations = await this.memberRegistrationRepository.find({
       semesterId,
     });
-
-    const [divisions, studentEnums] = await Promise.all([
-      this.divisionPublicService.getCurrentDivisions(),
-      this.userPublicService.getStudentEnumsByIdsAndSemesterIdWithRollover(
-        registrations.map(e => e.student.id),
-        semesterId,
-      ),
-    ]);
 
     const clubIds = registrations.reduce((acc: number[], registration) => {
       if (!acc.includes(registration.club.id)) {
@@ -1434,12 +1484,33 @@ export class RegistrationService {
       }
       return acc;
     }, []);
+
+    const [studentEnums, clubSummaries] = await Promise.all([
+      this.userPublicService.getStudentEnumsByIdsAndSemesterIdWithRollover(
+        registrations.map(e => e.student.id),
+        semesterId,
+      ),
+      this.clubPublicService.fetchSummaries(clubIds, [semesterId]),
+    ]);
+
+    const divisions = await this.clubPublicService.fetchDivisionSummaries(
+      Array.from(new Set(clubSummaries.map(club => club.division.id))),
+    );
+
     const clubIdSummaryIsPermanentDivisionTuples = await Promise.all(
       clubIds.map(async clubId => {
-        const club = await this.clubPublicService.fetchSummary(clubId);
+        const club =
+          clubSummaries.find(clubSummary => clubSummary.id === clubId) ??
+          (await this.clubPublicService.fetchSummary(clubId));
         const isPermanent =
           await this.clubPublicService.isPermanentClubsByClubId(club.id);
-        const division = divisions.find(e => e.id === club.division.id);
+        const division =
+          divisions.find(e => e.id === club.division.id) ??
+          (
+            await this.clubPublicService.fetchDivisionSummaries([
+              club.division.id,
+            ])
+          )[0];
 
         return {
           clubId,
@@ -1508,7 +1579,14 @@ export class RegistrationService {
       ).length,
     }));
 
+    const pastSemesters =
+      param.query.semesterId === undefined
+        ? await this.getPastSemestersWithMemberRegistrations(semester)
+        : undefined;
+
     return {
+      semester,
+      ...(pastSemesters ? { pastSemesters } : {}),
       total: totalItems.length,
       items: totalItems.slice(
         // TODO: 나중에 쿼리 자체 변경 필요

--- a/packages/interface/src/api/registration/endpoint/apiReg014.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg014.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClubName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
@@ -20,12 +22,15 @@ const requestParam = z.object({});
 const requestQuery = z.object({
   pageOffset: z.coerce.number().int().min(1),
   itemCount: z.coerce.number().int().min(1),
+  semesterId: zSemester.shape.id.optional(),
 });
 
 const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
+    semester: zSemester,
+    pastSemesters: z.array(zSemester).optional(),
     items: z.array(
       z.object({
         id: z.coerce.number().int().min(1),

--- a/packages/interface/src/api/registration/endpoint/apiReg019.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg019.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClub } from "@clubs/interface/api/club/type/club.type";
 import { zDivision } from "@clubs/interface/api/division/type/division.type";
 import { registry } from "@clubs/interface/open-api";
@@ -18,11 +20,14 @@ const requestParam = z.object({});
 const requestQuery = z.object({
   pageOffset: z.coerce.number().int().min(1),
   itemCount: z.coerce.number().int().min(1),
+  semesterId: zSemester.shape.id.optional(),
 });
 const requestBody = z.object({});
 
 const responseBodyMap = {
   [HttpStatusCode.Ok]: z.object({
+    semester: zSemester,
+    pastSemesters: z.array(zSemester).optional(),
     items: z.array(
       z.object({
         clubId: zClub.shape.id,

--- a/packages/interface/src/api/registration/endpoint/apiReg020.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg020.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
 import { zMemberRegistration } from "@clubs/domain/registration/member-registration";
+import { zSemester } from "@clubs/domain/semester/semester";
 
 import { zClub } from "@clubs/interface/api/club/type/club.type";
 import { zUserName } from "@clubs/interface/common/commonString";
@@ -22,6 +23,7 @@ const requestQuery = z.object({
   clubId: zClub.shape.id,
   pageOffset: z.coerce.number().int().min(1),
   itemCount: z.coerce.number().int().min(1),
+  semesterId: zSemester.shape.id.optional(),
 });
 const requestBody = z.object({});
 

--- a/packages/web/src/app/executive/register-club/semester/[id]/page.tsx
+++ b/packages/web/src/app/executive/register-club/semester/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
@@ -12,9 +13,14 @@ import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
 import { ExecutiveRegistrationClubFrame } from "@sparcs-clubs/web/features/executive/register-club/frames/ExecutiveRegistrationClubFrame";
 
-const ExecutiveRegisterClub = () => {
+const ExecutiveRegisterClubSemester = () => {
   const { isLoggedIn, login, profile } = useAuth();
   const [loading, setLoading] = useState(true);
+  const { id } = useParams<{ id: string }>();
+
+  const parsedSemesterId = Number(id);
+  const isValidSemesterId =
+    Number.isInteger(parsedSemesterId) && parsedSemesterId > 0;
 
   useEffect(() => {
     if (isLoggedIn !== undefined || profile !== undefined) {
@@ -30,7 +36,7 @@ const ExecutiveRegisterClub = () => {
     return <LoginRequired login={login} />;
   }
 
-  if (profile?.type !== UserTypeEnum.Executive) {
+  if (profile?.type !== UserTypeEnum.Executive || !isValidSemesterId) {
     return <NotFound />;
   }
 
@@ -39,16 +45,17 @@ const ExecutiveRegisterClub = () => {
       <PageHead
         items={[
           { name: "집행부원 대시보드", path: "/executive" },
-          { name: "동아리 등록 신청 내역", path: `/executive/register-club` },
+          { name: "동아리 등록 신청 내역", path: "/executive/register-club" },
         ]}
         title="동아리 등록 신청 내역"
+        enableLast
       />
       <ExecutiveRegistrationClubFrame
         url="/executive/register-club"
-        showPastDashboard
+        semesterId={parsedSemesterId}
       />
     </FlexWrapper>
   );
 };
 
-export default ExecutiveRegisterClub;
+export default ExecutiveRegisterClubSemester;

--- a/packages/web/src/app/executive/register-member/page.tsx
+++ b/packages/web/src/app/executive/register-member/page.tsx
@@ -37,7 +37,7 @@ const RegisterMember = () => {
         ]}
         title="회원 등록 신청 내역"
       />
-      <ExecutiveRegisterMember />
+      <ExecutiveRegisterMember showPastDashboard />
     </FlexWrapper>
   );
 };

--- a/packages/web/src/app/executive/register-member/semester/[id]/page.tsx
+++ b/packages/web/src/app/executive/register-member/semester/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 
 import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
 
@@ -10,27 +11,25 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-clubs/web/common/components/PageHead";
 import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
-import { ExecutiveRegistrationClubFrame } from "@sparcs-clubs/web/features/executive/register-club/frames/ExecutiveRegistrationClubFrame";
+import { ExecutiveRegisterMember } from "@sparcs-clubs/web/features/executive/register-member/frames/ExecutiveRegisterMemberFrame";
 
-const ExecutiveRegisterClub = () => {
+const ExecutiveRegisterMemberSemester = () => {
   const { isLoggedIn, login, profile } = useAuth();
-  const [loading, setLoading] = useState(true);
+  const { id } = useParams<{ id: string }>();
 
-  useEffect(() => {
-    if (isLoggedIn !== undefined || profile !== undefined) {
-      setLoading(false);
-    }
-  }, [isLoggedIn, profile]);
-
-  if (loading) {
-    return <AsyncBoundary isLoading={loading} isError />;
-  }
+  const parsedSemesterId = Number(id);
+  const isValidSemesterId =
+    Number.isInteger(parsedSemesterId) && parsedSemesterId > 0;
 
   if (!isLoggedIn) {
     return <LoginRequired login={login} />;
   }
 
-  if (profile?.type !== UserTypeEnum.Executive) {
+  if (profile === null) {
+    return <AsyncBoundary isLoading isError={false} />;
+  }
+
+  if (profile?.type !== UserTypeEnum.Executive || !isValidSemesterId) {
     return <NotFound />;
   }
 
@@ -39,16 +38,14 @@ const ExecutiveRegisterClub = () => {
       <PageHead
         items={[
           { name: "집행부원 대시보드", path: "/executive" },
-          { name: "동아리 등록 신청 내역", path: `/executive/register-club` },
+          { name: "회원 등록 신청 내역", path: "/executive/register-member" },
         ]}
-        title="동아리 등록 신청 내역"
+        title="회원 등록 신청 내역"
+        enableLast
       />
-      <ExecutiveRegistrationClubFrame
-        url="/executive/register-club"
-        showPastDashboard
-      />
+      <ExecutiveRegisterMember semesterId={parsedSemesterId} />
     </FlexWrapper>
   );
 };
 
-export default ExecutiveRegisterClub;
+export default ExecutiveRegisterMemberSemester;

--- a/packages/web/src/features/executive/components/ExecutivePastSemesterDashboardSection.tsx
+++ b/packages/web/src/features/executive/components/ExecutivePastSemesterDashboardSection.tsx
@@ -1,0 +1,69 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import { ISemester } from "@clubs/domain/semester/semester";
+
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
+import Table from "@sparcs-clubs/web/common/components/Table";
+import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
+
+interface ExecutivePastSemesterDashboardSectionProps {
+  title: string;
+  emptyMessage: string;
+  semesters: ISemester[];
+  rowLink: (semester: ISemester) => string;
+}
+
+const columnHelper = createColumnHelper<ISemester>();
+
+const columns = [
+  columnHelper.accessor(row => `${row.year}년 ${row.name}`, {
+    id: "semester",
+    header: "학기",
+    cell: info => info.getValue(),
+    size: 220,
+  }),
+  columnHelper.accessor(
+    row =>
+      `${formatDate(new Date(row.startTerm))} ~ ${formatDate(new Date(row.endTerm))}`,
+    {
+      id: "duration",
+      header: "학기 기간",
+      cell: info => info.getValue(),
+      size: 420,
+    },
+  ),
+];
+
+const ExecutivePastSemesterDashboardSection = ({
+  title,
+  emptyMessage,
+  semesters,
+  rowLink,
+}: ExecutivePastSemesterDashboardSectionProps) => {
+  const table = useReactTable({
+    data: semesters,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return (
+    <FoldableSectionTitle title={title}>
+      <FlexWrapper direction="column" gap={20}>
+        <Table
+          table={table}
+          minWidth={820}
+          emptyMessage={emptyMessage}
+          rowLink={row => rowLink(row)}
+        />
+      </FlexWrapper>
+    </FoldableSectionTitle>
+  );
+};
+
+export default ExecutivePastSemesterDashboardSection;

--- a/packages/web/src/features/executive/register-club/frames/ExecutiveRegistrationClubFrame.tsx
+++ b/packages/web/src/features/executive/register-club/frames/ExecutiveRegistrationClubFrame.tsx
@@ -20,6 +20,7 @@ import Pagination from "@sparcs-clubs/web/common/components/Pagination";
 import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import useGetDivisionType from "@sparcs-clubs/web/common/hooks/useGetDivisionType";
 import { RegistrationTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import ExecutivePastSemesterDashboardSection from "@sparcs-clubs/web/features/executive/components/ExecutivePastSemesterDashboardSection";
 import { useGetRegisterClub } from "@sparcs-clubs/web/features/executive/register-club/services/useGetRegisterClub";
 
 interface ConvertedSelectedCategories {
@@ -63,9 +64,15 @@ const RegistrationTypeList = Object.keys(RegistrationTypeTagList).map(key =>
   parseInt(key),
 );
 
-export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
-  url,
-}) => {
+interface ExecutiveRegistrationClubFrameProps {
+  url: string;
+  semesterId?: number;
+  showPastDashboard?: boolean;
+}
+
+export const ExecutiveRegistrationClubFrame: React.FC<
+  ExecutiveRegistrationClubFrameProps
+> = ({ url, semesterId, showPastDashboard = false }) => {
   const t = useTranslations();
   const [currentPage, setCurrentPage] = useState(1);
   const limit = 200;
@@ -74,6 +81,7 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
   const { data, isLoading, isError } = useGetRegisterClub({
     pageOffset: currentPage,
     itemCount: limit,
+    ...(semesterId ? { semesterId } : {}),
   });
 
   const {
@@ -82,14 +90,16 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
     isError: divisionError,
   } = useGetDivisionType();
 
+  const divisions = divisionData?.divisions;
+
   const DivisionNameList = useMemo(
-    () => divisionData?.divisions?.map(item => item.name) ?? [],
-    [divisionData],
+    () => divisions?.map(item => item.name) ?? [],
+    [divisions],
   );
 
   const DivisionIdList = useMemo(
-    () => divisionData?.divisions?.map(item => item.id.toString()) ?? [],
-    [divisionData],
+    () => divisions?.map(item => item.id.toString()) ?? [],
+    [divisions],
   );
 
   const [categories, setCategories] = useState<CategoryProps[]>([
@@ -113,20 +123,7 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
     },
   ]);
 
-  const [convertedCategories, setConvertedCategories] = useState<
-    ConvertedSelectedCategories[]
-  >([
-    {
-      name: "등록 구분",
-      selectedContent: RegistrationTypeList,
-    },
-    {
-      name: "분과",
-      selectedContent: divisionData?.divisions?.map(item => item.id) ?? [],
-    },
-  ]);
-
-  useEffect(() => {
+  const convertedCategories = useMemo<ConvertedSelectedCategories[]>(() => {
     const convertedRegistrationType = categories[0].selectedContent.flatMap(
       item => getEnumRegistration(item),
     );
@@ -135,7 +132,7 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
       parseInt(item),
     );
 
-    setConvertedCategories([
+    return [
       {
         name: "등록 구분",
         selectedContent: convertedRegistrationType,
@@ -144,7 +141,7 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
         name: "분과",
         selectedContent: convertedDivisionId,
       },
-    ]);
+    ];
   }, [categories]);
 
   const filterClubsWithSearch = useMemo(() => {
@@ -192,17 +189,25 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
   );
 
   useEffect(() => {
-    if (categories[1].content.length === 0 && divisionData) {
-      setCategories([
-        ...categories.slice(0, 1),
+    if (DivisionNameList.length === 0 || DivisionIdList.length === 0) {
+      return;
+    }
+
+    setCategories(prevCategories => {
+      if (prevCategories[1].content.length > 0) {
+        return prevCategories;
+      }
+
+      return [
+        ...prevCategories.slice(0, 1),
         {
           name: "분과",
           content: DivisionNameList,
           selectedContent: DivisionIdList,
         },
-      ]);
-    }
-  }, [categories, DivisionIdList, DivisionNameList]);
+      ];
+    });
+  }, [DivisionIdList, DivisionNameList]);
 
   return (
     <AsyncBoundary
@@ -265,6 +270,16 @@ export const ExecutiveRegistrationClubFrame: React.FC<{ url: string }> = ({
           />
         </FlexWrapper>
       </TableWithPaginationWrapper>
+      {showPastDashboard && (
+        <ExecutivePastSemesterDashboardSection
+          title="과거 동아리 등록 대시보드"
+          emptyMessage="과거 동아리 등록 대시보드가 없습니다"
+          semesters={data?.pastSemesters ?? []}
+          rowLink={semester =>
+            `/executive/register-club/semester/${semester.id}`
+          }
+        />
+      )}
     </AsyncBoundary>
   );
 };

--- a/packages/web/src/features/executive/register-member/components/RegisterMemberTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterMemberTable.tsx
@@ -16,7 +16,8 @@ import {
 } from "@sparcs-clubs/web/types/clubdetail.types";
 
 interface RegisterMemberTableProps {
-  registerMemberList: ApiReg019ResponseOk;
+  registerMemberList: Pick<ApiReg019ResponseOk, "items" | "total" | "offset">;
+  semesterId?: number;
 }
 
 const columnHelper = createColumnHelper<ApiReg019ResponseOk["items"][number]>();
@@ -73,6 +74,7 @@ const columns = [
 
 const RegistrationMemberTable: React.FC<RegisterMemberTableProps> = ({
   registerMemberList,
+  semesterId,
 }) => {
   const table = useReactTable({
     columns,
@@ -85,7 +87,9 @@ const RegistrationMemberTable: React.FC<RegisterMemberTableProps> = ({
     <Table
       table={table}
       count={registerMemberList.total}
-      rowLink={row => `/executive/register-member/${row.clubId}`}
+      rowLink={row =>
+        `/executive/register-member/${row.clubId}${semesterId ? `?semesterId=${semesterId}` : ""}`
+      }
     />
   );
 };

--- a/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberDetailFrame.tsx
+++ b/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberDetailFrame.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Divider } from "@mui/material";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import React, { useCallback, useState } from "react";
 
 import { RegistrationApplicationStudentStatusEnum } from "@clubs/interface/common/enum/registration.enum";
@@ -30,13 +30,25 @@ const ExecutiveRegisterMemberDetail: React.FC = () => {
   const limit = 10;
 
   const { id } = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
   const clubId = parseInt(id);
+  const semesterIdParam = searchParams.get("semesterId");
+  const parsedSemesterId = semesterIdParam
+    ? Number(semesterIdParam)
+    : undefined;
+  const semesterId =
+    parsedSemesterId &&
+    Number.isInteger(parsedSemesterId) &&
+    parsedSemesterId > 0
+      ? parsedSemesterId
+      : undefined;
 
   const club = useGetClubDetail(id as string);
   const { data, isLoading, isError } = useGetRegisterMemberDetail({
     clubId,
     pageOffset: currentPage,
     itemCount: limit,
+    ...(semesterId ? { semesterId } : {}),
   });
 
   const getStatusInfo = useCallback(

--- a/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberFrame.tsx
+++ b/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberFrame.tsx
@@ -13,6 +13,7 @@ import { CategoryProps } from "@sparcs-clubs/web/common/components/MultiFilter/t
 import Pagination from "@sparcs-clubs/web/common/components/Pagination";
 import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import useGetDivisionType from "@sparcs-clubs/web/common/hooks/useGetDivisionType";
+import ExecutivePastSemesterDashboardSection from "@sparcs-clubs/web/features/executive/components/ExecutivePastSemesterDashboardSection";
 import RegistrationMemberTable from "@sparcs-clubs/web/features/executive/register-member/components/RegisterMemberTable";
 import { useGetMemberRegistration } from "@sparcs-clubs/web/features/executive/register-member/services/useGetMemberRegistration";
 
@@ -53,7 +54,14 @@ interface ConvertedSelectedCategories {
   selectedContent: (number | string)[];
 }
 
-export const ExecutiveRegisterMember: React.FC = () => {
+interface ExecutiveRegisterMemberProps {
+  semesterId?: number;
+  showPastDashboard?: boolean;
+}
+
+export const ExecutiveRegisterMember: React.FC<
+  ExecutiveRegisterMemberProps
+> = ({ semesterId, showPastDashboard = false }) => {
   const t = useTranslations("club");
   const [currentPage, setCurrentPage] = useState<number>(1);
   const limit = 200;
@@ -61,6 +69,7 @@ export const ExecutiveRegisterMember: React.FC = () => {
   const { data, isLoading, isError } = useGetMemberRegistration({
     pageOffset: currentPage,
     itemCount: limit,
+    ...(semesterId ? { semesterId } : {}),
   });
 
   const {
@@ -69,9 +78,11 @@ export const ExecutiveRegisterMember: React.FC = () => {
     isError: divisionError,
   } = useGetDivisionType();
 
+  const divisions = divisionData?.divisions;
+
   const DivisionNameList = useMemo(
-    () => divisionData?.divisions?.map(item => item.name) ?? [],
-    [divisionData],
+    () => divisions?.map(item => item.name) ?? [],
+    [divisions],
   );
 
   const [searchText, setSearchText] = useState<string>("");
@@ -89,14 +100,7 @@ export const ExecutiveRegisterMember: React.FC = () => {
     },
   ]);
 
-  const [convertedCategories, setConvertedCategories] = useState<
-    ConvertedSelectedCategories[]
-  >([
-    { name: "구분", selectedContent: [1, 2, 3] },
-    { name: "분과", selectedContent: DivisionNameList },
-  ]);
-
-  useMemo(() => {
+  const convertedCategories = useMemo<ConvertedSelectedCategories[]>(() => {
     const convertedClubType = categories[0].selectedContent.map(item => {
       if (item === "정동아리") return 1;
       if (item === "가동아리") return 2;
@@ -104,18 +108,16 @@ export const ExecutiveRegisterMember: React.FC = () => {
       return 0;
     });
 
-    const convertedDivisionNames = categories[1].selectedContent;
-
-    setConvertedCategories([
+    return [
       {
         name: "구분",
         selectedContent: convertedClubType,
       },
       {
         name: "분과",
-        selectedContent: convertedDivisionNames,
+        selectedContent: categories[1].selectedContent,
       },
-    ]);
+    ];
   }, [categories]);
 
   const filteredClubs = useMemo(() => {
@@ -148,17 +150,25 @@ export const ExecutiveRegisterMember: React.FC = () => {
   }, [data, searchText, convertedCategories]);
 
   useEffect(() => {
-    if (categories[1].content.length === 0 && divisionData) {
-      setCategories([
-        ...categories.slice(0, 1),
+    if (DivisionNameList.length === 0) {
+      return;
+    }
+
+    setCategories(prevCategories => {
+      if (prevCategories[1].content.length > 0) {
+        return prevCategories;
+      }
+
+      return [
+        ...prevCategories.slice(0, 1),
         {
           name: "분과",
           content: DivisionNameList,
           selectedContent: DivisionNameList,
         },
-      ]);
-    }
-  }, [categories, DivisionNameList, divisionData]);
+      ];
+    });
+  }, [DivisionNameList]);
 
   return (
     <AsyncBoundary
@@ -201,7 +211,10 @@ export const ExecutiveRegisterMember: React.FC = () => {
             </ResetSearchAndFilterWrapper>
           </ClubSearchAndFilterWrapper>
           <TableWithPaginationWrapper>
-            <RegistrationMemberTable registerMemberList={filteredClubs} />
+            <RegistrationMemberTable
+              registerMemberList={filteredClubs}
+              semesterId={semesterId}
+            />
             <FlexWrapper direction="row" gap={16} justify="center">
               <Pagination
                 totalPage={Math.ceil(data.total / limit)}
@@ -211,6 +224,16 @@ export const ExecutiveRegisterMember: React.FC = () => {
               />
             </FlexWrapper>
           </TableWithPaginationWrapper>
+          {showPastDashboard && (
+            <ExecutivePastSemesterDashboardSection
+              title="과거 회원 등록 대시보드"
+              emptyMessage="과거 회원 등록 대시보드가 없습니다"
+              semesters={data?.pastSemesters ?? []}
+              rowLink={semester =>
+                `/executive/register-member/semester/${semester.id}`
+              }
+            />
+          )}
         </>
       )}
     </AsyncBoundary>

--- a/packages/web/src/features/executive/register-member/services/_mock/mockupMemberRegistration.ts
+++ b/packages/web/src/features/executive/register-member/services/_mock/mockupMemberRegistration.ts
@@ -38,6 +38,13 @@ const items = Array.from({ length: 120 }, (_, index) => ({
 }));
 
 const mockupRegistrationMember: ApiReg019ResponseOk = {
+  semester: {
+    id: 1,
+    year: 2025,
+    name: "봄",
+    startTerm: new Date("2025-03-01"),
+    endTerm: new Date("2025-09-01"),
+  },
   items,
   total: items.length,
   offset: 1,

--- a/packages/web/src/features/permanent/register-club/components/ClubRegistrationTable.tsx
+++ b/packages/web/src/features/permanent/register-club/components/ClubRegistrationTable.tsx
@@ -89,10 +89,9 @@ const columns = [
   }),
 ];
 
-const ClubRegistrationTable: React.FC<ApiReg014ResponseOk> = ({
-  items,
-  total,
-}) => {
+const ClubRegistrationTable: React.FC<
+  Pick<ApiReg014ResponseOk, "items" | "total">
+> = ({ items, total }) => {
   const table = useReactTable({
     columns,
     data: items,


### PR DESCRIPTION
## Summary
- 집행부 동아리 등록/회원 등록 대시보드에 과거 semester 목록과 semester별 대시보드 route를 추가했습니다.
- REG-014/REG-019/REG-020에 semesterId 쿼리를 연결하고, 등록 과거 목록은 activity duration이 아니라 semester id 기준으로 조회하도록 변경했습니다.
- 과거 회원 등록 조회에서 해당 semester의 club summary를 사용해 등록취소/과거 club 상태도 누락 없이 표시되도록 정리했습니다.

## Test
- pnpm --filter=domain build
- pnpm --filter=interface build
- pnpm --filter=api build
- pnpm --filter=api lint
- pnpm --filter=web lint
- pnpm --filter=web build

## Patch Note
<!-- clubs:patch-note:start -->
category: feature
text: 집행부 동아리 등록과 회원 등록 대시보드에서 과거 학기 등록 현황을 확인할 수 있습니다.
<!-- clubs:patch-note:end -->

## Task
- TU-422: https://www.notion.so/363c25603b0b8105b39ad78baaf5b33d