### PR TITLE
[TU-399] 활동보고서 승인 상태 분리

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,4 +5,6 @@ if [ -d "$NVM_DIR/versions/node/$NODE_VER/bin" ]; then
   export PATH="$NVM_DIR/versions/node/$NODE_VER/bin:$PATH"
 fi
 
+pnpm format:check:changed
+pnpm lint
 pnpm mcdc:changed --fail-on-missing

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,6 +5,8 @@ if [ -d "$NVM_DIR/versions/node/$NODE_VER/bin" ]; then
   export PATH="$NVM_DIR/versions/node/$NODE_VER/bin:$PATH"
 fi
 
+set -e
+
 pnpm format:check:changed
 pnpm lint
 pnpm prisma-query:changed

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "turbo run build --force",
     "build:api": "turbo run build --filter=api",
     "mcdc": "node scripts/mcdc/cli.mjs",
-    "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 2",
+    "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 1",
     "mcdc:jest": "node scripts/mcdc/jest-runner.mjs",
     "start": "turbo run start",
     "clean": "turbo run clean",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:api": "turbo run build --filter=api",
     "format:check:changed": "node scripts/check-format-changed.mjs",
     "mcdc": "node scripts/mcdc/cli.mjs",
-    "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 1",
+    "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 2",
     "mcdc:jest": "node scripts/mcdc/jest-runner.mjs",
     "start": "turbo run start",
     "clean": "turbo run clean",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev-no-d": "turbo run dev:setup && turbo run dev --no-daemon",
     "build": "turbo run build --force",
     "build:api": "turbo run build --filter=api",
+    "format:check:changed": "node scripts/check-format-changed.mjs",
     "mcdc": "node scripts/mcdc/cli.mjs",
     "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 1",
     "mcdc:jest": "node scripts/mcdc/jest-runner.mjs",

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -141,6 +141,15 @@ describe("ActivityService", () => {
     expect(updatedActivity.professorApprovedAt).toBeUndefined();
   });
 
