### PR TITLE
[TU-427] DX 워크플로우 개선 - 코덱스 스킬, 패치노트 생성

### DIFF
--- a/.claude/skills/clubs-task-cleanup/SKILL.md
+++ b/.claude/skills/clubs-task-cleanup/SKILL.md
@@ -1,11 +1,8 @@
 ---
-name: delete-worktree
-description: Delete a completed ar-002-clubs worktree when the user wants to reclaim disk space. Use it to remove a sibling worktree under ../clubs-worktrees, delete its local branch, and clean up any leftover directory. Never use it for the current worktree or the primary repository checkout.
-metadata:
-  short-description: Delete a completed worktree and local branch
+description: "Clean up a completed Clubs task worktree for this ar-002-clubs repo. Use this when the user says 워크트리 종료, 워크트리 정리, 워크트리 삭제, 태스크 종료, TU 종료, 작업 종료, 작업 정리, or asks to clean up/delete/close a worktree, task, TU, or work item. Remove the sibling worktree under ../clubs-worktrees, delete its local branch, and clean up leftover directories. Never use it for the current worktree or primary checkout."
 ---
 
-# Delete Worktree
+# Clubs Task Cleanup
 
 Delete a completed worktree and its local branch to free local disk space.
 
@@ -14,6 +11,8 @@ Delete a completed worktree and its local branch to free local disk space.
 Use this skill when:
 
 - the user says a task is complete and wants the worktree removed
+- the user says 워크트리 종료, 워크트리 정리, or 워크트리 삭제
+- the user says 태스크 종료, TU 종료, or 작업 종료
 - the user asks to remove a TU worktree under `../clubs-worktrees`
 - the user wants the local branch deleted after the worktree is no longer needed
 
@@ -22,6 +21,15 @@ Do not use this skill to remove:
 - the current worktree you are actively editing in
 - the primary repository checkout
 - a worktree with uncommitted changes unless the user explicitly wants a forced delete
+
+## Trigger aliases
+
+Treat these natural-language aliases as this skill:
+
+- 워크트리 종료 / 워크트리 정리 / 워크트리 삭제
+- 태스크 종료 / 태스크 정리 / 태스크 삭제
+- TU 종료 / TU 정리 / TU 삭제
+- 작업 종료 / 작업 정리 / 작업 삭제 / 작업 마무리
 
 ## Inputs
 
@@ -49,18 +57,18 @@ Before deleting:
 
 Use the helper command:
 
-`pnpm delete-worktree -- --branch TU-408`
+`pnpm clubs-task-cleanup -- --branch TU-408`
 
 Optional modes:
 
 - Path-based:
-  - `pnpm delete-worktree -- --worktree-path /Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
+  - `pnpm clubs-task-cleanup -- --worktree-path /Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
 - Forced delete:
-  - `pnpm delete-worktree -- --branch TU-408 --force`
+  - `pnpm clubs-task-cleanup -- --branch TU-408 --force`
 - Preview only:
-  - `pnpm delete-worktree -- --branch TU-408 --dry-run`
+  - `pnpm clubs-task-cleanup -- --branch TU-408 --dry-run`
 - No explicit target:
-  - `pnpm delete-worktree`
+  - `pnpm clubs-task-cleanup`
   - ask whether the current worktree should be deleted before doing anything
 
 ## Expected behavior

--- a/.claude/skills/clubs-task-cleanup/SKILL.md
+++ b/.claude/skills/clubs-task-cleanup/SKILL.md
@@ -39,7 +39,7 @@ Prefer one of these:
 - worktree path, for example `/Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
 
 If the user gives only a TU number, convert it to `TU-<number>`.
-If the user gives no target, the helper should ask whether the current worktree should be deleted.
+If the user gives no target, `pnpm clubs-task-cleanup` must abort and ask for an explicit non-current worktree target.
 
 ## Safety rules
 
@@ -69,7 +69,7 @@ Optional modes:
   - `pnpm clubs-task-cleanup -- --branch TU-408 --dry-run`
 - No explicit target:
   - `pnpm clubs-task-cleanup`
-  - ask whether the current worktree should be deleted before doing anything
+  - abort and require `--branch` or `--worktree-path` for a non-current worktree
 
 ## Expected behavior
 

--- a/.claude/skills/clubs-task-start/SKILL.md
+++ b/.claude/skills/clubs-task-start/SKILL.md
@@ -1,11 +1,8 @@
 ---
-name: create-worktree
-description: Create a ready-to-run worktree for this ar-002-clubs repo when the user gives a TU task, Notion spec link, or GitHub PR link. Use it to inspect task context first, choose the correct branch, create the worktree under ../clubs-worktrees, copy required ignored files from the main repo, and run the bootstrap commands in order.
-metadata:
-  short-description: Create and bootstrap a worktree for this repo
+description: "Start a ready-to-run Clubs task worktree for this ar-002-clubs repo. Use this when the user says 워크트리 시작, 워크트리 파, 워크트리 만들어, 태스크 시작, TU 시작, 작업 시작, or asks to start/create/open a worktree, task, TU, or work item. Read the task source first, confirm the TU number and scope, choose the correct branch, create the worktree under ../clubs-worktrees, copy ignored files, and run bootstrap commands."
 ---
 
-# Create Worktree
+# Clubs Task Start
 
 Create an isolated, runnable worktree for this repo before starting a new task.
 
@@ -14,6 +11,8 @@ Create an isolated, runnable worktree for this repo before starting a new task.
 Use this skill when:
 
 - the user asks to start work on a new TU task
+- the user says 워크트리 시작, 워크트리 파, or 워크트리 만들어
+- the user says 태스크 시작, TU 시작, or 작업 시작
 - the user gives a Notion task/spec page and wants implementation to happen in a fresh worktree
 - the user gives only a new task summary and the task page must be created before the worktree
 - the user gives a GitHub PR link and wants that existing branch pulled into a separate worktree
@@ -21,13 +20,22 @@ Use this skill when:
 
 Do not use this skill if the user explicitly wants work to happen in the current worktree.
 
+## Trigger aliases
+
+Treat these natural-language aliases as this skill:
+
+- 워크트리 시작 / 워크트리 파 / 워크트리 만들어
+- 태스크 시작 / 태스크 파 / 태스크 만들어
+- TU 시작 / TU 파 / TU 작업 시작
+- 작업 시작 / 작업 파 / 작업 만들어
+
 ## Task source first
 
 Always inspect the task source before creating the worktree.
 
 ### If the user gives a Notion page
 
-1. Use the Notion plugin to fetch the page if available.
+1. Use the available Notion integration or fetched page content if present.
 2. Extract:
    - TU number
    - requested work
@@ -59,8 +67,8 @@ Always inspect the task source before creating the worktree.
 
 - Existing PR: reuse the PR head branch exactly.
 - Fresh task with a TU number: use `TU-<number>`.
+- If only the numeric TU id is passed to the helper, it normalizes `405` to `TU-405`.
 - If the task source does not contain a TU number and no PR branch exists, create a Notion task page first when tools are available. Ask the user for the TU number only when the task page cannot be created.
-- Fresh branch creation should sync `dev` first by running a `git pull origin dev` from the primary repo worktree.
 
 ## Worktree location rules
 
@@ -107,7 +115,7 @@ Only do these when the task needs the app or DB to run:
 
 Use the helper command:
 
-`pnpm create-worktree -- --branch <branch> [--start-point <ref>] [--reuse-remote-branch]`
+`pnpm clubs-task-start -- --branch <branch> [--start-point <ref>] [--reuse-remote-branch]`
 
 ### Use these modes
 
@@ -120,12 +128,7 @@ Use `--dry-run` first when:
 
 - the branch name came from a long PR head ref
 - the repo state looks unusual
-- you want to show the user the exact operations before doing them
-
-When a fresh branch must be created, the helper should:
-
-1. sync the primary repo worktree to the latest `dev`
-2. only then create the new worktree branch from `origin/dev`
+- you want to show the exact operations before doing them
 
 ## Validation after setup
 

--- a/.claude/skills/create-branch-pr/SKILL.md
+++ b/.claude/skills/create-branch-pr/SKILL.md
@@ -75,8 +75,21 @@ Always resolve these into a confirmed TU number before you create the branch or 
 
 ### PR title naming
 
-- Default format: `[TU-405] short task title`
+- Required format: `[TU-405] one-line task summary`
+- The TU number must be wrapped in square brackets.
+- The text after the TU number should be a concise first-pass summary of the work.
+- Do not use a generic title like `chore`, `fix`, or `update`.
 - Reuse the existing PR title if the PR already exists
+
+### Squash merge title guard
+
+GitHub uses the single commit title as the default squash title when a PR has only one commit. To make the squash title follow the PR title by default:
+
+- Before creating a PR, compare the head branch against the base branch.
+- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit with the formatted PR title as the commit message.
+- Only do this on the current branch and only when the worktree is clean.
+- Use `HUSKY=0 git commit --allow-empty -m "[TU-405] one-line task summary"` so local commit hooks do not reject the bracketed PR title format.
+- Do not add an empty commit if the branch already has 2 or more commits relative to the base.
 
 ### PR base branch
 
@@ -129,6 +142,8 @@ Examples:
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 
+During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds the squash-title empty commit automatically when the branch has fewer than 2 commits relative to the base.
+
 ## Validation
 
 After branch creation:
@@ -141,10 +156,11 @@ After PR creation:
 1. Run `gh pr view --json number,title,headRefName,baseRefName,url,body`
 2. Confirm:
    - base is `dev`
-   - title includes the TU number
+   - title follows `[TU-405] one-line task summary`
    - Notion URL is present in the body
    - `## Patch Note` and the `clubs:patch-note` block are present
    - non-`none` categories have user-facing Korean `text`
