### PR TITLE
[TU-390] 지원금 최종 검토자 표시 수정

### DIFF
--- a/packages/api/src/feature/funding/model/funding.summary.model.ts
+++ b/packages/api/src/feature/funding/model/funding.summary.model.ts
@@ -8,9 +8,10 @@ export type FundingSummaryDBResult = {
   fundingStatusEnum: number;
   expenditureAmount: number;
   purposeActivityId: number | null;
-  approvedAmount: number;
+  approvedAmount: number | null;
   clubId: number;
   chargedExecutiveId: number | null;
+  commentedExecutiveId?: number | null;
 };
 
 export class VFundingSummary implements IFundingSummary {
@@ -29,6 +30,8 @@ export class VFundingSummary implements IFundingSummary {
   club: IFundingSummary["club"];
 
   chargedExecutive: IFundingSummary["chargedExecutive"];
+
+  commentedExecutive: IFundingSummary["commentedExecutive"];
 
   // 첫 번째 생성자: IFundingSummary로부터 초기화
   constructor(fundingSummary: IFundingSummary);
@@ -58,10 +61,13 @@ export class VFundingSummary implements IFundingSummary {
       purposeActivity: result.purposeActivityId
         ? { id: result.purposeActivityId }
         : undefined,
-      approvedAmount: result.approvedAmount,
+      approvedAmount: result.approvedAmount ?? undefined,
       club: result.clubId ? { id: result.clubId } : undefined,
       chargedExecutive: result.chargedExecutiveId
         ? { id: result.chargedExecutiveId }
+        : undefined,
+      commentedExecutive: result.commentedExecutiveId
+        ? { id: result.commentedExecutiveId }
         : undefined,
     });
   }

--- a/packages/api/src/feature/funding/model/funding.summary.model.ts
+++ b/packages/api/src/feature/funding/model/funding.summary.model.ts
@@ -12,6 +12,7 @@ export type FundingSummaryDBResult = {
   clubId: number;
   chargedExecutiveId: number | null;
   commentedExecutiveId?: number | null;
+  feedbacks?: { executiveId: number }[];
 };
 
 export class VFundingSummary implements IFundingSummary {
@@ -53,6 +54,9 @@ export class VFundingSummary implements IFundingSummary {
   }
 
   static fromDBResult(result: FundingSummaryDBResult) {
+    const commentedExecutiveId =
+      result.commentedExecutiveId ?? result.feedbacks?.[0]?.executiveId;
+
     return new VFundingSummary({
       id: result.id,
       name: result.name,
@@ -66,8 +70,8 @@ export class VFundingSummary implements IFundingSummary {
       chargedExecutive: result.chargedExecutiveId
         ? { id: result.chargedExecutiveId }
         : undefined,
-      commentedExecutive: result.commentedExecutiveId
-        ? { id: result.commentedExecutiveId }
+      commentedExecutive: commentedExecutiveId
+        ? { id: commentedExecutiveId }
         : undefined,
     });
   }

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -18,6 +18,33 @@ import {
 } from "../model/funding.summary.model";
 import { buildFundingTransportationPassengerFindManyArgs } from "./funding.repository.util";
 
+const fundingSummarySelect = {
+  id: true,
+  name: true,
+  expenditureAmount: true,
+  approvedAmount: true,
+  fundingStatusEnum: true,
+  purposeActivityId: true,
+  clubId: true,
+  chargedExecutiveId: true,
+  feedbacks: {
+    where: {
+      deletedAt: null,
+    },
+    orderBy: {
+      id: "desc",
+    },
+    take: 1,
+    select: {
+      executiveId: true,
+    },
+  },
+} satisfies Prisma.FundingSelect;
+
+type FundingSummaryPrismaResult = Prisma.FundingGetPayload<{
+  select: typeof fundingSummarySelect;
+}>;
+
 @Injectable()
 export default class FundingRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -162,210 +189,100 @@ export default class FundingRepository {
     });
   }
 
