### PR TITLE
[TU-425] API 응답 파싱 길이 제한 정합화

### DIFF
--- a/packages/domain/src/club/club-semester.ts
+++ b/packages/domain/src/club/club-semester.ts
@@ -77,7 +77,7 @@ export const zClubSemester = z.object({
   }),
   characteristicKr: z
     .string()
-    .max(30)
+    .max(255)
     .nullable()
     .openapi({
       description: "동아리 성격 국문",
@@ -85,7 +85,7 @@ export const zClubSemester = z.object({
     }),
   characteristicEn: z
     .string()
-    .max(30)
+    .max(255)
     .nullable()
     .openapi({
       description: "동아리 성격 영문",

--- a/packages/domain/src/club/club.ts
+++ b/packages/domain/src/club/club.ts
@@ -11,11 +11,11 @@ export const zClub = z.object({
     examples: [1, 2, 3],
   }),
   // plain schema
-  nameKr: z.string().max(255).min(1).openapi({
+  nameKr: z.string().max(30).min(1).openapi({
     description: "동아리의 한국어 이름입니다.",
     example: "술박스",
   }),
-  nameEn: z.string().max(255).min(1).openapi({
+  nameEn: z.string().max(100).min(1).openapi({
     description: "동아리의 영어 이름입니다.",
     example: "sulbox",
   }),

--- a/packages/domain/src/user/professor.ts
+++ b/packages/domain/src/user/professor.ts
@@ -11,7 +11,7 @@ export enum ProfessorEnum {
 export const zProfessor = z.object({
   id: z.coerce.number(),
   userId: z.coerce.number().optional(),
-  name: z.string(),
+  name: z.string().max(255),
   email: z.string(),
   phoneNumber: z.string().optional(),
   professorEnum: z.nativeEnum(ProfessorEnum),

--- a/packages/interface/src/api/activity/endpoint/apiAct023.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct023.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 
 import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
 
+import {
+  zClubNameEn,
+  zClubNameKr,
+  zUserName,
+} from "@clubs/interface/common/commonString";
 import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 import { zId } from "@clubs/interface/common/type/id.type";
 
@@ -36,16 +41,16 @@ const responseBodyMap = {
         clubId: zId,
         clubTypeEnum: z.nativeEnum(ClubTypeEnum),
         divisionName: z.string().max(10),
-        clubNameKr: z.string().max(30),
-        clubNameEn: z.string().max(30),
-        advisor: z.string().max(255).optional(),
+        clubNameKr: zClubNameKr,
+        clubNameEn: zClubNameEn,
+        advisor: zUserName.optional(),
         pendingActivitiesCount: z.coerce.number().int().min(0),
         approvedActivitiesCount: z.coerce.number().int().min(0),
         rejectedActivitiesCount: z.coerce.number().int().min(0),
         chargedExecutive: z
           .object({
             id: zId,
-            name: z.string().max(30),
+            name: zUserName,
           })
           .optional(),
       }),
@@ -59,8 +64,8 @@ const responseBodyMap = {
             clubId: zId,
             clubTypeEnum: z.nativeEnum(ClubTypeEnum),
             divisionName: z.string().max(10),
-            clubNameKr: z.string().max(30),
-            clubNameEn: z.string().max(30),
+            clubNameKr: zClubNameKr,
+            clubNameEn: zClubNameEn,
             pendingActivitiesCount: z.coerce.number().int().min(0),
             approvedActivitiesCount: z.coerce.number().int().min(0),
             rejectedActivitiesCount: z.coerce.number().int().min(0),

--- a/packages/interface/src/api/activity/endpoint/apiAct024.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct024.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
 import { zActivityDuration } from "@clubs/domain/semester/activity-duration";
 
+import { zUserName } from "@clubs/interface/common/commonString";
 import { zId } from "@clubs/interface/common/type/id.type";
 
 /**
@@ -30,7 +31,7 @@ const responseBodyMap = {
     chargedExecutive: z
       .object({
         id: zId,
-        name: z.string().max(30),
+        name: zUserName,
       })
       .optional(),
     items: z.array(
@@ -43,13 +44,13 @@ const responseBodyMap = {
         commentedExecutive: z
           .object({
             id: zId,
-            name: z.string().max(30),
+            name: zUserName,
           })
           .optional(),
         chargedExecutive: z
           .object({
             id: zId,
-            name: z.string().max(30),
+            name: zUserName,
           })
           .optional(),
         updatedAt: z.coerce.date(),

--- a/packages/interface/src/api/club/endpoint/apiClb001.ts
+++ b/packages/interface/src/api/club/endpoint/apiClb001.ts
@@ -5,6 +5,10 @@ import { zClub } from "@clubs/domain/club/club";
 import { ClubTypeEnum } from "@clubs/domain/club/club-semester";
 import { zDivision } from "@clubs/domain/division/division";
 
+import {
+  zClubCharacteristic,
+  zUserName,
+} from "@clubs/interface/common/commonString";
 import { registry } from "@clubs/interface/open-api";
 
 const url = () => `/clubs`;
@@ -29,9 +33,9 @@ const responseBodyMap = {
             nameEn: zClub.shape.nameEn,
             type: z.nativeEnum(ClubTypeEnum), // 동아리 유형(정동아리 | 가동아리) // TODO: domain 추가하기
             isPermanent: z.coerce.boolean(), // 상임동아리 여부 // TODO: domain 추가하기
-            characteristic: zClub.shape.description, // 동아리 소개
-            representative: z.coerce.string().max(20), // 동아리 대표 // TODO: domain 추가하기
-            advisor: z.coerce.string().max(20).optional(), // 동아리 지도교수 // TODO: domain 추가하기
+            characteristic: zClubCharacteristic.nullable(), // 동아리 소개
+            representative: zUserName, // 동아리 대표 // TODO: domain 추가하기
+            advisor: zUserName.nullable().optional(), // 동아리 지도교수 // TODO: domain 추가하기
             totalMemberCnt: z.coerce.number().int().min(1), // TODO: domain 없는게 맞을수도
           })
           .array(),

--- a/packages/interface/src/api/club/endpoint/apiClb002.ts
+++ b/packages/interface/src/api/club/endpoint/apiClb002.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 import { zClub } from "@clubs/domain/club/club";
 
 import { zDivision } from "@clubs/interface/api/division/type/division.type";
+import {
+  zClubCharacteristic,
+  zClubRoom,
+  zUserName,
+} from "@clubs/interface/common/commonString";
 import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 import { registry } from "@clubs/interface/open-api";
 
@@ -30,9 +35,9 @@ const responseBodyMap = {
     nameEn: zClub.shape.nameEn,
     type: z.nativeEnum(ClubTypeEnum), // 동아리 유형(정동아리 | 가동아리)
     isPermanent: z.coerce.boolean(), // 상임동아리 여부
-    characteristic: z.coerce.string().max(50), // 동아리 소개
-    representative: z.coerce.string().max(20), // 동아리 대표
-    advisor: z.coerce.string().max(20).optional(), // 동아리 지도교수
+    characteristic: zClubCharacteristic.nullable(), // 동아리 소개
+    representative: zUserName, // 동아리 대표
+    advisor: zUserName.nullable().optional(), // 동아리 지도교수
     totalMemberCnt: z.coerce.number().int().min(1),
     description: zClub.shape.description,
     division: z.object({
@@ -40,7 +45,7 @@ const responseBodyMap = {
       name: zDivision.shape.name,
     }), // 분과명
     foundingYear: zClub.shape.foundingYear,
-    room: z.coerce.string().max(50), // 동아리방 위치
+    room: zClubRoom, // 동아리방 위치
   }),
 };
 

--- a/packages/interface/src/api/club/endpoint/apiClb003.ts
+++ b/packages/interface/src/api/club/endpoint/apiClb003.ts
@@ -5,6 +5,10 @@ import { zClub } from "@clubs/domain/club/club";
 import { ClubTypeEnum } from "@clubs/domain/club/club-semester";
 import { zSemester } from "@clubs/domain/semester/semester";
 
+import {
+  zClubCharacteristic,
+  zUserName,
+} from "@clubs/interface/common/commonString";
 import { registry } from "@clubs/interface/open-api";
 
 /**
@@ -34,9 +38,9 @@ const responseBodyMap = {
             nameEn: zClub.shape.nameEn,
             type: z.nativeEnum(ClubTypeEnum), // 동아리 유형(정동아리 | 가동아리)
             isPermanent: z.coerce.boolean(), // 상임동아리 여부
-            characteristic: z.coerce.string().max(50), // 동아리 소개
-            representative: z.coerce.string().max(20), // 동아리 대표
-            advisor: z.coerce.string().max(20).optional(), // 동아리 지도교수
+            characteristic: zClubCharacteristic.nullable(), // 동아리 소개
+            representative: zUserName, // 동아리 대표
+            advisor: zUserName.nullable().optional(), // 동아리 지도교수
             totalMemberCnt: z.coerce.number().int().min(1),
           })
           .array(),

--- a/packages/interface/src/api/club/endpoint/apiClb016.ts
+++ b/packages/interface/src/api/club/endpoint/apiClb016.ts
@@ -5,6 +5,10 @@ import { zClub } from "@clubs/domain/club/club";
 import { ClubTypeEnum } from "@clubs/domain/club/club-semester";
 import { zSemester } from "@clubs/domain/semester/semester";
 
+import {
+  zClubCharacteristic,
+  zUserName,
+} from "@clubs/interface/common/commonString";
 import { registry } from "@clubs/interface/open-api";
 
 /**
@@ -34,9 +38,9 @@ const responseBodyMap = {
             nameEn: zClub.shape.nameEn,
             type: z.nativeEnum(ClubTypeEnum), // 동아리 유형(정동아리 | 가동아리)
             isPermanent: z.coerce.boolean(), // 상임동아리 여부
-            characteristic: z.coerce.string().max(50), // 동아리 소개
-            representative: z.coerce.string().max(20), // 동아리 대표
-            advisor: z.coerce.string().max(20).optional(), // 동아리 지도교수
+            characteristic: zClubCharacteristic.nullable(), // 동아리 소개
+            representative: zUserName, // 동아리 대표
+            advisor: zUserName.nullable().optional(), // 동아리 지도교수
             totalMemberCnt: z.coerce.number().int().min(1),
           })
           .array(),

--- a/packages/interface/src/api/club/type/club.type.ts
+++ b/packages/interface/src/api/club/type/club.type.ts
@@ -10,6 +10,11 @@ import {
 } from "@clubs/interface/api/division/type/division.type";
 import { zProfessor, zStudent } from "@clubs/interface/api/user/type/user.type";
 import {
+  zClubCharacteristic,
+  zClubNameEn,
+  zClubNameKr,
+} from "@clubs/interface/common/commonString";
+import {
   ClubBuildingEnum,
   ClubDelegateEnum,
   ClubTypeEnum,
@@ -40,11 +45,11 @@ export const zClub = z.object({
     examples: [1, 2, 3],
   }),
   // plain schema
-  nameKr: z.string().max(255).min(1).openapi({
+  nameKr: zClubNameKr.min(1).openapi({
     description: "동아리의 한국어 이름입니다.",
     example: "술박스",
   }),
-  nameEn: z.string().max(255).min(1).openapi({
+  nameEn: zClubNameEn.min(1).openapi({
     description: "동아리의 영어 이름입니다.",
     example: "sulbox",
   }),
@@ -52,8 +57,8 @@ export const zClub = z.object({
   foundingYear: z.coerce.number(),
   // clubT schema
   typeEnum: z.nativeEnum(ClubTypeEnum),
-  characteristicKr: z.string().max(30).nullable(),
-  characteristicEn: z.string().max(30).nullable(),
+  characteristicKr: zClubCharacteristic.nullable(),
+  characteristicEn: zClubCharacteristic.nullable(),
   semester: zSemester.pick({ id: true }),
   clubRoom: zClubRoom.pick({ id: true }).nullable(),
   // delegate schema

--- a/packages/interface/src/api/registration/endpoint/apiReg001.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg001.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
-import { zClubName } from "@clubs/interface/common/commonString";
+import { zClubName, zUserName } from "@clubs/interface/common/commonString";
 import { RegistrationTypeEnum } from "@clubs/interface/common/enum/registration.enum";
 import { ProfessorEnum } from "@clubs/interface/common/enum/user.enum";
 import { zKrPhoneNumber } from "@clubs/interface/common/type/phoneNumber.type";
@@ -43,7 +43,7 @@ const requestBody = z
      */
     professor: z
       .object({
-        name: z.string(),
+        name: zUserName,
         email: z
           .string()
           .email()

--- a/packages/interface/src/api/registration/endpoint/apiReg012.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg012.ts
@@ -2,7 +2,7 @@ import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
 import { zClub } from "@clubs/interface/api/club/type/club.type";
-import { zClubName } from "@clubs/interface/common/commonString";
+import { zClubName, zUserName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
   RegistrationTypeEnum,
@@ -38,7 +38,7 @@ const responseBodyMap = {
         clubId: zClub.pick({ id: true }).shape.id,
         activityFieldKr: z.string().max(255),
         activityFieldEn: z.string().max(255),
-        professorName: z.string().max(255),
+        professorName: zUserName,
       }),
     ),
   }),

--- a/packages/interface/src/api/registration/endpoint/apiReg014.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg014.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { zSemester } from "@clubs/domain/semester/semester";
 
-import { zClubName } from "@clubs/interface/common/commonString";
+import { zClubName, zUserName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
   RegistrationTypeEnum,
@@ -44,7 +44,7 @@ const responseBodyMap = {
         representativeName: z.string(),
         activityFieldKr: z.string().max(255),
         activityFieldEn: z.string().max(255),
-        professorName: z.string().optional(),
+        professorName: zUserName.optional(),
       }),
     ),
     total: z.coerce.number().int().min(1),

--- a/packages/interface/src/api/registration/endpoint/apiReg024.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg024.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
-import { zClubName } from "@clubs/interface/common/commonString";
+import { zClubName, zUserName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
   RegistrationTypeEnum,
@@ -39,7 +39,7 @@ const responseBodyMap = {
         representativeName: z.string(),
         activityFieldKr: z.string().max(255),
         activityFieldEn: z.string().max(255),
-        professorName: z.string().optional(),
+        professorName: zUserName.optional(),
       }),
     ),
     total: z.coerce.number().int().min(1),

--- a/packages/interface/src/api/user/type/user.type.ts
+++ b/packages/interface/src/api/user/type/user.type.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import { zSemester } from "@clubs/domain/semester/semester";
 
+import { zUserName } from "@clubs/interface/common/commonString";
 import {
   ProfessorEnum,
   StudentStatusEnum,
@@ -83,7 +84,7 @@ export const zStudentSummary = zStudent.pick({
 export const zProfessor = z.object({
   id: z.coerce.number(),
   userId: z.coerce.number().nullable(),
-  name: z.string(),
+  name: zUserName,
   email: z.string(),
   phoneNumber: z.string().optional(),
   professorEnum: z.nativeEnum(ProfessorEnum),

--- a/packages/interface/src/common/commonString.ts
+++ b/packages/interface/src/common/commonString.ts
@@ -1,5 +1,9 @@
 import z from "zod";
 
 export const zClubName = z.string().max(128);
+export const zClubNameKr = z.string().max(30);
+export const zClubNameEn = z.string().max(100);
+export const zClubCharacteristic = z.string().max(255);
+export const zClubRoom = z.string().max(51);
 export const zUserName = z.string().max(255);
 export const zFileName = z.string().max(256);


### PR DESCRIPTION
## Summary
- 실제 DB 길이에 맞춰 동아리 상세 응답의 지도교수, 대표자, 성격, 동아리방 schema 제한을 조정
- 활동보고서 대시보드 응답의 영문 동아리명과 담당자 이름 schema 제한을 조정
- 등록 신청/총람 등 지도교수 이름을 쓰는 공용 및 관련 API schema를 255자 기준으로 정리

## Task Context
- Task ID: TU-425
- Notion: https://www.notion.so/363c25603b0b8100ba39fd894dbce6ff

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 동아리 상세와 활동보고서 화면에서 실제 저장 가능한 길이의 이름이나 성격 값 때문에 조회 오류가 발생하던 문제를 수정했습니다.
<!-- clubs:patch-note:end -->