+   - if the branch had fewer than 2 commits before PR creation, one empty commit with the PR title was added
 
 ## Response expectations
 

--- a/.claude/skills/create-branch-pr/SKILL.md
+++ b/.claude/skills/create-branch-pr/SKILL.md
@@ -86,9 +86,9 @@ Always resolve these into a confirmed TU number before you create the branch or 
 GitHub uses the single commit title as the default squash title when a PR has only one commit. To make the squash title follow the PR title by default:
 
 - Before creating a PR, compare the head branch against the base branch.
-- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit with the formatted PR title as the commit message.
+- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit so GitHub's squash dialog defaults to the PR title.
 - Only do this on the current branch and only when the worktree is clean.
-- Use `HUSKY=0 git commit --allow-empty -m "[TU-405] one-line task summary"` so local commit hooks do not reject the bracketed PR title format.
+- Use `HUSKY=0 git commit --allow-empty -m "chore: empty for squash merge"` so the empty commit itself follows the repo's conventional commit rules.
 - Do not add an empty commit if the branch already has 2 or more commits relative to the base.
 
 ### PR base branch
@@ -142,7 +142,7 @@ Examples:
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 
-During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds the squash-title empty commit automatically when the branch has fewer than 2 commits relative to the base.
+During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds a `chore: empty for squash merge` empty commit automatically when the branch has fewer than 2 commits relative to the base.
 
 ## Validation
 
@@ -160,7 +160,7 @@ After PR creation:
    - Notion URL is present in the body
    - `## Patch Note` and the `clubs:patch-note` block are present
    - non-`none` categories have user-facing Korean `text`
-   - if the branch had fewer than 2 commits before PR creation, one empty commit with the PR title was added
+   - if the branch had fewer than 2 commits before PR creation, one `chore: empty for squash merge` empty commit was added
 
 ## Response expectations
 

--- a/.claude/skills/create-branch-pr/SKILL.md
+++ b/.claude/skills/create-branch-pr/SKILL.md
@@ -121,11 +121,11 @@ Examples:
 Examples:
 
 - Auto body:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 - With explicit summary bullets:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --summary "add a shared Node helper" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --summary "add a shared Node helper" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 - Existing task number without page URL:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 

--- a/.github/workflows/prepare-release-patch-note.yml
+++ b/.github/workflows/prepare-release-patch-note.yml
@@ -76,14 +76,15 @@ jobs:
           --head HEAD
           --bump ${{ steps.bump.outputs.bump }}
           --file packages/web/src/constants/patchNote.ts
+          --app-package-file packages/web/package.json
+          --app-info-file packages/web/src/constants/appVersion.mjs
 
       - name: Format generated patch note
-        if: ${{ hashFiles('packages/web/src/constants/patchNote.ts') != '' }}
-        run: pnpm exec prettier --write packages/web/src/constants/patchNote.ts
+        run: pnpm exec prettier --write packages/web/package.json packages/web/src/constants/appVersion.mjs packages/web/src/constants/patchNote.ts
 
       - name: Validate generated files
         run: |
-          unexpected="$(git diff --name-only | grep -Ev '^packages/web/src/constants/patchNote\.ts$' || true)"
+          unexpected="$(git diff --name-only | grep -Ev '^(packages/web/package\.json|packages/web/src/constants/appVersion\.mjs|packages/web/src/constants/patchNote\.ts)$' || true)"
           if [ -n "${unexpected}" ]; then
             echo "Unexpected generated files:"
             echo "${unexpected}"
@@ -94,8 +95,10 @@ jobs:
         id: commit
         env:
           RELEASE_PR_NUMBER: ${{ github.event.pull_request.number || github.run_id }}
+          RELEASE_VERSION: ${{ steps.generate.outputs.version }}
+          RELEASE_DISPLAY_VERSION: ${{ steps.generate.outputs.display_version }}
         run: |
-          if git diff --quiet -- packages/web/src/constants/patchNote.ts; then
+          if git diff --quiet -- packages/web/package.json packages/web/src/constants/appVersion.mjs packages/web/src/constants/patchNote.ts; then
             echo "No patch note changes to commit."
             echo "created=false" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -105,8 +108,17 @@ jobs:
           git switch -c "${branch}"
           git config user.name "clubs-release-bot"
           git config user.email "clubs-release-bot@users.noreply.github.com"
-          git add packages/web/src/constants/patchNote.ts
-          HUSKY=0 git commit -m "chore: update release patch note"
+
+          if ! git diff --quiet -- packages/web/package.json packages/web/src/constants/appVersion.mjs; then
+            git add packages/web/package.json packages/web/src/constants/appVersion.mjs
+            HUSKY=0 git commit -m "chore(web): bump clubs version to ${RELEASE_VERSION}"
+          fi
+
+          if ! git diff --quiet -- packages/web/src/constants/patchNote.ts; then
+            git add packages/web/src/constants/patchNote.ts
+            HUSKY=0 git commit -m "docs(web): update release patch note for ${RELEASE_DISPLAY_VERSION}"
+          fi
+
           git push --force origin "HEAD:${branch}"
 
           echo "created=true" >> "${GITHUB_OUTPUT}"
@@ -120,11 +132,12 @@ jobs:
           PATCH_NOTE_BRANCH: ${{ steps.commit.outputs.branch }}
           RELEASE_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           RELEASE_TYPE: ${{ steps.bump.outputs.label }}
-          RELEASE_VERSION: ${{ steps.generate.outputs.display_version }}
+          RELEASE_VERSION: ${{ steps.generate.outputs.version }}
+          RELEASE_DISPLAY_VERSION: ${{ steps.generate.outputs.display_version }}
         run: |
-          title="PATCH NOTE"
-          if [ -n "${RELEASE_VERSION}" ]; then
-            title="PATCH NOTE - ${RELEASE_VERSION}"
+          title="docs(web): update release patch note"
+          if [ -n "${RELEASE_DISPLAY_VERSION}" ]; then
+            title="docs(web): update release patch note for ${RELEASE_DISPLAY_VERSION}"
           fi
 
           release_ref="manual workflow run"
@@ -138,8 +151,8 @@ jobs:
           이 PR은 ${release_ref}에서 생성된 패치노트 커밋입니다.
 
           - Release type: [${RELEASE_TYPE}]
