### PR TITLE
[TU-426] gb 크레딧 변경

### DIFF
--- a/packages/web/src/features/credits/credits.ts
+++ b/packages/web/src/features/credits/credits.ts
@@ -26,9 +26,9 @@ const credits: SemesterCredit[] = [
       {
         nickname: "gb",
         name: "권혁원",
-        role: "BE",
-        roleType: RoleType.member,
-        comment: "AI와 함께하는 클럽스",
+        role: "PM",
+        roleType: RoleType.PM,
+        comment: "Project Maintainer",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- gb 크레딧의 직책을 PM으로 변경했습니다.
- gb 크레딧의 설명 문구를 Project Maintainer로 변경했습니다.

## Task Context
- Task ID: TU-426
- Notion: https://www.notion.so/363c25603b0b81138490ff2a081b5643

## Patch Note

<!-- clubs:patch-note:start -->
category: design
text: 만든 사람들 페이지에서 gb의 크레딧 표기를 업데이트했습니다.
<!-- clubs:patch-note:end -->