+  it("rejects regular activity report edits outside writing and modification periods", async () => {
+    const { activityRepository, service } = createService([]);
+
+    await expect(
+      service.putStudentActivity({ activityId: activity.id }, body, 1),
+    ).rejects.toThrow("is empty");
+    expect(activityRepository.put).not.toHaveBeenCalled();
+  });
+
   it("keeps professor approval when a provisional activity report is edited", async () => {
     const { activityRepository, registrationPublicService, service } =
       createService();

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -1,5 +1,6 @@
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
 import { ActivityDeadlineEnum } from "@clubs/domain/semester/deadline";
+
 import { ActivityTypeEnum } from "@clubs/interface/common/enum/activity.enum";
 
 import { MActivity } from "../model/activity.model.new";

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -1,0 +1,161 @@
+import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
+import { ActivityDeadlineEnum } from "@clubs/domain/semester/deadline";
+import { ActivityTypeEnum } from "@clubs/interface/common/enum/activity.enum";
+
+import { MActivity } from "../model/activity.model.new";
+import ActivityService from "./activity.service.new";
+
+describe("ActivityService", () => {
+  const activityDuration = {
+    id: 10,
+    startTerm: new Date("2026-03-01T00:00:00.000Z"),
+    endTerm: new Date("2026-06-30T14:59:59.999Z"),
+  };
+  const approvedAt = new Date("2026-04-01T00:00:00.000Z");
+  const editedAt = new Date("2026-04-02T00:00:00.000Z");
+  const activity = {
+    id: 1,
+    name: "original activity",
+    activityTypeEnum: ActivityTypeEnum.matchedInternalActivity,
+    durations: [
+      {
+        startTerm: new Date("2026-03-10T00:00:00.000Z"),
+        endTerm: new Date("2026-03-11T00:00:00.000Z"),
+      },
+    ],
+    location: "N1",
+    purpose: "purpose",
+    detail: "detail",
+    evidence: "evidence",
+    evidenceFiles: [{ id: "file-1" }],
+    participants: [{ id: 1 }],
+    chargedExecutive: { id: 7 },
+    activityDuration: { id: activityDuration.id },
+    activityStatusEnum: ActivityStatusEnum.Approved,
+    club: { id: 20 },
+    editedAt,
+    professorApprovedAt: approvedAt,
+    commentedAt: null,
+    commentedExecutive: null,
+  };
+  const body = {
+    name: "updated activity",
+    activityTypeEnumId: ActivityTypeEnum.matchedExternalActivity,
+    durations: [
+      {
+        startTerm: new Date("2026-03-12T00:00:00.000Z"),
+        endTerm: new Date("2026-03-13T00:00:00.000Z"),
+      },
+    ],
+    location: "N2",
+    purpose: "updated purpose",
+    detail: "updated detail",
+    evidence: "updated evidence",
+    evidenceFiles: [{ fileId: "file-2" }],
+    participants: [{ studentId: 1 }],
+  };
+
+  const createService = (
+    activityDeadlines = [{ deadlineEnum: ActivityDeadlineEnum.Writing }],
+  ) => {
+    const activityRepository = {
+      fetch: jest.fn().mockResolvedValue(activity),
+      put: jest.fn().mockResolvedValue(new MActivity(activity)),
+    };
+    const clubPublicService = {
+      checkIsStudentDelegate: jest.fn().mockResolvedValue(undefined),
+      getMemberFromSemester: jest
+        .fn()
+        .mockResolvedValue([{ studentId: 1 }, { studentId: 2 }]),
+    };
+    const filePublicService = {
+      getFileInfoById: jest
+        .fn()
+        .mockImplementation((id: string) => Promise.resolve({ id })),
+    };
+    const registrationPublicService = {
+      resetClubRegistrationStatusEnum: jest.fn().mockResolvedValue(undefined),
+    };
+    const activityDurationPublicService = {
+      load: jest.fn().mockResolvedValue(activityDuration),
+      getById: jest.fn().mockResolvedValue(activityDuration),
+    };
+    const activityDeadlinePublicService = {
+      search: jest.fn().mockResolvedValue(activityDeadlines),
+    };
+    const semesterPublicService = {
+      loadId: jest.fn().mockResolvedValue(1),
+    };
+    const activityDurationValidatorService = {
+      getValidationError: jest.fn().mockReturnValue(null),
+    };
+
+    const service = new ActivityService(
+      activityRepository as never,
+      {} as never,
+      {} as never,
+      activityDurationPublicService as never,
+      activityDeadlinePublicService as never,
+      semesterPublicService as never,
+      clubPublicService as never,
+      filePublicService as never,
+      registrationPublicService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      activityDurationValidatorService as never,
+    );
+
+    return {
+      activityRepository,
+      filePublicService,
+      registrationPublicService,
+      service,
+    };
+  };
+
+  it("clears professor approval when a regular activity report is edited during the writing period", async () => {
+    const { activityRepository, service } = createService([
+      { deadlineEnum: ActivityDeadlineEnum.Writing },
+    ]);
+
+    await service.putStudentActivity({ activityId: activity.id }, body, 1);
+
+    const updatedActivity = activityRepository.put.mock
+      .calls[0][0] as MActivity;
+    expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
+    expect(updatedActivity.professorApprovedAt).toBeNull();
+  });
+
+  it("keeps professor approval when a regular activity report is edited during the modification period", async () => {
+    const { activityRepository, service } = createService([
+      { deadlineEnum: ActivityDeadlineEnum.Modification },
+    ]);
+
+    await service.putStudentActivity({ activityId: activity.id }, body, 1);
+
+    const updatedActivity = activityRepository.put.mock
+      .calls[0][0] as MActivity;
+    expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
+    expect(updatedActivity.professorApprovedAt).toBeUndefined();
+  });
+
+  it("keeps professor approval when a provisional activity report is edited", async () => {
+    const { activityRepository, registrationPublicService, service } =
+      createService();
+
+    await service.putStudentActivityProvisional(
+      { activityId: activity.id },
+      body,
+      1,
+    );
+
+    const updatedActivity = activityRepository.put.mock
+      .calls[0][0] as MActivity;
+    expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
+    expect(updatedActivity.professorApprovedAt).toBeUndefined();
+    expect(
+      registrationPublicService.resetClubRegistrationStatusEnum,
+    ).toHaveBeenCalledWith(activity.club.id);
+  });
+});

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -347,7 +347,7 @@ export default class ActivityService {
       clubId: activity.club.id,
     });
     // 오늘이 활동보고서 작성기간이거나, 수정 작성기간인지 확인합니다.
-    await this.activityDeadlinePublicService.search({
+    const availableDeadlines = await this.activityDeadlinePublicService.search({
       date: new Date(),
       deadlineEnum: [
         ActivityDeadlineEnum.Writing,
@@ -355,6 +355,9 @@ export default class ActivityService {
         // ActivityDeadlineEnum.Exception,
       ],
     });
+    const shouldResetProfessorApproval = availableDeadlines.some(
+      deadline => deadline.deadlineEnum === ActivityDeadlineEnum.Writing,
+    );
     // 해당 활동이 지난 활동기간에 대한 활동인지 확인합니다.
     const activityD = await this.activityDurationPublicService.load();
     if (activity.activityDuration.id !== activityD.id)
@@ -414,7 +417,7 @@ export default class ActivityService {
         activityStatusEnum: ActivityStatusEnum.Applied,
         club: { id: activity.club.id },
         editedAt: new Date(),
-        professorApprovedAt: undefined,
+        professorApprovedAt: shouldResetProfessorApproval ? null : undefined,
         commentedAt: undefined,
         commentedExecutive: undefined,
       }),
@@ -729,6 +732,7 @@ export default class ActivityService {
       })),
       activityDuration: { id: activity.activityDuration.id },
       activityStatusEnum: ActivityStatusEnum.Applied,
+      professorApprovedAt: undefined,
     });
     if (!isUpdateSucceed)
       throw new HttpException(

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -356,7 +356,7 @@ export default class ActivityService {
       ],
     });
     const shouldResetProfessorApproval = availableDeadlines.some(deadline => {
-      const deadlineEnum = deadline.deadlineEnum;
+      const { deadlineEnum } = deadline;
       const writingDeadlineEnum = ActivityDeadlineEnum.Writing;
 
       return deadlineEnum === writingDeadlineEnum;

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -355,12 +355,9 @@ export default class ActivityService {
         // ActivityDeadlineEnum.Exception,
       ],
     });