-  async fetchSummaries(ids: number[]): Promise<IFundingSummary[]>;
-  async fetchSummaries(activityDId: number): Promise<IFundingSummary[]>;
+  private toFundingSummaryDBResult(
+    funding: FundingSummaryPrismaResult,
+  ): FundingSummaryDBResult {
+    return {
+      id: funding.id,
+      name: funding.name,
+      fundingStatusEnum: funding.fundingStatusEnum,
+      expenditureAmount: funding.expenditureAmount,
+      purposeActivityId: funding.purposeActivityId,
+      approvedAmount: funding.approvedAmount,
+      clubId: funding.clubId,
+      chargedExecutiveId: funding.chargedExecutiveId,
+      commentedExecutiveId: funding.feedbacks[0]?.executiveId ?? null,
+    };
+  }
+
+  private async fetchSummariesByWhere(
+    where: Prisma.FundingWhereInput,
+  ): Promise<VFundingSummary[]> {
+    const fundings = await this.prisma.funding.findMany({
+      select: fundingSummarySelect,
+      where: {
+        AND: [{ deletedAt: null }, where],
+      },
+    });
+
+    return fundings.map(funding =>
+      VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(funding)),
+    );
+  }
+
+  async fetchSummaries(ids: number[]): Promise<VFundingSummary[]>;
+  async fetchSummaries(activityDId: number): Promise<VFundingSummary[]>;
   async fetchSummaries(
     clubId: number,
     activityDId: number,
-  ): Promise<IFundingSummary[]>;
+  ): Promise<VFundingSummary[]>;
   async fetchSummaries(
     clubIds: number[],
     activityDId: number,
-  ): Promise<IFundingSummary[]>;
+  ): Promise<VFundingSummary[]>;
   async fetchSummaries(
     arg1: number | number[],
     arg2?: number,
-  ): Promise<IFundingSummary[]> {
+  ): Promise<VFundingSummary[]> {
     if (Array.isArray(arg1)) {
       if (arg1.length === 0) {
         return [];
       }
 
       if (arg2 === undefined) {
-        const fundings = await this.prisma.funding.findMany({
-          select: {
-            id: true,
-            name: true,
-            expenditureAmount: true,
-            approvedAmount: true,
-            fundingStatusEnum: true,
-            purposeActivityId: true,
-            clubId: true,
-            chargedExecutiveId: true,
-          },
-          where: {
-            id: { in: arg1 },
-            deletedAt: null,
-          },
-        });
-
-        return fundings.map(funding => ({
-          ...funding,
-          purposeActivity: {
-            id: funding.purposeActivityId,
-          },
-          club: {
-            id: funding.clubId,
-          },
-          chargedExecutive: {
-            id: funding.chargedExecutiveId,
-          },
-        }));
+        return this.fetchSummariesByWhere({ id: { in: arg1 } });
       }
 
-      const fundings = await this.prisma.funding.findMany({
-        select: {
-          id: true,
-          name: true,
-          expenditureAmount: true,
-          approvedAmount: true,
-          fundingStatusEnum: true,
-          purposeActivityId: true,
-          clubId: true,
-          chargedExecutiveId: true,
-        },
-        where: {
-          clubId: { in: arg1 },
-          activityDId: arg2,
-          deletedAt: null,
-        },
+      return this.fetchSummariesByWhere({
+        clubId: { in: arg1 },
+        activityDId: arg2,
       });
-
-      return fundings.map(funding => ({
-        ...funding,
-        purposeActivity: {
-          id: funding.purposeActivityId,
-        },
-        club: {
-          id: funding.clubId,
-        },
-        chargedExecutive: {
-          id: funding.chargedExecutiveId,
-        },
-      }));
     }
 
     if (arg2 === undefined) {
-      const fundings = await this.prisma.funding.findMany({
-        select: {
-          id: true,
-          name: true,
-          expenditureAmount: true,
-          approvedAmount: true,
-          fundingStatusEnum: true,
-          purposeActivityId: true,
-          clubId: true,
-          chargedExecutiveId: true,
-        },
-        where: {
-          activityDId: arg1,
-          deletedAt: null,
-        },
-      });
-
-      if (fundings.length === 0) {
-        return [];
-      }
-
-      return fundings.map(funding => ({
-        ...funding,
-        purposeActivity: {
-          id: funding.purposeActivityId,
-        },
-        club: {
-          id: funding.clubId,
-        },
-        chargedExecutive: {
-          id: funding.chargedExecutiveId,
-        },
-      }));
+      return this.fetchSummariesByWhere({ activityDId: arg1 });
     }
 
-    const fundings = await this.prisma.funding.findMany({
-      select: {
-        id: true,
-        name: true,
-        expenditureAmount: true,
-        approvedAmount: true,
-        fundingStatusEnum: true,
-        purposeActivityId: true,
-        clubId: true,
-        chargedExecutiveId: true,
-      },
-      where: {
-        clubId: arg1,
-        activityDId: arg2,
-        deletedAt: null,
-      },
+    return this.fetchSummariesByWhere({
+      clubId: arg1,
+      activityDId: arg2,
     });
-
-    if (fundings.length === 0) {
-      return [];
-    }
-
-    return fundings.map(funding => ({
-      ...funding,
-      purposeActivity: {
-        id: funding.purposeActivityId,
-      },
-      club: {
-        id: funding.clubId,
-      },
-      chargedExecutive: {
-        id: funding.chargedExecutiveId,
-      },
-    }));
   }
 
   async fetchCommentedSummaries(
     executiveId: number,
-  ): Promise<IFundingSummary[]> {
-    const fundings = await this.prisma.$queryRaw<
-      Array<{
-        id: number;
-        fundingStatusEnum: number;
-        name: string;
-        expenditureAmount: number;
-        approvedAmount: number | null;
-        purposeActivityId: number | null;
-        clubId: number;
-        chargedExecutiveId: number | null;
-      }>
-    >(Prisma.sql`
-      SELECT
-        f.id,
-        f.funding_status_enum AS fundingStatusEnum,
-        f.name,
-        f.expenditure_amount AS expenditureAmount,
-        f.approved_amount AS approvedAmount,
-        f.purpose_activity_id AS purposeActivityId,
-        f.club_id AS clubId,
-        f.charged_executive_id AS chargedExecutiveId
-      FROM funding f
-      WHERE f.deleted_at IS NULL
-        AND (
-          f.charged_executive_id = ${executiveId}
-          OR EXISTS (
-            SELECT 1 FROM funding_feedback ff
-            WHERE ff.funding_id = f.id
-              AND ff.executive_id = ${executiveId}
-              AND ff.deleted_at IS NULL
-          )
-        )
-    `);
+  ): Promise<VFundingSummary[]> {
+    const fundings = await this.prisma.funding.findMany({
+      select: fundingSummarySelect,
+      where: {
+        deletedAt: null,
+        OR: [
+          { chargedExecutiveId: executiveId },
+          {
+            feedbacks: {
+              some: {
+                executiveId,
+                deletedAt: null,
+              },
+            },
+          },
+        ],
+      },
+    });
 
-    return fundings.map(funding => ({
-      ...funding,
-      purposeActivity: {
-        id: funding.purposeActivityId,
-      },
-      club: {
-        id: funding.clubId,
-      },
-      chargedExecutive: {
-        id: funding.chargedExecutiveId,
-      },
-    }));
+    return fundings.map(funding =>
+      VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(funding)),
+    );
   }
 
   async insert(

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -956,14 +956,16 @@ export default class FundingRepository {
     tx: PrismaTransactionClient,
     id: number,
   ): Promise<VFundingSummary> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await (tx as any).funding.findFirst({ where: { id } });
+    const result = await tx.funding.findFirst({
+      select: fundingSummarySelect,
+      where: { id, deletedAt: null },
+    });
 
     if (!result) {
       throw new NotFoundException(`Funding: ${id} not found`);
     }
 
-    return VFundingSummary.fromDBResult(result as FundingSummaryDBResult);
+    return VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(result));
   }
 
   async patchStatus(param: {

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -12,10 +12,7 @@ import { PrismaTransactionClient } from "@sparcs-clubs/api/common/base/base.repo
 import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 import { FundingDBResult, MFunding } from "../model/funding.model";
-import {
-  FundingSummaryDBResult,
-  VFundingSummary,
-} from "../model/funding.summary.model";
+import { VFundingSummary } from "../model/funding.summary.model";
 import { buildFundingTransportationPassengerFindManyArgs } from "./funding.repository.util";
 
 const fundingSummarySelect = {
@@ -40,10 +37,6 @@ const fundingSummarySelect = {
     },
   },
 } satisfies Prisma.FundingSelect;
-
-type FundingSummaryPrismaResult = Prisma.FundingGetPayload<{
-  select: typeof fundingSummarySelect;
-}>;
 
 @Injectable()
 export default class FundingRepository {
@@ -189,22 +182,6 @@ export default class FundingRepository {
     });
   }
 
-  private toFundingSummaryDBResult(
-    funding: FundingSummaryPrismaResult,
-  ): FundingSummaryDBResult {
-    return {
-      id: funding.id,
-      name: funding.name,
-      fundingStatusEnum: funding.fundingStatusEnum,
-      expenditureAmount: funding.expenditureAmount,
-      purposeActivityId: funding.purposeActivityId,
-      approvedAmount: funding.approvedAmount,
-      clubId: funding.clubId,
-      chargedExecutiveId: funding.chargedExecutiveId,
-      commentedExecutiveId: funding.feedbacks[0]?.executiveId ?? null,
-    };
-  }
-
   private async fetchSummariesByWhere(
     where: Prisma.FundingWhereInput,
   ): Promise<VFundingSummary[]> {
@@ -215,9 +192,7 @@ export default class FundingRepository {
       },
     });
 
-    return fundings.map(funding =>
-      VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(funding)),
-    );
+    return fundings.map(funding => VFundingSummary.fromDBResult(funding));
   }
 
   async fetchSummaries(ids: number[]): Promise<VFundingSummary[]>;