-          - Release version: ${RELEASE_VERSION}
-          - Generated file: \`packages/web/src/constants/patchNote.ts\`
+          - Release version: ${RELEASE_DISPLAY_VERSION}
+          - Generated files: \`packages/web/package.json\`, \`packages/web/src/constants/appVersion.mjs\`, \`packages/web/src/constants/patchNote.ts\`
 
           이 PR을 \`dev\`에 머지하면 열려 있는 \`dev -> main\` release PR에 패치노트가 포함됩니다.
 
@@ -148,8 +161,8 @@ jobs:
           This PR contains the generated patch note commit for ${release_ref}.
 
           - Release type: [${RELEASE_TYPE}]
-          - Release version: ${RELEASE_VERSION}
-          - Generated file: \`packages/web/src/constants/patchNote.ts\`
+          - Release version: ${RELEASE_DISPLAY_VERSION}
+          - Generated files: \`packages/web/package.json\`, \`packages/web/src/constants/appVersion.mjs\`, \`packages/web/src/constants/patchNote.ts\`
 
           Merge this PR into \`dev\` to include the patch note in the open \`dev -> main\` release PR.
           BODY
@@ -167,11 +180,11 @@ jobs:
           echo "::notice::Patch note PR: ${url}"
 
       - name: Update release PR title
-        if: github.event_name == 'pull_request' && steps.generate.outputs.display_version != ''
+        if: github.event_name == 'pull_request' && steps.generate.outputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TYPE: ${{ steps.bump.outputs.label }}
-          RELEASE_VERSION: ${{ steps.generate.outputs.display_version }}
+          RELEASE_VERSION: ${{ steps.generate.outputs.version }}
         run: |
           gh pr edit "${{ github.event.pull_request.number }}" \
             --repo "${GITHUB_REPOSITORY}" \

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "repository": "",
   "license": "MIT",
   "scripts": {
+    "clubs-task-start": "node plugins/worktree-tools/skills/clubs-task-start/scripts/create_worktree.mjs",
+    "clubs-task-cleanup": "node plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs",
     "create-branch-pr": "node plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs",
-    "create-worktree": "node plugins/worktree-tools/skills/create-worktree/scripts/create_worktree.mjs",
     "prepare-patch-note": "node scripts/release/prepare-patch-note.mjs",
-    "delete-worktree": "node plugins/worktree-tools/skills/delete-worktree/scripts/delete_worktree.mjs",
     "dev": "turbo run dev:setup && turbo watch dev",
     "dev:api": "turbo run dev:setup && turbo watch dev --filter=api",
     "dev:setup": "node -e \"\"",

--- a/packages/api/test/integration/clubs-version.spec.ts
+++ b/packages/api/test/integration/clubs-version.spec.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type ParsedVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  raw: string;
+};
+
+const repoRoot = resolve(process.cwd(), "../..");
+
+const readRepoFile = (path: string) =>
+  readFileSync(resolve(repoRoot, path), "utf8");
+
+const parseVersion = (raw: string): ParsedVersion => {
+  const match = raw.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${raw}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    raw,
+  };
+};
+
+const compareVersion = (a: ParsedVersion, b: ParsedVersion) =>
+  a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+
+const readPackageVersion = () => {
+  const packageJson = JSON.parse(readRepoFile("packages/web/package.json")) as {
+    version?: string;
+  };
+  if (!packageJson.version) {
+    throw new Error("packages/web/package.json does not have a version.");
+  }
+  return packageJson.version;
+};
+
+const readAppInfoVersion = () => {
+  const source = readRepoFile("packages/web/src/constants/appVersion.mjs");
+  const match = source.match(/export const CLUBS_VERSION = "([^"]+)";/);
+  if (!match) {
+    throw new Error(
+      "packages/web/src/constants/appVersion.mjs does not export CLUBS_VERSION.",
+    );
+  }
+  return match[1];
+};
+
+const readLatestPatchNoteVersion = () => {
+  const source = readRepoFile("packages/web/src/constants/patchNote.ts");
+  const versions = [...source.matchAll(/version:\s*"v\.(\d+\.\d+\.\d+)"/g)]
+    .map(match => parseVersion(match[1]))
+    .sort(compareVersion);
+
+  const latest = versions.at(-1);
+  if (!latest) {
+    throw new Error("patchNote.ts does not contain any patch note versions.");
+  }
+
+  return latest.raw;
+};
+
+describe("Clubs version metadata", () => {
+  it("keeps appInfo, package.json, and the latest patch note version in sync", () => {
+    const packageVersion = readPackageVersion();
+    const appInfoVersion = readAppInfoVersion();
+    const latestPatchNoteVersion = readLatestPatchNoteVersion();
+
+    const message = [
+      "Clubs version mismatch:",
+      `- packages/web/package.json: ${packageVersion}`,
+      `- packages/web/src/constants/appVersion.mjs: ${appInfoVersion}`,
+      `- packages/web/src/constants/patchNote.ts: ${latestPatchNoteVersion}`,
+    ].join("\n");
+
+    if (
+      packageVersion !== appInfoVersion ||
+      latestPatchNoteVersion !== appInfoVersion
+    ) {
+      throw new Error(message);
+    }
+
+    expect(packageVersion).toBe(appInfoVersion);
+    expect(latestPatchNoteVersion).toBe(appInfoVersion);
+  });
+
+  it("derives the display version from CLUBS_VERSION", () => {
+    const source = readRepoFile("packages/web/src/constants/appVersion.mjs");
+
+    expect(source).toMatch(
+      /export const CLUBS_DISPLAY_VERSION = `v\$\{CLUBS_VERSION\}`;/,
+    );
+  });
+});

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -1,5 +1,7 @@
 import createNextIntlPlugin from "next-intl/plugin";
 
+import { CLUBS_VERSION } from "./src/constants/appVersion.mjs";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   compiler: {
@@ -19,6 +21,10 @@ const nextConfig = {
           {
             key: "x-nextjs-version",
             value: "15.5.18",
+          },
+          {
+            key: "x-clubs-version",
+            value: CLUBS_VERSION,
           },
         ],
       },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "dotenv -e ../../.env next dev",

--- a/packages/web/src/common/components/DebugBadge/index.tsx
+++ b/packages/web/src/common/components/DebugBadge/index.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import styled from "styled-components";
 
+import { CLUBS_APP } from "@sparcs-clubs/web/constants/appInfo";
+
 const Container = styled.div`
   pointer-events: none;
   position: absolute;