-    const shouldResetProfessorApproval = availableDeadlines.some(deadline => {
-      const { deadlineEnum } = deadline;
-      const writingDeadlineEnum = ActivityDeadlineEnum.Writing;
-
-      return deadlineEnum === writingDeadlineEnum;
-    });
+    const shouldResetProfessorApproval = availableDeadlines.some(
+      deadline => deadline.deadlineEnum === ActivityDeadlineEnum.Writing,
+    );
     // 해당 활동이 지난 활동기간에 대한 활동인지 확인합니다.
     const activityD = await this.activityDurationPublicService.load();
     if (activity.activityDuration.id !== activityD.id)

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -355,9 +355,12 @@ export default class ActivityService {
         // ActivityDeadlineEnum.Exception,
       ],
     });
-    const shouldResetProfessorApproval = availableDeadlines.some(
-      deadline => deadline.deadlineEnum === ActivityDeadlineEnum.Writing,
-    );
+    const shouldResetProfessorApproval = availableDeadlines.some(deadline => {
+      const deadlineEnum = deadline.deadlineEnum;
+      const writingDeadlineEnum = ActivityDeadlineEnum.Writing;
+
+      return deadlineEnum === writingDeadlineEnum;
+    });
     // 해당 활동이 지난 활동기간에 대한 활동인지 확인합니다.
     const activityD = await this.activityDurationPublicService.load();
     if (activity.activityDuration.id !== activityD.id)

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -347,14 +347,16 @@ export default class ActivityService {
       clubId: activity.club.id,
     });
     // 오늘이 활동보고서 작성기간이거나, 수정 작성기간인지 확인합니다.