@@ -280,9 +255,7 @@ export default class FundingRepository {
       },
     });
 
-    return fundings.map(funding =>
-      VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(funding)),
-    );
+    return fundings.map(funding => VFundingSummary.fromDBResult(funding));
   }
 
   async insert(
@@ -965,7 +938,7 @@ export default class FundingRepository {
       throw new NotFoundException(`Funding: ${id} not found`);
     }
 
-    return VFundingSummary.fromDBResult(this.toFundingSummaryDBResult(result));
+    return VFundingSummary.fromDBResult(result);
   }
 
   async patchStatus(param: {

--- a/packages/api/src/feature/funding/service/funding.service.spec.ts
+++ b/packages/api/src/feature/funding/service/funding.service.spec.ts
@@ -1,0 +1,115 @@
+import { FundingStatusEnum } from "@clubs/interface/common/enum/funding.enum";
+
+import FundingService from "./funding.service";
+
+type FundingServiceDependencies = ConstructorParameters<typeof FundingService>;
+
+const activityDuration = { id: 301 };
+const club = { id: 201, name: "동아리" };
+const chargedExecutive = {
+  id: 101,
+  name: "담당자",
+  studentNumber: "20241001",
+};
+const latestCommentedExecutive = {
+  id: 102,
+  name: "최종 검토자",
+  studentNumber: "20241002",
+};
+const funding = {
+  id: 401,
+  name: "지원금 항목",
+  expenditureAmount: 10000,
+  approvedAmount: 8000,
+  fundingStatusEnum: FundingStatusEnum.Approved,
+  purposeActivity: { id: 501 },
+  club: { id: club.id },
+  chargedExecutive: { id: chargedExecutive.id },
+  commentedExecutive: { id: latestCommentedExecutive.id },
+};
+const activity = { id: 501, name: "활동" };
+
+const createFundingService = () => {
+  const fundingRepository = {
+    fetchSummaries: jest.fn(),
+    fetchCommentedSummaries: jest.fn(),
+  };
+  const fundingCommentRepository = {
+    find: jest.fn(),
+  };
+  const userPublicService = {
+    checkCurrentExecutive: jest.fn().mockResolvedValue(undefined),
+    fetchExecutiveSummaries: jest
+      .fn()
+      .mockResolvedValue([chargedExecutive, latestCommentedExecutive]),
+    findExecutiveSummary: jest.fn().mockResolvedValue(chargedExecutive),
+  };
+  const clubPublicService = {
+    fetchSummary: jest.fn().mockResolvedValue(club),
+    fetchSummaries: jest.fn().mockResolvedValue([club]),
+  };
+  const activityPublicService = {
+    fetchSummaries: jest.fn().mockResolvedValue([activity]),
+  };
+  const semesterPublicService = {
+    loadId: jest.fn(),
+  };
+  const activityDurationPublicService = {
+    load: jest.fn().mockResolvedValue(activityDuration),
+  };
+
+  const service = new FundingService(
+    fundingRepository as FundingServiceDependencies[0],
+    fundingCommentRepository as FundingServiceDependencies[1],
+    {} as FundingServiceDependencies[2],
+    userPublicService as FundingServiceDependencies[3],
+    clubPublicService as FundingServiceDependencies[4],
+    activityPublicService as FundingServiceDependencies[5],
+    semesterPublicService as FundingServiceDependencies[6],
+    activityDurationPublicService as FundingServiceDependencies[7],
+    {} as FundingServiceDependencies[8],
+    {} as FundingServiceDependencies[9],
+    {} as FundingServiceDependencies[10],
+  );
+
+  return {
+    service,
+    fundingRepository,
+    fundingCommentRepository,
+  };
+};
+
+describe("FundingService final commented executive", () => {
+  it("uses the latest funding feedback by descending id for club brief", async () => {
+    const { service, fundingRepository, fundingCommentRepository } =
+      createFundingService();
+    fundingRepository.fetchSummaries.mockResolvedValue([funding]);
+
+    const result = await service.getExecutiveFundingsClubBrief(
+      chargedExecutive.id,
+      { clubId: club.id },
+      { semesterId: 1 },
+    );
+
+    expect(fundingCommentRepository.find).not.toHaveBeenCalled();
+    expect(result.fundings[0].commentedExecutive).toEqual(
+      latestCommentedExecutive,
+    );
+  });
+
+  it("uses the latest funding feedback by descending id for executive brief", async () => {
+    const { service, fundingRepository, fundingCommentRepository } =
+      createFundingService();
+    fundingRepository.fetchCommentedSummaries.mockResolvedValue([funding]);
+
+    const result = await service.getExecutiveFundingsExecutiveBrief(
+      chargedExecutive.id,
+      { executiveId: chargedExecutive.id },
+    );
+
+    expect(fundingCommentRepository.find).not.toHaveBeenCalled();
+    expect(result.fundings[0].commentedExecutive).toEqual(
+      latestCommentedExecutive,
+    );
+  });
+});

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -859,31 +859,15 @@ export default class FundingService {
     const chargedExecutive =
       await this.userPublicService.findExecutiveSummary(chargedExecutiveId);
 
-    const fundingsWithCommentedExecutive = await Promise.all(
-      fundings.map(async funding => {
-        const comments = await this.fundingCommentRepository.find({
-          fundingId: funding.id,
-        });
-        return {
-          ...funding,
-          commentedExecutive: comments[0]?.executive,
-        };
-      }),
-    );
-
-    const activityIds = fundingsWithCommentedExecutive
+    const activityIds = fundings
       .map(funding => funding.purposeActivity?.id)
       .filter((id): id is number => id != null);
     const activities =
       await this.activityPublicService.fetchSummaries(activityIds);
 
     const executiveIds = [
-      ...fundingsWithCommentedExecutive.map(
-        funding => funding.chargedExecutive?.id,
-      ),
-      ...fundingsWithCommentedExecutive.map(
-        funding => funding.commentedExecutive?.id,
-      ),
+      ...fundings.map(funding => funding.chargedExecutive?.id),
+      ...fundings.map(funding => funding.commentedExecutive?.id),
     ].filter((id): id is number => id != null);
 
     const executives = await this.userPublicService.fetchExecutiveSummaries(
@@ -931,7 +915,7 @@ export default class FundingService {
           funding.fundingStatusEnum === FundingStatusEnum.Committee,
       ).length,
       chargedExecutive,
-      fundings: fundingsWithCommentedExecutive.map(funding => ({
+      fundings: fundings.map(funding => ({
         ...funding,
         club: clubs.find(c => c.id === funding.club.id),
         purposeActivity: activities.find(
@@ -959,31 +943,15 @@ export default class FundingService {
       param.executiveId,
     );
 
-    const fundingsWithCommentedExecutive = await Promise.all(
-      fundings.map(async funding => {
-        const comments = await this.fundingCommentRepository.find({
-          fundingId: funding.id,
-        });
-        return {
-          ...funding,
-          commentedExecutive: comments[0]?.executive,
-        };
-      }),
-    );
-
-    const activityIds = fundingsWithCommentedExecutive
+    const activityIds = fundings
       .map(funding => funding.purposeActivity?.id)
       .filter((id): id is number => id != null);
     const activities =
       await this.activityPublicService.fetchSummaries(activityIds);
 
     const executiveIds = [
-      ...fundingsWithCommentedExecutive.map(
-        funding => funding.chargedExecutive?.id,
-      ),
-      ...fundingsWithCommentedExecutive.map(
-        funding => funding.commentedExecutive?.id,
-      ),
+      ...fundings.map(funding => funding.chargedExecutive?.id),
+      ...fundings.map(funding => funding.commentedExecutive?.id),
     ].filter((id): id is number => id != null);
     const executives = await this.userPublicService.fetchExecutiveSummaries(
       Array.from(new Set(executiveIds)),
@@ -1015,7 +983,7 @@ export default class FundingService {
       committeeCount: fundings.filter(
         funding => funding.fundingStatusEnum === FundingStatusEnum.Committee,
       ).length,
-      fundings: fundingsWithCommentedExecutive.map(funding => ({
+      fundings: fundings.map(funding => ({
         ...funding,
         club: clubs.find(club => club.id === funding.club.id),
         purposeActivity: activities.find(

--- a/packages/interface/src/api/funding/type/funding.type.ts
+++ b/packages/interface/src/api/funding/type/funding.type.ts
@@ -365,6 +365,7 @@ export const zFundingSummary = zFunding.pick({
   purposeActivity: true,
   club: true,
   chargedExecutive: true,
+  commentedExecutive: true,
 });
 
 export const zFundingSummaryResponse = zFundingSummary.extend({


### PR DESCRIPTION
## Summary
- 지원금 summary read model에 최신 검토자 정보를 포함하도록 API contract를 확장했습니다.
- 지원금 목록 조회에서 최신 funding feedback 작성자를 Prisma projection으로 함께 조회하도록 수정했습니다.
- 집행부 지원금 목록의 최종 검토자 매핑을 검증하는 unit test를 추가했습니다.

## Test
- pnpm --filter=interface build
- pnpm --filter=api lint -- src/feature/funding/service/funding.service.ts src/feature/funding/service/funding.service.spec.ts src/feature/funding/repository/funding.repository.ts src/feature/funding/model/funding.summary.model.ts
- pnpm --filter=api build
- pnpm --filter=api test:unit -- funding.service.spec.ts
- pnpm mcdc:changed --fail-on-missing

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 집행부 지원금 목록에서 최종 검토자가 최신 검토 이력을 기준으로 표시되도록 수정했습니다.
<!-- clubs:patch-note:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Funding summaries now include which executive provided the most recent comment for each funding item.

* **Improvements**
  * Approved amount can now be null to better represent missing approvals.
  * Summary retrieval streamlined to return enriched summaries directly, reducing extra lookups and improving efficiency.
  * Brief-building logic updated to consume enriched summaries directly.

* **Tests**
  * Added unit tests validating selection of the final commented executive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->