@@ -85,7 +87,7 @@ const DebugBadge: React.FC = () => {
       {environment && (
         <>
           <Badge>
-            {`${environment} ${MOCK_STATUS}`}
+            {`${CLUBS_APP.displayVersion} ${environment} ${MOCK_STATUS}`}
             <br />
             {process.env.NEXT_PUBLIC_BUILD_TIME || date}
           </Badge>

--- a/packages/web/src/constants/appInfo.ts
+++ b/packages/web/src/constants/appInfo.ts
@@ -1,0 +1,7 @@
+import { CLUBS_DISPLAY_VERSION, CLUBS_VERSION } from "./appVersion.mjs";
+
+export const CLUBS_APP = {
+  name: "Clubs",
+  version: CLUBS_VERSION,
+  displayVersion: CLUBS_DISPLAY_VERSION,
+} as const;

--- a/packages/web/src/constants/appVersion.mjs
+++ b/packages/web/src/constants/appVersion.mjs
@@ -1,0 +1,2 @@
+export const CLUBS_VERSION = "0.1.2";
+export const CLUBS_DISPLAY_VERSION = `v${CLUBS_VERSION}`;

--- a/packages/web/src/lib/axios.ts
+++ b/packages/web/src/lib/axios.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError } from "axios";
 import MockAdapter from "axios-mock-adapter";
 import qs from "qs";
 
+import { CLUBS_APP } from "@sparcs-clubs/web/constants/appInfo";
 import { env } from "@sparcs-clubs/web/env";
 
 import tokenInterceptor from "./_axios/axiosAuthTokenInterceptor";
@@ -76,6 +77,7 @@ export const axiosClient = axios.create({
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",
+    "x-clubs-client-version": CLUBS_APP.version,
   },
   transformRequest: [data => JSON.stringify(serializeDates(data))],
   transformResponse: [data => parseDates(data)],
@@ -113,6 +115,7 @@ export const axiosClientWithAuth = axios.create({
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",
+    "x-clubs-client-version": CLUBS_APP.version,
   },
   transformRequest: [data => JSON.stringify(serializeDates(data))],
   transformResponse: [data => parseDates(data)],

--- a/plugins/worktree-tools/.codex-plugin/plugin.json
+++ b/plugins/worktree-tools/.codex-plugin/plugin.json
@@ -1,32 +1,23 @@
 {
   "name": "worktree-tools",
   "version": "0.1.0",
-  "description": "Project-local workflows for creating and deleting ready-to-run worktrees and standardizing TU branch/PR creation for ar-002-clubs tasks.",
+  "description": "Project-local workflows for starting and cleaning up ready-to-run Clubs task worktrees and standardizing TU branch/PR creation for ar-002-clubs tasks.",
   "author": {
     "name": "SPARCS Clubs",
     "url": "https://github.com/sparcs-kaist/clubs"
   },
   "repository": "https://github.com/sparcs-kaist/clubs",
   "license": "MIT",
-  "keywords": [
-    "git",
-    "worktree",
-    "bootstrap",
-    "dx",
-    "codex"
-  ],
+  "keywords": ["git", "worktree", "bootstrap", "dx", "codex"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Worktree Tools",
-    "shortDescription": "Create and delete worktrees and standardize TU branch and PR setup",
-    "longDescription": "Project-local workflow helpers for ar-002-clubs. Reads Notion or PR task context, creates sibling worktrees under ../clubs-worktrees, copies required ignored files, bootstraps the repo, deletes completed worktrees, and standardizes TU-based branch and PR creation.",
+    "shortDescription": "Start and clean up Clubs task worktrees and standardize TU branch and PR setup",
+    "longDescription": "Project-local workflow helpers for ar-002-clubs. Reads Notion or PR task context, starts sibling worktrees under ../clubs-worktrees, copies required ignored files, bootstraps the repo, cleans up completed worktrees, and standardizes TU-based branch and PR creation.",
     "developerName": "SPARCS Clubs",
     "category": "Coding",
-    "capabilities": [
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Read", "Write"],
     "websiteURL": "https://github.com/sparcs-kaist/clubs",
-    "defaultPrompt": "Create or delete a repo worktree, or standardize branch and PR setup from a TU task, Notion spec, or PR link"
+    "defaultPrompt": "Use clubs-task-start or clubs-task-cleanup for worktree, task, TU, or 작업 start/cleanup requests, or standardize branch and PR setup from a TU task, Notion spec, or PR link"
   }
 }

--- a/plugins/worktree-tools/agents/openai.yaml
+++ b/plugins/worktree-tools/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Worktree Tools"
-  short_description: "Create and delete worktrees and standardize TU branch and PR setup"
-  default_prompt: "Create or delete a repo worktree, or standardize branch and PR setup from a TU task, Notion spec, or PR link, including the required PR patch-note block."
+  short_description: "Start and clean up Clubs task worktrees and standardize TU branch and PR setup"
+  default_prompt: "Use clubs-task-start or clubs-task-cleanup for worktree, task, TU, or 작업 start/cleanup requests, or standardize branch and PR setup from a TU task, Notion spec, or PR link, including the required PR patch-note block."

--- a/plugins/worktree-tools/skills/clubs-task-cleanup/SKILL.md
+++ b/plugins/worktree-tools/skills/clubs-task-cleanup/SKILL.md
@@ -42,7 +42,7 @@ Prefer one of these:
 - worktree path, for example `/Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
 
 If the user gives only a TU number, convert it to `TU-<number>`.
-If the user gives no target, the helper should ask whether the current worktree should be deleted.
+If the user gives no target, `pnpm clubs-task-cleanup` must abort and ask for an explicit non-current worktree target.
 
 ## Safety rules
 
@@ -72,7 +72,7 @@ Optional modes:
   - `pnpm clubs-task-cleanup -- --branch TU-408 --dry-run`
 - No explicit target:
   - `pnpm clubs-task-cleanup`
-  - ask whether the current worktree should be deleted before doing anything
+  - abort and require `--branch` or `--worktree-path` for a non-current worktree
 
 ## Expected behavior
 

--- a/plugins/worktree-tools/skills/clubs-task-cleanup/SKILL.md
+++ b/plugins/worktree-tools/skills/clubs-task-cleanup/SKILL.md
@@ -1,8 +1,11 @@
 ---
-description: Delete a completed ar-002-clubs worktree when the user wants to reclaim disk space. Use it to remove a sibling worktree under ../clubs-worktrees, delete its local branch, and clean up any leftover directory. Never use it for the current worktree or the primary repository checkout.
+name: clubs-task-cleanup
+description: "Clean up a completed Clubs task worktree for this ar-002-clubs repo. Use this when the user says 워크트리 종료, 워크트리 정리, 워크트리 삭제, 태스크 종료, TU 종료, 작업 종료, 작업 정리, or asks to clean up/delete/close a worktree, task, TU, or work item. It removes the sibling worktree under ../clubs-worktrees, deletes the local branch, and cleans leftover directories."
+metadata:
+  short-description: Clean up a completed Clubs task worktree and local branch
 ---
 
-# Delete Worktree
+# Clubs Task Cleanup
 
 Delete a completed worktree and its local branch to free local disk space.
 
@@ -11,6 +14,8 @@ Delete a completed worktree and its local branch to free local disk space.
 Use this skill when:
 
 - the user says a task is complete and wants the worktree removed
+- the user says 워크트리 종료, 워크트리 정리, or 워크트리 삭제
+- the user says 태스크 종료, TU 종료, or 작업 종료
 - the user asks to remove a TU worktree under `../clubs-worktrees`
 - the user wants the local branch deleted after the worktree is no longer needed
 
@@ -19,6 +24,15 @@ Do not use this skill to remove:
 - the current worktree you are actively editing in
 - the primary repository checkout
 - a worktree with uncommitted changes unless the user explicitly wants a forced delete
+
+## Trigger aliases
+
+Treat these natural-language aliases as this skill:
+
+- 워크트리 종료 / 워크트리 정리 / 워크트리 삭제
+- 태스크 종료 / 태스크 정리 / 태스크 삭제
+- TU 종료 / TU 정리 / TU 삭제
+- 작업 종료 / 작업 정리 / 작업 삭제 / 작업 마무리
 
 ## Inputs
 
@@ -46,18 +60,18 @@ Before deleting:
 
 Use the helper command:
 
-`pnpm delete-worktree -- --branch TU-408`
+`pnpm clubs-task-cleanup -- --branch TU-408`
 
 Optional modes:
 
 - Path-based:
-  - `pnpm delete-worktree -- --worktree-path /Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
+  - `pnpm clubs-task-cleanup -- --worktree-path /Users/kwonhyukwon/developer/clubs-worktrees/TU-408`
 - Forced delete:
-  - `pnpm delete-worktree -- --branch TU-408 --force`
+  - `pnpm clubs-task-cleanup -- --branch TU-408 --force`
 - Preview only:
-  - `pnpm delete-worktree -- --branch TU-408 --dry-run`
+  - `pnpm clubs-task-cleanup -- --branch TU-408 --dry-run`
 - No explicit target:
-  - `pnpm delete-worktree`
+  - `pnpm clubs-task-cleanup`
   - ask whether the current worktree should be deleted before doing anything
 
 ## Expected behavior

--- a/plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs
+++ b/plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs
@@ -3,8 +3,6 @@
 import { existsSync, rmSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
-import readline from "node:readline/promises";
-import { stdin as input, stdout as output } from "node:process";
 
 function parseArgs(argv) {
   const options = {
@@ -117,24 +115,6 @@ function currentBranch(repoRoot) {
   return runGit(["branch", "--show-current"], repoRoot);
 }
 
-async function confirmDeleteCurrentWorktree(currentRoot) {
-  if (!input.isTTY) {
-    throw new Error(
-      `No target was provided. Re-run with --branch/--worktree-path, or run interactively to confirm deleting the current worktree: ${currentRoot}`,
-    );
-  }
-
-  const rl = readline.createInterface({ input, output });
-  try {
-    const answer = await rl.question(
-      `No worktree target was provided. Delete the current worktree at ${currentRoot}? [y/N] `,
-    );
-    return /^y(es)?$/i.test(answer.trim());
-  } finally {
-    rl.close();
-  }
-}
-
 function runGitCommand(args, cwd, dryRun, { allowFailure = false } = {}) {
   console.log(`$ git ${args.join(" ")}`);
   if (dryRun) return { ok: true, skipped: true };
@@ -166,13 +146,9 @@ async function main() {
   const currentBranchName = currentBranch(repoRoot);
 
   if (!targetBranch && !targetPath) {
-    const confirmed = await confirmDeleteCurrentWorktree(currentRoot);
-    if (!confirmed) {
-      console.log("Cancelled.");
-      return;
-    }
-    targetPath = resolve(currentRoot);
-    targetBranch = currentBranchName;
+    throw new Error(
+      "No worktree target was provided. Re-run with --branch or --worktree-path for a non-current worktree.",
+    );
   }
 
   const matched = worktrees.find(entry => {

--- a/plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs
+++ b/plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs
@@ -49,7 +49,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Usage: pnpm delete-worktree -- [options]
+  console.log(`Usage: pnpm clubs-task-cleanup -- [options]
 
 Options:
   --branch <name>             Branch name for the worktree to delete
@@ -183,8 +183,10 @@ async function main() {
 
   const resolvedPath = matched
     ? resolve(matched.worktree)
-    : targetPath || resolve(worktreesRoot, (targetBranch || "").replaceAll("/", "-"));
-  const resolvedBranch = matched?.branch || targetBranch || basename(resolvedPath);
+    : targetPath ||
+      resolve(worktreesRoot, (targetBranch || "").replaceAll("/", "-"));
+  const resolvedBranch =
+    matched?.branch || targetBranch || basename(resolvedPath);
 
   if (resolvedPath === resolve(currentRoot)) {
     throw new Error("Refusing to delete the current worktree");
@@ -195,13 +197,17 @@ async function main() {
   }
 
   if (resolvedBranch && resolvedBranch === currentBranchName) {
-    throw new Error("Refusing to delete the branch checked out in the current worktree");
+    throw new Error(
+      "Refusing to delete the branch checked out in the current worktree",
+    );
   }
 
   if (matched && existsSync(resolvedPath)) {
     const status = runGit(["status", "--short"], resolvedPath);
     if (status && !options.force) {
-      throw new Error("Target worktree has uncommitted changes. Re-run with --force if you really want to delete it.");
+      throw new Error(
+        "Target worktree has uncommitted changes. Re-run with --force if you really want to delete it.",
+      );
     }
   }
 
@@ -220,7 +226,9 @@ async function main() {
       removedWorktree = true;
     } else {
       const remaining = parseWorktreeList(repoRoot).some(
-        entry => resolve(entry.worktree) === resolvedPath || entry.branch === resolvedBranch,
+        entry =>
+          resolve(entry.worktree) === resolvedPath ||
+          entry.branch === resolvedBranch,
       );
       removedWorktree = removeResult.ok || !remaining;
       if (!removedWorktree) {
@@ -239,13 +247,25 @@ async function main() {
 
   let removedBranch = false;
   if (resolvedBranch) {
-    const deleteResult = runGitCommand(["branch", "-D", resolvedBranch], repoRoot, options.dryRun, {
-      allowFailure: true,
-    });
-    removedBranch = options.dryRun || deleteResult.ok || !localBranchExists(repoRoot, resolvedBranch);
+    const deleteResult = runGitCommand(
+      ["branch", "-D", resolvedBranch],
+      repoRoot,
+      options.dryRun,
+      {
+        allowFailure: true,
+      },
+    );
+    removedBranch =
+      options.dryRun ||
+      deleteResult.ok ||
+      !localBranchExists(repoRoot, resolvedBranch);
   }
 
-  if (!matched && !existsSync(resolvedPath) && !localBranchExists(repoRoot, resolvedBranch)) {
+  if (
+    !matched &&
+    !existsSync(resolvedPath) &&
+    !localBranchExists(repoRoot, resolvedBranch)
+  ) {
     console.log(`Worktree already absent: ${resolvedPath}`);
     if (resolvedBranch) {
       console.log(`Local branch already absent: ${resolvedBranch}`);

--- a/plugins/worktree-tools/skills/clubs-task-start/SKILL.md
+++ b/plugins/worktree-tools/skills/clubs-task-start/SKILL.md
@@ -1,8 +1,11 @@
 ---
-description: Create a ready-to-run worktree for this ar-002-clubs repo when the user gives a TU task, Notion spec link, or GitHub PR link. Use it whenever new implementation should happen in a fresh sibling worktree instead of the current checkout. Read the task source first, confirm the TU number and scope, choose the correct branch, create the worktree under ../clubs-worktrees, copy required ignored files from the main repo, and run the bootstrap commands in order.
+name: clubs-task-start
+description: "Start a ready-to-run Clubs task worktree for this ar-002-clubs repo. Use this when the user says 워크트리 시작, 워크트리 파, 워크트리 만들어, 태스크 시작, TU 시작, 작업 시작, or asks to start/create/open a worktree, task, TU, or work item. It inspects task context first, chooses the correct branch, creates the worktree under ../clubs-worktrees, copies ignored files, and bootstraps the repo."
+metadata:
+  short-description: Start and bootstrap a Clubs task worktree
 ---
 
-# Create Worktree
+# Clubs Task Start
 
 Create an isolated, runnable worktree for this repo before starting a new task.
 
@@ -11,6 +14,8 @@ Create an isolated, runnable worktree for this repo before starting a new task.
 Use this skill when:
 
 - the user asks to start work on a new TU task
+- the user says 워크트리 시작, 워크트리 파, or 워크트리 만들어
+- the user says 태스크 시작, TU 시작, or 작업 시작
 - the user gives a Notion task/spec page and wants implementation to happen in a fresh worktree
 - the user gives only a new task summary and the task page must be created before the worktree
 - the user gives a GitHub PR link and wants that existing branch pulled into a separate worktree
@@ -18,13 +23,22 @@ Use this skill when:
 
 Do not use this skill if the user explicitly wants work to happen in the current worktree.
 
+## Trigger aliases
+
+Treat these natural-language aliases as this skill:
+
+- 워크트리 시작 / 워크트리 파 / 워크트리 만들어
+- 태스크 시작 / 태스크 파 / 태스크 만들어
+- TU 시작 / TU 파 / TU 작업 시작
+- 작업 시작 / 작업 파 / 작업 만들어
+
 ## Task source first
 
 Always inspect the task source before creating the worktree.
 
 ### If the user gives a Notion page
 
-1. Use the available Notion integration or fetched page content if present.
+1. Use the Notion plugin to fetch the page if available.
 2. Extract:
    - TU number
    - requested work
@@ -56,7 +70,9 @@ Always inspect the task source before creating the worktree.
 
 - Existing PR: reuse the PR head branch exactly.
 - Fresh task with a TU number: use `TU-<number>`.
+- If only the numeric TU id is passed to the helper, it normalizes `405` to `TU-405`.
 - If the task source does not contain a TU number and no PR branch exists, create a Notion task page first when tools are available. Ask the user for the TU number only when the task page cannot be created.
+- Fresh branch creation should sync `dev` first by running a `git pull origin dev` from the primary repo worktree.
 
 ## Worktree location rules
 
@@ -103,7 +119,7 @@ Only do these when the task needs the app or DB to run:
 
 Use the helper command:
 
-`pnpm create-worktree -- --branch <branch> [--start-point <ref>] [--reuse-remote-branch]`
+`pnpm clubs-task-start -- --branch <branch> [--start-point <ref>] [--reuse-remote-branch]`
 
 ### Use these modes
 
@@ -116,7 +132,12 @@ Use `--dry-run` first when:
 
 - the branch name came from a long PR head ref
 - the repo state looks unusual
-- you want to show the exact operations before doing them
+- you want to show the user the exact operations before doing them
+
+When a fresh branch must be created, the helper should:
+
+1. sync the primary repo worktree to the latest `dev`
+2. only then create the new worktree branch from `origin/dev`
 
 ## Validation after setup
 

--- a/plugins/worktree-tools/skills/clubs-task-start/scripts/create_worktree.mjs
+++ b/plugins/worktree-tools/skills/clubs-task-start/scripts/create_worktree.mjs
@@ -74,7 +74,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Usage: pnpm create-worktree -- --branch <name> [options]
+  console.log(`Usage: pnpm clubs-task-start -- --branch <name> [options]
 
 Options:
   --branch <name>             Branch name to use in the worktree
@@ -100,9 +100,7 @@ function gitRoot() {
 
 function primaryWorktreeRoot(repoRoot) {
   const output = runGit(["worktree", "list", "--porcelain"], repoRoot);
-  const line = output
-    .split("\n")
-    .find(entry => entry.startsWith("worktree "));
+  const line = output.split("\n").find(entry => entry.startsWith("worktree "));
 
   if (!line) {
     throw new Error("Could not determine the primary worktree root.");
@@ -127,6 +125,17 @@ function localBranchExists(repoRoot, branch) {
     { cwd: repoRoot },
   );
   return result.status === 0;
+}
+
+function normalizeBranch(input) {
+  if (!input) return "";
+  if (/^TU-\d+$/i.test(input)) {
+    return input.toUpperCase();
+  }
+  if (/^\d+$/.test(input)) {
+    return `TU-${input}`;
+  }
+  return input;
 }
 
 function currentBranch(repoRoot) {
@@ -222,11 +231,14 @@ function main() {
     throw new Error("--branch is required");
   }
 
+  options.branch = normalizeBranch(options.branch);
+
   const repoRoot = gitRoot();
   const sourceRoot = primaryWorktreeRoot(repoRoot);
   const nodeVersion = readNodeVersion(sourceRoot);
   const worktreesRoot = resolve(sourceRoot, "..", "clubs-worktrees");
-  const worktreeName = options.worktreeName || options.branch.replaceAll("/", "-");
+  const worktreeName =
+    options.worktreeName || options.branch.replaceAll("/", "-");
   const target = join(worktreesRoot, worktreeName);
 
   console.log(`Current repo root: ${repoRoot}`);
@@ -246,7 +258,8 @@ function main() {
   }
 
   const shouldCreateFreshBranch =
-    !options.reuseRemoteBranch || !remoteBranchExists(sourceRoot, options.branch);
+    !options.reuseRemoteBranch ||
+    !remoteBranchExists(sourceRoot, options.branch);
 
   if (shouldCreateFreshBranch) {
     const sourceBranch = currentBranch(sourceRoot);
@@ -267,7 +280,10 @@ function main() {
   }
 
   let worktreeArgs;
-  if (options.reuseRemoteBranch && remoteBranchExists(sourceRoot, options.branch)) {
+  if (
+    options.reuseRemoteBranch &&
+    remoteBranchExists(sourceRoot, options.branch)
+  ) {
     if (localBranchExists(sourceRoot, options.branch)) {
       worktreeArgs = ["worktree", "add", target, options.branch];
     } else {

--- a/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
+++ b/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
@@ -124,11 +124,11 @@ Examples:
 Examples:
 
 - Auto body:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 - With explicit summary bullets:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --summary "add a shared Node helper" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --notion-url <url> --summary "add project-local Codex and Claude Code skills" --summary "add a shared Node helper" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 - Existing task number without page URL:
-  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add create-worktree skills" --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
+  - `pnpm create-branch-pr -- pr --task-id TU-405 --title "add clubs-task-start and clubs-task-cleanup skills" --summary "add project-local Codex and Claude Code skills" --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다."`
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 

--- a/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
+++ b/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
@@ -78,8 +78,21 @@ Always resolve these into a confirmed TU number before you create the branch or 
 
 ### PR title naming
 
-- Default format: `[TU-405] short task title`
+- Required format: `[TU-405] one-line task summary`
+- The TU number must be wrapped in square brackets.
+- The text after the TU number should be a concise first-pass summary of the work.
+- Do not use a generic title like `chore`, `fix`, or `update`.
 - Reuse the existing PR title if the PR already exists
+
+### Squash merge title guard
+
+GitHub uses the single commit title as the default squash title when a PR has only one commit. To make the squash title follow the PR title by default:
+
+- Before creating a PR, compare the head branch against the base branch.
+- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit with the formatted PR title as the commit message.
+- Only do this on the current branch and only when the worktree is clean.
+- Use `HUSKY=0 git commit --allow-empty -m "[TU-405] one-line task summary"` so local commit hooks do not reject the bracketed PR title format.
+- Do not add an empty commit if the branch already has 2 or more commits relative to the base.
 
 ### PR base branch
 
@@ -132,6 +145,8 @@ Examples:
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 
+During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds the squash-title empty commit automatically when the branch has fewer than 2 commits relative to the base.
+
 ## Validation
 
 After branch creation:
@@ -144,10 +159,11 @@ After PR creation:
 1. Run `gh pr view --json number,title,headRefName,baseRefName,url,body`
 2. Confirm:
    - base is `dev`
-   - title includes the TU number
+   - title follows `[TU-405] one-line task summary`
    - Notion URL is present in the body
    - `## Patch Note` and the `clubs:patch-note` block are present
    - non-`none` categories have user-facing Korean `text`
+   - if the branch had fewer than 2 commits before PR creation, one empty commit with the PR title was added
 
 ## Response expectations
 

--- a/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
+++ b/plugins/worktree-tools/skills/create-branch-pr/SKILL.md
@@ -89,9 +89,9 @@ Always resolve these into a confirmed TU number before you create the branch or 
 GitHub uses the single commit title as the default squash title when a PR has only one commit. To make the squash title follow the PR title by default:
 
 - Before creating a PR, compare the head branch against the base branch.
-- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit with the formatted PR title as the commit message.
+- If the branch has 0 or 1 commits relative to the base, add exactly one empty commit so GitHub's squash dialog defaults to the PR title.
 - Only do this on the current branch and only when the worktree is clean.
-- Use `HUSKY=0 git commit --allow-empty -m "[TU-405] one-line task summary"` so local commit hooks do not reject the bracketed PR title format.
+- Use `HUSKY=0 git commit --allow-empty -m "chore: empty for squash merge"` so the empty commit itself follows the repo's conventional commit rules.
 - Do not add an empty commit if the branch already has 2 or more commits relative to the base.
 
 ### PR base branch
@@ -145,7 +145,7 @@ Examples:
 
 The helper does not create Notion task pages by itself. It assumes the task page already exists or the task summary is already known when you run the command.
 
-During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds the squash-title empty commit automatically when the branch has fewer than 2 commits relative to the base.
+During PR creation, the helper formats the title as `[TU-405] one-line task summary`. It also adds a `chore: empty for squash merge` empty commit automatically when the branch has fewer than 2 commits relative to the base.
 
 ## Validation
 
@@ -163,7 +163,7 @@ After PR creation:
    - Notion URL is present in the body
    - `## Patch Note` and the `clubs:patch-note` block are present
    - non-`none` categories have user-facing Korean `text`
-   - if the branch had fewer than 2 commits before PR creation, one empty commit with the PR title was added
+   - if the branch had fewer than 2 commits before PR creation, one `chore: empty for squash merge` empty commit was added
 
 ## Response expectations
 

--- a/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
+++ b/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
@@ -253,6 +253,7 @@ const patchNoteCategories = new Set([
 ]);
 const patchNoteStartMarker = "<!-- clubs:patch-note:start -->";
 const patchNoteEndMarker = "<!-- clubs:patch-note:end -->";
+const squashEmptyCommitMessage = "chore: empty for squash merge";
 
 function normalizePatchNoteCategory(category) {
   const normalized = category.toLowerCase();
@@ -404,7 +405,13 @@ function ensureSquashTitleCommit({ base, head, title, dryRun }) {
     );
   }
 
-  const cmd = ["git", "commit", "--allow-empty", "-m", title];
+  const cmd = [
+    "git",
+    "commit",
+    "--allow-empty",
+    "-m",
+    squashEmptyCommitMessage,
+  ];
   console.log(`$ HUSKY=0 ${cmd.join(" ")}`);
   if (dryRun) {
     return;

--- a/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
+++ b/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
@@ -490,48 +490,50 @@ function createPullRequest(options) {
     validatePatchNoteBlock(readFileSync(bodyFile, "utf8"));
   }
 
-  ensureSquashTitleCommit({
-    base: options.base,
-    head,
-    title,
-    dryRun: options.dryRun,
-  });
+  try {
+    ensureSquashTitleCommit({
+      base: options.base,
+      head,
+      title,
+      dryRun: options.dryRun,
+    });
 
-  const cmd = [
-    "gh",
-    "pr",
-    "create",
-    "--base",
-    options.base,
-    "--head",
-    head,
-    "--title",
-    title,
-    "--body-file",
-    bodyFile,
-  ];
+    const cmd = [
+      "gh",
+      "pr",
+      "create",
+      "--base",
+      options.base,
+      "--head",
+      head,
+      "--title",
+      title,
+      "--body-file",
+      bodyFile,
+    ];
 
-  if (options.draft) {
-    cmd.push("--draft");
-  }
+    if (options.draft) {
+      cmd.push("--draft");
+    }
 
-  console.log(`$ ${cmd.join(" ")}`);
-  if (options.dryRun) {
+    console.log(`$ ${cmd.join(" ")}`);
+    if (options.dryRun) {
+      if (tempDir) {
+        console.log("--- generated body ---");
+        console.log(generatedBody.trimEnd());
+        console.log("--- end body ---");
+      }
+      return;
+    }
+
+    const result = spawnSync(cmd[0], cmd.slice(1), { stdio: "inherit" });
+    if (result.status !== 0) {
+      throw new Error("gh pr create failed");
+    }
+  } finally {
     if (tempDir) {
-      console.log("--- generated body ---");
-      console.log(generatedBody.trimEnd());
-      console.log("--- end body ---");
       rmSync(tempDir, { recursive: true, force: true });
     }
-    return;
-  }
-
-  const result = spawnSync(cmd[0], cmd.slice(1), { stdio: "inherit" });
-  if (tempDir) {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-  if (result.status !== 0) {
-    throw new Error("gh pr create failed");
   }
 }
 

--- a/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
+++ b/plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs
@@ -147,7 +147,7 @@ Branch options:
   --reuse-remote-branch       Reuse origin/<branch> when it already exists
 
 PR options:
-  --title <text>              PR title body without or with TU prefix
+  --title <text>              One-line PR summary, with or without TU prefix
   --notion-url <url>          Optional Notion task/spec URL for PR body context
   --base <branch>             Base branch (default: dev)
   --head <branch>             Head branch (default: current branch)
@@ -169,6 +169,15 @@ function runGit(args, cwd = process.cwd()) {
 
 function currentBranch() {
   return runGit(["branch", "--show-current"]);
+}
+
+function isWorktreeClean() {
+  return runGit(["status", "--short"]) === "";
+}
+
+function refExists(ref) {
+  const result = spawnSync("git", ["rev-parse", "--verify", "--quiet", ref]);
+  return result.status === 0;
 }
 
 function localBranchExists(branch) {
@@ -207,17 +216,31 @@ function normalizeTaskId(taskId) {
   return taskId;
 }
 
+function normalizePrSummary(title) {
+  const summary = title.replace(/^\[TU-\d+\]\s*/i, "").trim();
+
+  if (!summary) {
+    throw new Error(
+      "--title must include a one-line summary after the TU prefix",
+    );
+  }
+
+  if (summary.includes("\n") || summary.includes("\r")) {
+    throw new Error("--title must be a single-line summary");
+  }
+
+  return summary;
+}
+
 function formatPrTitle(taskId, title) {
   if (!title) {
     throw new Error("--title is required for PR creation");
   }
 
   const normalizedTaskId = normalizeTaskId(taskId);
-  if (title.startsWith(`[${normalizedTaskId}]`)) {
-    return title;
-  }
+  const summary = normalizePrSummary(title);
 
-  return `[${normalizedTaskId}] ${title}`;
+  return `[${normalizedTaskId}] ${summary}`;
 }
 
 const patchNoteCategories = new Set([
@@ -338,6 +361,64 @@ function switchOrCreateBranch(branch, startPoint, reuseRemoteBranch, dryRun) {
   return currentBranch();
 }
 
+function comparisonBaseRef(base) {
+  const remoteBase = `origin/${base}`;
+  if (refExists(remoteBase)) {
+    return remoteBase;
+  }
+
+  if (refExists(base)) {
+    return base;
+  }
+
+  throw new Error(`Cannot find base ref for PR comparison: ${base}`);
+}
+
+function commitCountFromBase(base, head) {
+  const baseRef = comparisonBaseRef(base);
+  return Number(runGit(["rev-list", "--count", `${baseRef}..${head}`]));
+}
+
+function ensureSquashTitleCommit({ base, head, title, dryRun }) {
+  const current = currentBranch();
+
+  if (head !== current) {
+    console.log(
+      `Skipping squash-title empty commit because --head (${head}) is not the current branch (${current}).`,
+    );
+    return;
+  }
+
+  if (head === base) {
+    throw new Error("PR head branch must differ from the base branch");
+  }
+
+  const commitCount = commitCountFromBase(base, head);
+  if (commitCount >= 2) {
+    return;
+  }
+
+  if (!isWorktreeClean()) {
+    throw new Error(
+      "Cannot add a squash-title empty commit while the worktree has uncommitted changes.",
+    );
+  }
+
+  const cmd = ["git", "commit", "--allow-empty", "-m", title];
+  console.log(`$ HUSKY=0 ${cmd.join(" ")}`);
+  if (dryRun) {
+    return;
+  }
+
+  const result = spawnSync(cmd[0], cmd.slice(1), {
+    env: { ...process.env, HUSKY: "0" },
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error("git empty commit failed");
+  }
+}
+
 function generatedPrBody({
   notionUrl,
   summary,
@@ -401,6 +482,13 @@ function createPullRequest(options) {
   } else {
     validatePatchNoteBlock(readFileSync(bodyFile, "utf8"));
   }
+
+  ensureSquashTitleCommit({
+    base: options.base,
+    head,
+    title,
+    dryRun: options.dryRun,
+  });
 
   const cmd = [
     "gh",

--- a/scripts/release/prepare-patch-note.mjs
+++ b/scripts/release/prepare-patch-note.mjs
@@ -5,6 +5,8 @@ import { createHash } from "node:crypto";
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 const DEFAULT_FILE = "packages/web/src/constants/patchNote.ts";
+const DEFAULT_APP_PACKAGE_FILE = "packages/web/package.json";
+const DEFAULT_APP_INFO_FILE = "packages/web/src/constants/appVersion.mjs";
 const PATCH_NOTE_START = "<!-- clubs:patch-note:start -->";
 const PATCH_NOTE_END = "<!-- clubs:patch-note:end -->";
 
@@ -21,6 +23,8 @@ function parseArgs(argv) {
     base: "origin/main",
     head: "HEAD",
     file: DEFAULT_FILE,
+    appPackageFile: DEFAULT_APP_PACKAGE_FILE,
+    appInfoFile: DEFAULT_APP_INFO_FILE,
     bump: "patch",
     dryRun: false,
   };
@@ -42,6 +46,18 @@ function parseArgs(argv) {
 
     if (arg === "--file") {
       options.file = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--app-package-file") {
+      options.appPackageFile = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--app-info-file") {
+      options.appInfoFile = argv[index + 1] ?? "";
       index += 1;
       continue;
     }
@@ -337,11 +353,15 @@ function bumpVersion(version, bump) {
 }
 
 function formatVersion(version) {
-  return `v.${version.major}.${version.minor}.${version.patch}`;
+  return `${version.major}.${version.minor}.${version.patch}`;
 }
 
 function displayVersion(version) {
-  return version.replace(/^v\./, "");
+  return `v${version}`;
+}
+
+function patchNoteVersion(version) {
+  return `v.${version}`;
 }
 
 function writeGitHubOutput(values) {
@@ -388,7 +408,6 @@ function escapeTemplateLiteral(value) {
 }
 
 function buildPatchNoteContent(version, notes) {
-  const contentVersion = version.replace(/^v\./, "v");
   const grouped = new Map(
     CATEGORY_SECTIONS.map(([category]) => [category, []]),
   );
@@ -397,7 +416,7 @@ function buildPatchNoteContent(version, notes) {
     grouped.get(note.category)?.push(note.text);
   }
 
-  const lines = [`Clubs ${contentVersion}`];
+  const lines = [`Clubs ${displayVersion(version)}`];
   for (const [category, title] of CATEGORY_SECTIONS) {
     const items = grouped.get(category) ?? [];
     if (items.length === 0) {
@@ -415,10 +434,11 @@ function buildPatchNoteContent(version, notes) {
 }
 
 function buildEntry(version, notes, sourceHash) {
+  const versionForPatchNote = patchNoteVersion(version);
   const content = escapeTemplateLiteral(buildPatchNoteContent(version, notes));
-  return `  // clubs:auto-patch-note version=${version} source=${sourceHash}
+  return `  // clubs:auto-patch-note version=${versionForPatchNote} source=${sourceHash}
   {
-    version: "${version}",
+    version: "${versionForPatchNote}",
     date: new Date("${kstDateLiteral()}"),
     patchNoteContent: \`${content}\`,
   },
@@ -443,6 +463,25 @@ function replaceOrInsertEntry(source, version, entry) {
   return source.replace(listStart, `${listStart}${entry}`);
 }
 
+function replacePackageVersion(source, version) {
+  const packageJson = JSON.parse(source);
+  packageJson.version = version;
+  return `${JSON.stringify(packageJson, null, 2)}\n`;
+}
+
+function replaceAppInfoVersion(source, version) {
+  const updated = source.replace(
+    /export const CLUBS_VERSION = "[^"]+";/,
+    `export const CLUBS_VERSION = "${version}";`,
+  );
+
+  if (updated === source && !source.includes(`CLUBS_VERSION = "${version}"`)) {
+    throw new Error("Could not find CLUBS_VERSION declaration.");
+  }
+
+  return updated;
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const repository = parseRepository();
@@ -465,6 +504,7 @@ async function main() {
   writeGitHubOutput({
     version,
     display_version: displayVersion(version),
+    patch_note_version: patchNoteVersion(version),
   });
 
   const sourceHash = createHash("sha256")
@@ -473,19 +513,52 @@ async function main() {
     .slice(0, 12);
   const source = readFileSync(options.file, "utf8");
   const entry = buildEntry(version, notes, sourceHash);
-  const updated = replaceOrInsertEntry(source, version, entry);
+  const updated = replaceOrInsertEntry(
+    source,
+    patchNoteVersion(version),
+    entry,
+  );
+  const appPackageSource = readFileSync(options.appPackageFile, "utf8");
+  const appPackageUpdated = replacePackageVersion(appPackageSource, version);
+  const appInfoSource = readFileSync(options.appInfoFile, "utf8");
+  const appInfoUpdated = replaceAppInfoVersion(appInfoSource, version);
 
   if (options.dryRun) {
+    if (appPackageUpdated !== appPackageSource) {
+      console.log(
+        `Would update ${options.appPackageFile} to ${displayVersion(version)}.`,
+      );
+    }
+    if (appInfoUpdated !== appInfoSource) {
+      console.log(
+        `Would update ${options.appInfoFile} to ${displayVersion(version)}.`,
+      );
+    }
     console.log(entry);
     return;
   }
 
-  if (updated === source) {
+  if (
+    updated === source &&
+    appPackageUpdated === appPackageSource &&
+    appInfoUpdated === appInfoSource
+  ) {
     console.log(`Patch note ${version} is already up to date.`);
     return;
   }
 
-  writeFileSync(options.file, updated, "utf8");
+  if (appInfoUpdated !== appInfoSource) {
+    writeFileSync(options.appInfoFile, appInfoUpdated, "utf8");
+  }
+
+  if (appPackageUpdated !== appPackageSource) {
+    writeFileSync(options.appPackageFile, appPackageUpdated, "utf8");
+  }
+
+  if (updated !== source) {
+    writeFileSync(options.file, updated, "utf8");
+  }
+
   console.log(`Prepared ${version} with ${notes.length} patch note entries.`);
 }
 

--- a/scripts/release/prepare-patch-note.mjs
+++ b/scripts/release/prepare-patch-note.mjs
@@ -525,14 +525,10 @@ async function main() {
 
   if (options.dryRun) {
     if (appPackageUpdated !== appPackageSource) {
-      console.log(
-        `Would update ${options.appPackageFile} to ${displayVersion(version)}.`,
-      );
+      console.log(`Would update ${options.appPackageFile} to ${version}.`);
     }
     if (appInfoUpdated !== appInfoSource) {
-      console.log(
-        `Would update ${options.appInfoFile} to ${displayVersion(version)}.`,
-      );
+      console.log(`Would update ${options.appInfoFile} to ${version}.`);
     }
     console.log(entry);
     return;


### PR DESCRIPTION
## Summary
- Clubs client version source를 `packages/web/src/constants/appVersion.mjs`로 분리하고 package version, app version, patch note version을 동기화했습니다.
- release patch note workflow가 `package.json`, `appVersion.mjs`, `patchNote.ts`를 함께 갱신하고 version bump commit과 patch note commit을 분리하도록 개선했습니다.
- CI integration test에 세 버전 값의 일치 여부를 검증하는 consistency spec을 추가했습니다.
- worktree helper 스킬/명령을 `clubs-task-start`, `clubs-task-cleanup`으로 변경하고 워크트리/태스크/TU/작업 시작·종료 alias를 설명에 반영했습니다.
- PR 생성 헬퍼가 제목을 `[TU-번호] 한 줄 요약` 형식으로 강제하고, squash merge 기본 제목을 PR 제목으로 유도하는 `chore: empty for squash merge` empty commit guard를 추가했습니다.
- CodeRabbit 리뷰를 반영해 PR body 임시 디렉터리 cleanup, cleanup helper no-target 안전 동작, patch note dry-run 로그를 정리했습니다.

## Tests
- `pnpm build`
- `pnpm --filter web lint`
- `pnpm --filter api lint -- test/integration/clubs-version.spec.ts`
- `pnpm --filter api exec jest --config ./test/jest-integration.json test/integration/clubs-version.spec.ts`
- CI env로 MySQL test DB 준비 후 `pnpm --filter api test:integration:ci`
- `node scripts/release/prepare-patch-note.mjs --base origin/main --head HEAD --bump patch --file packages/web/src/constants/patchNote.ts --app-package-file packages/web/package.json --app-info-file packages/web/src/constants/appVersion.mjs --dry-run`
- `pnpm exec prettier --check ...`
- `node --check scripts/release/prepare-patch-note.mjs`
- `node --check plugins/worktree-tools/skills/clubs-task-start/scripts/create_worktree.mjs`
- `node --check plugins/worktree-tools/skills/clubs-task-cleanup/scripts/delete_worktree.mjs`
- `node --check plugins/worktree-tools/skills/create-branch-pr/scripts/create_branch_pr.mjs`
- `pnpm clubs-task-start -- --help`
- `pnpm clubs-task-cleanup -- --help`
- `pnpm clubs-task-start -- --branch 427 --reuse-remote-branch --worktree-name __dry-run-normalize --skip-bootstrap --dry-run`
- `pnpm clubs-task-cleanup -- --branch 999999 --dry-run`
- `pnpm clubs-task-cleanup` exits with explicit-target error
- `pnpm create-branch-pr -- pr --task-id 427 --title "[TU-999] PR 생성 규칙 보강" --summary "PR 생성 제목 규칙과 squash title guard를 보강했습니다." --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다." --dry-run`
- `pnpm create-branch-pr -- pr --task-id 427 --base 1f277be9 --title "CodeRabbit 리뷰 반영" --summary "CodeRabbit 리뷰에서 확인된 PR helper와 cleanup helper 문제를 수정했습니다." --patch-note-category internal --patch-note-text "사용자에게 직접 보이는 변경은 없습니다." --dry-run`

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text: 릴리즈 준비 과정에서 클라이언트 버전과 패치노트 버전이 어긋나지 않도록 내부 검증을 추가했습니다.
<!-- clubs:patch-note:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App debug badge now shows the app display version; responses and client requests include version headers for visibility.

* **Tests**
  * Added an integration test verifying version consistency across app artifacts.

* **Chores**
  * Web app version bumped to 0.1.2; patch-note generation and release workflow enhanced to update version files and create focused commits/PRs.

* **Documentation**
  * Updated task start/cleanup and PR/skill docs and plugin metadata to reflect new command names and guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparcs-kaist/clubs/pull/1819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->