-    const availableDeadlines = await this.activityDeadlinePublicService.search({
-      date: new Date(),
-      deadlineEnum: [
-        ActivityDeadlineEnum.Writing,
-        ActivityDeadlineEnum.Modification,
-        // ActivityDeadlineEnum.Exception,
-      ],
-    });
+    const availableDeadlines = await this.activityDeadlinePublicService
+      .search({
+        date: new Date(),
+        deadlineEnum: [
+          ActivityDeadlineEnum.Writing,
+          ActivityDeadlineEnum.Modification,
+          // ActivityDeadlineEnum.Exception,
+        ],
+      })
+      .then(takeExist());
     const shouldResetProfessorApproval = availableDeadlines.some(
       deadline => deadline.deadlineEnum === ActivityDeadlineEnum.Writing,
     );

--- a/packages/web/src/features/activity-report/components/ActivityApprovalStatusTag.tsx
+++ b/packages/web/src/features/activity-report/components/ActivityApprovalStatusTag.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+import { ActivityStatusEnum } from "@clubs/interface/common/enum/activity.enum";
+
+import Tag from "@sparcs-clubs/web/common/components/Tag";
+import { ApplyTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import ProfessorApprovalEnum, {
+  getProfessorApprovalLabel,
+  getProfessorApprovalTagColor,
+} from "@sparcs-clubs/web/types/professorApproval";
+import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
+
+type ActivityApprovalStatusTagProps =
+  | {
+      type: "executive";
+      status: number;
+      width?: string;
+    }
+  | {
+      type: "professor";
+      status: ProfessorApprovalEnum | null;
+      width?: string;
+    };
+
+const ActivityApprovalStatusTag: React.FC<ActivityApprovalStatusTagProps> = ({
+  type,
+  status,
+  width = "fit-content",
+}) => {
+  if (type === "professor") {
+    if (status === null) {
+      return (
+        <Tag color="GRAY" width={width}>
+          -
+        </Tag>
+      );
+    }
+
+    return (
+      <Tag color={getProfessorApprovalTagColor(status)} width={width}>
+        {getProfessorApprovalLabel(status)}
+      </Tag>
+    );
+  }
+
+  const { color, text } = getTagDetail(
+    status as ActivityStatusEnum,
+    ApplyTagList,
+  );
+
+  return (
+    <Tag color={color} width={width}>
+      {text}
+    </Tag>
+  );
+};
+
+export default ActivityApprovalStatusTag;

--- a/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
@@ -13,9 +13,9 @@ import { ActTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import ActivityApprovalStatusTag from "./ActivityApprovalStatusTag";
 import useGetCurrentActivityReportList from "../hooks/useGetCurrentActivityReportList";
 import { ActivityReportTableData } from "../types/table";
+import ActivityApprovalStatusTag from "./ActivityApprovalStatusTag";
 
 interface CurrentActivityReportTableProps {
   clubId: number;

--- a/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
@@ -9,15 +9,11 @@ import React from "react";
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import {
-  ActTypeTagList,
-  ApplyTagList,
-  ProfessorApprovalTagList,
-} from "@sparcs-clubs/web/constants/tableTagList";
-import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
+import { ActTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
+import ActivityApprovalStatusTag from "./ActivityApprovalStatusTag";
 import useGetCurrentActivityReportList from "../hooks/useGetCurrentActivityReportList";
 import { ActivityReportTableData } from "../types/table";
 
@@ -27,29 +23,28 @@ interface CurrentActivityReportTableProps {
 
 const columnHelper = createColumnHelper<ActivityReportTableData>();
 const columns = [
-  columnHelper.accessor("activityStatusEnumId", {
-    header: "상태",
-    cell: info => {
-      const { color, text } = getTagDetail(info.getValue(), ApplyTagList);
-      return <Tag color={color}>{text}</Tag>;
-    },
-    size: 0,
-  }),
   columnHelper.accessor("professorApproval", {
     id: "professorApproval",
-    header: "지도교수",
-    cell: info => {
-      if (info.getValue() === null) {
-        return "-";
-      }
-
-      const { color, text } = getTagDetail(
-        info.getValue() as ProfessorApprovalEnum,
-        ProfessorApprovalTagList,
-      );
-      return <Tag color={color}>{text}</Tag>;
-    },
-    size: 0,
+    header: "지도교수 승인",
+    cell: info => (
+      <ActivityApprovalStatusTag
+        type="professor"
+        status={info.getValue()}
+        width="64px"
+      />
+    ),
+    size: 110,
+  }),
+  columnHelper.accessor("activityStatusEnumId", {
+    header: "집행부 승인",
+    cell: info => (
+      <ActivityApprovalStatusTag
+        type="executive"
+        status={info.getValue()}
+        width="64px"
+      />
+    ),
+    size: 110,
   }),
   columnHelper.accessor("name", {
     id: "activity",

--- a/packages/web/src/features/activity-report/components/professor/ProfessorActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/professor/ProfessorActivityReportTable.tsx
@@ -15,11 +15,7 @@ import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/C
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import {
-  ActTypeTagList,
-  ApplyTagList,
-  ProfessorApprovalTagList,
-} from "@sparcs-clubs/web/constants/tableTagList";
+import { ActTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
 import useGetProfessorActivityReportList from "@sparcs-clubs/web/features/activity-report/hooks/useGetProfessorActivityReportList";
 import usePostProfessorApproveActivityReport from "@sparcs-clubs/web/features/activity-report/services/useProfessorApproveActivityReport";
 import { ProfessorActivityReportTableData } from "@sparcs-clubs/web/features/activity-report/types/table";
@@ -27,31 +23,25 @@ import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 import { formatDate } from "@sparcs-clubs/web/utils/Date/formatDate";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
+import ActivityApprovalStatusTag from "../ActivityApprovalStatusTag";
+
 interface ProfessorActivityReportTableProps {
   clubId: number;
 }
 
 const columnHelper = createColumnHelper<ProfessorActivityReportTableData>();
 const columns = [
-  columnHelper.accessor("activityStatusEnumId", {
-    header: "상태",
-    cell: info => {
-      const { color, text } = getTagDetail(info.getValue(), ApplyTagList);
-      return <Tag color={color}>{text}</Tag>;
-    },
-    size: 0,
-  }),
   columnHelper.accessor("professorApproval", {
     id: "professorApproval",
-    header: "지도교수",
-    cell: info => {
-      const { color, text } = getTagDetail(
-        info.getValue(),
-        ProfessorApprovalTagList,
-      );
-      return <Tag color={color}>{text}</Tag>;
-    },
-    size: 0,
+    header: "지도교수 승인",
+    cell: info => (
+      <ActivityApprovalStatusTag
+        type="professor"
+        status={info.getValue()}
+        width="64px"
+      />
+    ),
+    size: 110,
   }),
   columnHelper.accessor("name", {
     id: "activity",

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -17,19 +17,15 @@ import List from "@sparcs-clubs/web/common/components/List";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
-import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
 import { Profile } from "@sparcs-clubs/web/common/providers/AuthContext";
 import { getActivityTypeLabel } from "@sparcs-clubs/web/types/activityType";
-import {
-  getProfessorApprovalLabel,
-  getProfessorApprovalTagColor,
-} from "@sparcs-clubs/web/types/professorApproval";
 import {
   formatDate,
   formatDotDetailDate,
 } from "@sparcs-clubs/web/utils/Date/formatDate";
 
+import ActivityApprovalStatusTag from "../components/ActivityApprovalStatusTag";
 import ActivityReportStatusSection from "../components/ActivityReportStatusSection";
 import ExecutiveActivityReportApprovalSection from "../components/ExecutiveActivityReportApprovalSection";
 import useGetActivityReportDetail from "../hooks/useGetActivityReportDetail";
@@ -213,12 +209,14 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
       <FlexWrapper direction="column" gap={40} style={{ alignSelf: "stretch" }}>
         <Card outline padding="32px" gap={20}>
           {(isProgressVisible || isOperatingCommittee) && (
-            <ActivityReportStatusSection
-              status={data.activityStatusEnumId}
-              editedAt={data.editedAt}
-              commentedAt={data.commentedAt ?? undefined}
-              comments={data.comments?.toReversed()}
-            />
+            <ActivitySection label="집행부 승인 상태">
+              <ActivityReportStatusSection
+                status={data.activityStatusEnumId}
+                editedAt={data.editedAt}
+                commentedAt={data.commentedAt ?? undefined}
+                comments={data.comments?.toReversed()}
+              />
+            </ActivitySection>
           )}
 
           <ActivitySection label="활동 정보">
@@ -284,17 +282,7 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
             />
           </ActivitySection>
           {data.professorApproval !== null && (
-            <FlexWrapper
-              direction="row"
-              gap={16}
-              justify="space-between"
-              style={{
-                alignItems: "center",
-                alignSelf: "stretch",
-                width: "100%",
-              }}
-            >
-              <ActivitySection label="지도교수 승인" />
+            <ActivitySection label="지도교수 승인 상태">
               <FlexWrapper
                 direction="row"
                 gap={8}
@@ -305,13 +293,13 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
                     {formatDotDetailDate(data.professorApprovedAt)}
                   </Typography>
                 )}
-                <Tag
-                  color={getProfessorApprovalTagColor(data.professorApproval)}
-                >
-                  {getProfessorApprovalLabel(data.professorApproval)}
-                </Tag>
+                <ActivityApprovalStatusTag
+                  type="professor"
+                  status={data.professorApproval}
+                  width="64px"
+                />
               </FlexWrapper>
-            </FlexWrapper>
+            </ActivitySection>
           )}
         </Card>
 

--- a/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
@@ -4,10 +4,10 @@ import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
 
 import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
 import useHasAdvisor from "@sparcs-clubs/web/features/clubs/hooks/useHasAdvisor";
-import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 
 import { useGetActivityReport } from "../services/useGetActivityReport";
 import { CurrentActivityReport } from "../types/activityReport";
+import getProfessorApprovalStatus from "../utils/getProfessorApprovalStatus";
 
 const useGetActivityReportDetail = (
   activityId: number,
@@ -55,17 +55,10 @@ const useGetActivityReportDetail = (
         name: participant.name,
         studentNumber: participant.studentNumber.toString(),
       })),
-      professorApproval: (() => {
-        if (!hasProfessor) {
-          return null;
-        }
-
-        if (!activityReport.professorApprovedAt) {
-          return ProfessorApprovalEnum.Pending;
-        }
-
-        return ProfessorApprovalEnum.Approved;
-      })(),
+      professorApproval: getProfessorApprovalStatus({
+        hasProfessor,
+        professorApprovedAt: activityReport.professorApprovedAt,
+      }),
       professorApprovedAt:
         activityReport.professorApprovedAt !== null
           ? activityReport.professorApprovedAt

--- a/packages/web/src/features/activity-report/hooks/useGetCurrentActivityReportList.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetCurrentActivityReportList.ts
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 
 import useHasAdvisor from "@sparcs-clubs/web/features/clubs/hooks/useHasAdvisor";
-import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 
 import useGetNewActivityReportList from "../services/useGetNewActivityReportList";
 import { ActivityReportTableData } from "../types/table";
+import getProfessorApprovalStatus from "../utils/getProfessorApprovalStatus";
 
 const useGetCurrentActivityReportList = (
   clubId: number,
@@ -37,14 +37,10 @@ const useGetCurrentActivityReportList = (
     return activityReportList.map(activityReport => ({
       ...activityReport,
       hasProfessor,
-      professorApproval: (() => {
-        if (!hasProfessor) {
-          return null;
-        }
-        return activityReport.professorApprovedAt !== null
-          ? ProfessorApprovalEnum.Approved
-          : ProfessorApprovalEnum.Pending;
-      })(),
+      professorApproval: getProfessorApprovalStatus({
+        hasProfessor,
+        professorApprovedAt: activityReport.professorApprovedAt,
+      }),
     }));
   }, [activityReportList, isLoading, isError, hasProfessor]);
 

--- a/packages/web/src/features/activity-report/hooks/useGetProfessorActivityReportList.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetProfessorActivityReportList.ts
@@ -4,6 +4,7 @@ import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 
 import useGetProfessorCurrentActivityReportList from "../services/useGetProfessorCurrentActivityReportList";
 import { ProfessorActivityReportTableData } from "../types/table";
+import getProfessorApprovalStatus from "../utils/getProfessorApprovalStatus";
 
 const useGetProfessorActivityReportList = (
   clubId: number,
@@ -28,9 +29,9 @@ const useGetProfessorActivityReportList = (
     return activityReportList.map(activityReport => ({
       ...activityReport,
       professorApproval:
-        activityReport.professorApprovedAt !== null
-          ? ProfessorApprovalEnum.Approved
-          : ProfessorApprovalEnum.Pending,
+        getProfessorApprovalStatus({
+          professorApprovedAt: activityReport.professorApprovedAt,
+        }) ?? ProfessorApprovalEnum.Pending,
     }));
   }, [activityReportList, isLoading, isError]);
 

--- a/packages/web/src/features/activity-report/hooks/useGetProfessorActivityReportList.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetProfessorActivityReportList.ts
@@ -1,7 +1,5 @@
 import { useMemo } from "react";
 
-import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
-
 import useGetProfessorCurrentActivityReportList from "../services/useGetProfessorCurrentActivityReportList";
 import { ProfessorActivityReportTableData } from "../types/table";
 import getProfessorApprovalStatus from "../utils/getProfessorApprovalStatus";
@@ -28,10 +26,9 @@ const useGetProfessorActivityReportList = (
 
     return activityReportList.map(activityReport => ({
       ...activityReport,
-      professorApproval:
-        getProfessorApprovalStatus({
-          professorApprovedAt: activityReport.professorApprovedAt,
-        }) ?? ProfessorApprovalEnum.Pending,
+      professorApproval: getProfessorApprovalStatus({
+        professorApprovedAt: activityReport.professorApprovedAt,
+      }),
     }));
   }, [activityReportList, isLoading, isError]);
 

--- a/packages/web/src/features/activity-report/utils/getProfessorApprovalStatus.ts
+++ b/packages/web/src/features/activity-report/utils/getProfessorApprovalStatus.ts
@@ -1,0 +1,21 @@
+import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
+
+interface GetProfessorApprovalStatusParam {
+  hasProfessor?: boolean;
+  professorApprovedAt?: Date | string | null;
+}
+
+const getProfessorApprovalStatus = ({
+  hasProfessor = true,
+  professorApprovedAt,
+}: GetProfessorApprovalStatusParam): ProfessorApprovalEnum | null => {
+  if (!hasProfessor) {
+    return null;
+  }
+
+  return professorApprovedAt
+    ? ProfessorApprovalEnum.Approved
+    : ProfessorApprovalEnum.Pending;
+};
+
+export default getProfessorApprovalStatus;

--- a/packages/web/src/features/activity-report/utils/getProfessorApprovalStatus.ts
+++ b/packages/web/src/features/activity-report/utils/getProfessorApprovalStatus.ts
@@ -1,14 +1,24 @@
 import ProfessorApprovalEnum from "@sparcs-clubs/web/types/professorApproval";
 
-interface GetProfessorApprovalStatusParam {
-  hasProfessor?: boolean;
+interface GetProfessorApprovalStatusBaseParam {
   professorApprovedAt?: Date | string | null;
 }
 
-const getProfessorApprovalStatus = ({
+function getProfessorApprovalStatus(
+  param: GetProfessorApprovalStatusBaseParam & { hasProfessor: false },
+): null;
+function getProfessorApprovalStatus(
+  param: GetProfessorApprovalStatusBaseParam & { hasProfessor?: true },
+): ProfessorApprovalEnum;
+function getProfessorApprovalStatus(
+  param: GetProfessorApprovalStatusBaseParam & { hasProfessor: boolean },
+): ProfessorApprovalEnum | null;
+function getProfessorApprovalStatus({
   hasProfessor = true,
   professorApprovedAt,
-}: GetProfessorApprovalStatusParam): ProfessorApprovalEnum | null => {
+}: GetProfessorApprovalStatusBaseParam & {
+  hasProfessor?: boolean;
+}): ProfessorApprovalEnum | null {
   if (!hasProfessor) {
     return null;
   }
@@ -16,6 +26,6 @@ const getProfessorApprovalStatus = ({
   return professorApprovedAt
     ? ProfessorApprovalEnum.Approved
     : ProfessorApprovalEnum.Pending;
-};
+}
 
 export default getProfessorApprovalStatus;

--- a/scripts/check-format-changed.mjs
+++ b/scripts/check-format-changed.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const baseRef = process.env.FORMAT_CHECK_BASE ?? "origin/dev";
+
+const diff = spawnSync(
+  "git",
+  ["diff", "--name-only", "--diff-filter=ACMRT", baseRef, "--"],
+  {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  },
+);
+
+if (diff.status !== 0) {
+  process.exitCode = diff.status ?? 1;
+  process.exit();
+}
+
+const files = diff.stdout
+  .split("\n")
+  .map(file => file.trim())
+  .filter(Boolean)
+  .filter(file => fs.existsSync(file));
+
+if (files.length === 0) {
+  console.log(`No changed files to format-check against ${baseRef}.`);
+  process.exit();
+}
+
+const result = spawnSync(
+  "pnpm",
+  ["exec", "prettier", "--check", "--ignore-unknown", ...files],
+  {
+    stdio: "inherit",
+  },
+);
+
+process.exitCode = result.status ?? 1;


### PR DESCRIPTION
## Summary
- 활동보고서 수정 시 작성기간에는 지도교수 승인을 초기화하고, 수정기간에는 기존 승인 값을 건드리지 않도록 수정했습니다.
- 대표자 화면에서는 지도교수 승인 상태와 집행부 승인 상태를 함께 표시하고, 지도교수 화면에서는 지도교수 승인 상태만 표시하도록 분리했습니다.
- pre-push에서 변경 파일 포맷, 전체 lint, 서버 MC/DC changed 체크를 함께 실행하도록 보강했습니다.
- `mcdc:changed` 단일 조건 감지는 property access 계측과 lint 규칙 충돌이 있어 이번 PR에서는 보류하고, TU-435 후속 태스크에 기록했습니다.

## Test
- `pnpm format:check:changed`
- `pnpm lint`
- `TEST_DATABASE_URL=mysql://root:test_password_123@127.0.0.1:3307/clubs_test pnpm --filter api test:unit -- --runTestsByPath src/feature/activity/service/activity.service.new.spec.ts`
- `pnpm --filter @clubs/domain build && pnpm --filter @clubs/interface build && pnpm --filter api build`
- `pnpm --filter web build`
- `pnpm mcdc:changed --fail-on-missing`

## Follow-up
- TU-435: MCDC 개선 - 타입 시스템 연동 추가
  - TypeScript 타입 시스템 연동
  - enum/property access safe 판정
  - level 1 MC/DC 적용 시 lint 규칙과 충돌하지 않는 instrumentation 전략 검토

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text:
- 활동보고서 수정 기간에는 지도교수 승인 상태가 유지되도록 수정했습니다.
- 활동보고서 화면에서 지도교수 승인 상태와 집행부 승인 상태를 구분해 볼 수 있도록 개선했습니다.
<!-- clubs:patch-note:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced activity approval status display with improved visual consistency across activity report tables and detail views.

* **Tests**
  * Added comprehensive test coverage for activity approval state management during activity edits.

* **Chores**
  * Introduced automatic formatting checks to the pre-push Git hook.
  * Added new format validation script.
  * Refactored internal approval status computation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->