### PR TITLE
[TU-434] Prisma raw SQL 변경 검증기 추가

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,4 +5,5 @@ if [ -d "$NVM_DIR/versions/node/$NODE_VER/bin" ]; then
   export PATH="$NVM_DIR/versions/node/$NODE_VER/bin:$PATH"
 fi
 
+pnpm prisma-query:changed
 pnpm mcdc:changed --fail-on-missing

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mcdc": "node scripts/mcdc/cli.mjs",
     "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 2",
     "mcdc:jest": "node scripts/mcdc/jest-runner.mjs",
+    "prisma-query:changed": "node scripts/prisma-query-guard/changed-raw-sql.mjs --changed-from origin/dev",
     "start": "turbo run start",
     "clean": "turbo run clean",
     "lint": "turbo run lint",
@@ -31,7 +32,12 @@
     "prepare": "husky",
     "test": "turbo run test --filter=api",
     "test:mcdc": "node --test scripts/mcdc/*.test.mjs",
+    "test:prisma-query-guard": "node --test scripts/prisma-query-guard/*.test.mjs",
     "test:api": "turbo run test --filter=api"
+  },
+  "_scriptComments": {
+    "prisma-query:changed": "Pre-push validator. Blocks Prisma raw SQL APIs on changed packages/api/src lines while allowing untouched brownfield raw SQL debt.",
+    "test:prisma-query-guard": "Node test fixtures for the changed-line Prisma raw SQL guard."
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,css,scss,md,mdx,yml,yaml}": [

--- a/packages/api/src/feature/club/repository-old/club.club-room-t.repository.spec.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-room-t.repository.spec.ts
@@ -1,0 +1,65 @@
+import { ClubRoomTRepository } from "./club.club-room-t.repository";
+
+describe("ClubRoomTRepository", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("findClubLocationById", () => {
+    it("finds the latest current club room with Prisma Query API", async () => {
+      const now = new Date("2026-06-02T12:00:00.000Z");
+      jest.useFakeTimers().setSystemTime(now);
+
+      const prisma = {
+        clubRoomT: {
+          findFirst: jest.fn().mockResolvedValue({
+            roomLocation: "301",
+            clubBuildingRel: { buildingName: "N1" },
+          }),
+        },
+      };
+      const repository = new ClubRoomTRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ClubRoomTRepository
+        >[0],
+      );
+
+      const result = await repository.findClubLocationById(10);
+
+      expect(prisma.clubRoomT.findFirst).toHaveBeenCalledWith({
+        where: {
+          clubId: 10,
+          startTerm: { lte: now },
+          OR: [{ endTerm: { gte: now } }, { endTerm: null }],
+        },
+        orderBy: { createdAt: "desc" },
+        select: {
+          roomLocation: true,
+          clubBuildingRel: {
+            select: { buildingName: true },
+          },
+        },
+      });
+      expect(result).toEqual({ room: "301", buildingName: "N1" });
+    });
+
+    it("returns null when no current club room exists", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-06-02T12:00:00.000Z"));
+
+      const prisma = {
+        clubRoomT: {
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+      };
+      const repository = new ClubRoomTRepository(
+        prisma as unknown as ConstructorParameters<
+          typeof ClubRoomTRepository
+        >[0],
+      );
+
+      const result = await repository.findClubLocationById(10);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
@@ -1,7 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Prisma } from "@prisma/client";
 
-import { takeOne } from "@sparcs-clubs/api/common/util/util";
 import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 @Injectable()
@@ -10,20 +8,28 @@ export class ClubRoomTRepository {
 
   async findClubLocationById(
     clubId: number,
-  ): Promise<{ room: string; buildingName: string }> {
-    const roomDetails = await this.prisma.$queryRaw<
-      Array<{ room: string | null; buildingName: string | null }>
-    >(Prisma.sql`
-      SELECT crt.room_location AS room, cbe.building_name AS buildingName
-      FROM club_room_t crt
-      LEFT JOIN club_building_enum cbe ON crt.club_building_enum = cbe.id
-      WHERE crt.club_id = ${clubId}
-        AND crt.start_term <= NOW()
-        AND (crt.end_term >= NOW() OR crt.end_term IS NULL)
-      ORDER BY crt.created_at DESC
-      LIMIT 1
-    `);
+  ): Promise<{ room: string | null; buildingName: string | null } | null> {
+    const now = new Date();
+    const roomDetails = await this.prisma.clubRoomT.findFirst({
+      where: {
+        clubId,
+        startTerm: { lte: now },
+        OR: [{ endTerm: { gte: now } }, { endTerm: null }],
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        roomLocation: true,
+        clubBuildingRel: {
+          select: { buildingName: true },
+        },
+      },
+    });
 
-    return takeOne(roomDetails);
+    return roomDetails
+      ? {
+          room: roomDetails.roomLocation,
+          buildingName: roomDetails.clubBuildingRel.buildingName,
+        }
+      : null;
   }
 }

--- a/scripts/prisma-query-guard/README.md
+++ b/scripts/prisma-query-guard/README.md
@@ -1,0 +1,67 @@
+# Prisma Query Guard
+
+`prisma-query-guard` prevents newly touched API production code from adding or editing Prisma raw SQL. It is intentionally line-based because this repo still has brownfield raw SQL debt: unchanged legacy raw SQL can remain while newly changed lines must move toward Prisma Client Query API.
+
+## Usage
+
+```sh
+pnpm prisma-query:changed
+```
+
+By default, the script compares the current branch against `origin/dev`.
+
+```sh
+node scripts/prisma-query-guard/changed-raw-sql.mjs --changed-from origin/dev
+```
+
+The pre-push hook runs this guard before MC/DC validation.
+
+## Scope
+
+The default source scope is `packages/api/src`.
+
+The guard checks production TypeScript files only:
+
+- included: `packages/api/src/**/*.ts`
+- excluded: `*.spec.ts`, `*.test.ts`
+- excluded by omission: `packages/api/test/**`, `packages/api/legacy_source/**`
+
+## Detected Raw SQL APIs
+
+The detector uses the TypeScript AST and reports these APIs:
+
+- `$queryRaw`
+- `$queryRawUnsafe`
+- `$executeRaw`
+- `$executeRawUnsafe`
+- `Prisma.sql`
+- `Prisma.raw`
+- `Prisma.join`
+- `Prisma.empty`
+
+## Change Detection
+
+The script:
+
+1. Resolves `git merge-base <changed-from> HEAD`.
+2. Reads `git diff --unified=0 --no-color --diff-filter=ACMR <base> -- packages/api/src`.
+3. Parses hunk headers and changed lines.
+4. Parses the current file AST and records raw SQL node line ranges.
+5. Fails when a raw SQL node overlaps an added or modified line.
+6. For deletion-only hunks, parses the base file AST too. If the deleted old line was inside raw SQL and the current raw SQL node still surrounds the deletion touch point, it fails.
+
+This means deleting a whole raw SQL block in favor of Prisma Query API passes, but editing a raw SQL block while leaving it in place fails.
+
+## Pass And Fail Examples
+
+Pass: a file has existing raw SQL, but only a different non-raw line changed.
+
+Pass: raw SQL is fully removed and replaced with `prisma.club.findMany(...)`.
+
+Fail: new `$queryRaw(...)` or `Prisma.sql` is added.
+
+Fail: a SQL line is deleted from inside an existing `Prisma.sql` template, but the template still remains.
+
+## Policy
+
+There is no allowlist or inline disable comment on purpose. If raw SQL becomes necessary later, add the policy first with a clear reason and tests.

--- a/scripts/prisma-query-guard/changed-raw-sql.mjs
+++ b/scripts/prisma-query-guard/changed-raw-sql.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  findPrismaRawSqlNodes,
+  isLineInsideRawSqlNode,
+} from "./raw-sql-detector.mjs";
+
+const DEFAULT_CHANGED_FROM = "origin/dev";
+const DEFAULT_SOURCE = "packages/api/src";
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const baseRef = resolveBaseRef(args.changedFrom, repoRoot);
+  const diffText = readDiff({
+    baseRef,
+    repoRoot,
+    sourcePaths: args.sources,
+  });
+  const changedFiles = parseChangedFileLineMap(diffText);
+  const violations = findChangedRawSqlViolations({
+    baseRef,
+    changedFiles,
+    repoRoot,
+  });
+
+  if (violations.length === 0) {
+    console.log(
+      `No Prisma raw SQL changes found relative to ${args.changedFrom}.`,
+    );
+    return;
+  }
+
+  console.error(formatViolations(violations));
+  process.exitCode = 1;
+}
+
+export function findChangedRawSqlViolations({
+  baseRef,
+  changedFiles,
+  repoRoot = process.cwd(),
+}) {
+  const violations = [];
+
+  for (const changedFile of changedFiles) {
+    if (!isApiProductionTypeScriptFile(changedFile.path)) {
+      continue;
+    }
+
+    const currentPath = path.resolve(repoRoot, changedFile.path);
+
+    if (!fs.existsSync(currentPath)) {
+      continue;
+    }
+
+    const currentSourceText = fs.readFileSync(currentPath, "utf8");
+    const currentAnalysis = findPrismaRawSqlNodes(
+      currentSourceText,
+      currentPath,
+    );
+
+    if (currentAnalysis.parseError) {
+      violations.push({
+        filePath: changedFile.path,
+        line: currentAnalysis.parseError.line,
+        column: currentAnalysis.parseError.column,
+        detected: "TypeScript parse error",
+        reason: currentAnalysis.parseError.message,
+      });
+      continue;
+    }
+
+    const baseRawNodes = analyzeBaseRawSqlNodes({
+      baseRef,
+      repoRoot,
+      sourcePath: changedFile.path,
+    });
+
+    for (const rawNode of currentAnalysis.nodes) {
+      if (lineRangesOverlapAny(rawNode, changedFile.addedRanges)) {
+        violations.push({
+          filePath: changedFile.path,
+          line: rawNode.line,
+          column: rawNode.column,
+          detected: rawNode.detected,
+          reason: "raw SQL API overlaps an added or modified line",
+        });
+        continue;
+      }
+
+      const touchedByDeletedRawLine = changedFile.deletedLines.some(
+        deletedLine =>
+          isLineInsideRawSqlNode(deletedLine.oldLine, baseRawNodes) &&
+          isDeletionTouchingNode(deletedLine, rawNode),
+      );
+
+      if (touchedByDeletedRawLine) {
+        violations.push({
+          filePath: changedFile.path,
+          line: rawNode.line,
+          column: rawNode.column,
+          detected: rawNode.detected,
+          reason: "deleted line modified a raw SQL block that still remains",
+        });
+      }
+    }
+  }
+
+  return violations.sort(
+    (left, right) =>
+      left.filePath.localeCompare(right.filePath) ||
+      left.line - right.line ||
+      left.column - right.column,
+  );
+}
+
+export function parseChangedFileLineMap(diffText) {
+  const files = new Map();
+  let currentFile = null;
+  let oldLine = 0;
+  let newLine = 0;
+  let insideHunk = false;
+
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      currentFile = null;
+      insideHunk = false;
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      currentFile = parseNewFilePath(line);
+      insideHunk = false;
+
+      if (currentFile && !files.has(currentFile)) {
+        files.set(currentFile, {
+          path: currentFile,
+          addedRanges: [],
+          deletedLines: [],
+        });
+      }
+      continue;
+    }
+
+    const hunk = line.match(
+      /^@@ -(?<oldStart>\d+)(?:,(?<oldCount>\d+))? \+(?<newStart>\d+)(?:,(?<newCount>\d+))? @@/u,
+    );
+
+    if (hunk) {
+      oldLine = Number(hunk.groups.oldStart);
+      newLine = Number(hunk.groups.newStart);
+      insideHunk = true;
+      continue;
+    }
+
+    if (!insideHunk || !currentFile) {
+      continue;
+    }
+
+    const file = files.get(currentFile);
+
+    if (line.startsWith("+")) {
+      addLineRange(file.addedRanges, newLine, newLine);
+      newLine += 1;
+    } else if (line.startsWith("-")) {
+      file.deletedLines.push({
+        oldLine,
+        previousLine: newLine - 1,
+        nextLine: newLine,
+      });
+      oldLine += 1;
+    } else if (line.startsWith(" ")) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return [...files.values()].filter(
+    file => file.addedRanges.length > 0 || file.deletedLines.length > 0,
+  );
+}
+
+function analyzeBaseRawSqlNodes({ baseRef, repoRoot, sourcePath }) {
+  const sourceText = readFileAtRef(baseRef, sourcePath, repoRoot);
+
+  if (sourceText === null) {
+    return [];
+  }
+
+  const analysis = findPrismaRawSqlNodes(
+    sourceText,
+    path.resolve(repoRoot, sourcePath),
+  );
+
+  return analysis.parseError ? [] : analysis.nodes;
+}
+
+function resolveBaseRef(changedFrom, repoRoot) {
+  try {
+    return execFileSync("git", ["merge-base", changedFrom, "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    throw new Error(
+      `Could not resolve merge-base for ${changedFrom}. Run 'git fetch origin dev' and try again.`,
+      { cause: error },
+    );
+  }
+}
+
+function readDiff({ baseRef, repoRoot, sourcePaths }) {
+  const args = [
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--diff-filter=ACMR",
+    baseRef,
+    "--",
+    ...sourcePaths,
+  ];
+
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+}
+
+function readFileAtRef(ref, filePath, cwd) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${filePath}`], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function lineRangesOverlapAny(rawNode, ranges) {
+  return ranges.some(
+    range =>
+      rawNode.startLine <= range.endLine && range.startLine <= rawNode.endLine,
+  );
+}
+
+function isDeletionTouchingNode(deletedLine, rawNode) {
+  return (
+    isLineInsideRange(deletedLine.previousLine, rawNode) ||
+    isLineInsideRange(deletedLine.nextLine, rawNode)
+  );
+}
+
+function isLineInsideRange(line, range) {
+  return range.startLine <= line && line <= range.endLine;
+}
+
+function addLineRange(ranges, startLine, endLine) {
+  const lastRange = ranges[ranges.length - 1];
+
+  if (lastRange && lastRange.endLine + 1 === startLine) {
+    lastRange.endLine = endLine;
+    return;
+  }
+
+  ranges.push({ startLine, endLine });
+}
+
+function parseNewFilePath(line) {
+  const filePath = line.slice("+++ ".length).trim();
+
+  if (filePath === "/dev/null") {
+    return null;
+  }
+
+  return filePath.startsWith("b/") ? filePath.slice(2) : filePath;
+}
+
+function isApiProductionTypeScriptFile(filePath) {
+  return (
+    toPosixPath(filePath).startsWith("packages/api/src/") &&
+    /\.ts$/u.test(filePath) &&
+    !/\.(?:spec|test)\.ts$/u.test(filePath)
+  );
+}
+
+function formatViolations(violations) {
+  const lines = [
+    "Prisma raw SQL is not allowed in changed API source lines.",
+    "Use Prisma Client Query API instead of raw SQL.",
+    "",
+  ];
+
+  for (const violation of violations) {
+    lines.push(`${violation.filePath}:${violation.line}:${violation.column}`);
+    lines.push(`  detected: ${violation.detected}`);
+    lines.push(`  reason: ${violation.reason}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function parseArgs(argv) {
+  const args = {
+    changedFrom: DEFAULT_CHANGED_FROM,
+    sources: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--changed-from") {
+      args.changedFrom = readValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--source" || arg === "-s") {
+      args.sources.push(readValue(argv, index, arg));
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.sources.length === 0) {
+    args.sources.push(DEFAULT_SOURCE);
+  }
+
+  return args;
+}
+
+function readValue(argv, index, arg) {
+  const value = argv[index + 1];
+
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${arg} requires a value.`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm prisma-query:changed [options]
+
+Options:
+  --changed-from <ref>  Base branch/ref to compare against (default: origin/dev)
+  --source <path>       Source path to inspect (default: packages/api/src)
+  -h, --help            Show this help message
+`);
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/prisma-query-guard/changed-raw-sql.test.mjs
+++ b/scripts/prisma-query-guard/changed-raw-sql.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findChangedRawSqlViolations,
+  parseChangedFileLineMap,
+} from "./changed-raw-sql.mjs";
+
+const SOURCE_PATH = "packages/api/src/feature/example.repository.ts";
+
+test("passes when a non-raw line changes in a file with existing raw SQL", () => {
+  const workspace = makeGitWorkspace();
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  const rows = await prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+  \`);
+
+  return rows.length;
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  const rows = await prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+  \`);
+
+  return rows.length + 1;
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("fails when raw SQL is added", () => {
+  const workspace = makeGitWorkspace();
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  return prisma.club.findMany();
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  return prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+  \`);
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].detected, "prisma.$queryRaw");
+  assert.equal(
+    violations[0].reason,
+    "raw SQL API overlaps an added or modified line",
+  );
+});
+
+test("passes when a raw SQL block is removed", () => {
+  const workspace = makeGitWorkspace();
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  return prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+  \`);
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export async function list(prisma) {
+  return prisma.club.findMany();
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("fails when a deleted line edits a raw SQL block that remains", () => {
+  const workspace = makeGitWorkspace();
+  writeSource(
+    workspace,
+    `
+export async function list(prisma, clubId) {
+  return prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+    WHERE id = \${clubId}
+      AND deleted_at IS NULL
+  \`);
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export async function list(prisma, clubId) {
+  return prisma.$queryRaw(Prisma.sql\`
+    SELECT *
+    FROM club
+    WHERE id = \${clubId}
+  \`);
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].detected, "prisma.$queryRaw");
+  assert.equal(
+    violations[0].reason,
+    "deleted line modified a raw SQL block that still remains",
+  );
+});
+
+function runGuard(workspace) {
+  const diff = execFileSync(
+    "git",
+    ["diff", "--unified=0", "--no-color", "--diff-filter=ACMR", "HEAD", "--"],
+    { cwd: workspace, encoding: "utf8" },
+  );
+
+  return findChangedRawSqlViolations({
+    baseRef: "HEAD",
+    changedFiles: parseChangedFileLineMap(diff),
+    repoRoot: workspace,
+  });
+}
+
+function makeGitWorkspace() {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), "prisma-query-guard-"),
+  );
+
+  fs.mkdirSync(path.dirname(path.join(workspace, SOURCE_PATH)), {
+    recursive: true,
+  });
+
+  execFileSync("git", ["init"], { cwd: workspace, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: workspace,
+  });
+  execFileSync("git", ["config", "user.name", "Test User"], {
+    cwd: workspace,
+  });
+
+  return workspace;
+}
+
+function writeSource(workspace, sourceText) {
+  fs.writeFileSync(path.join(workspace, SOURCE_PATH), sourceText.trimStart());
+}
+
+function commitAll(workspace, message) {
+  execFileSync("git", ["add", "."], { cwd: workspace });
+  execFileSync("git", ["commit", "-m", message], {
+    cwd: workspace,
+    stdio: "ignore",
+  });
+}

--- a/scripts/prisma-query-guard/raw-sql-detector.mjs
+++ b/scripts/prisma-query-guard/raw-sql-detector.mjs
@@ -1,0 +1,171 @@
+import path from "node:path";
+
+import ts from "typescript";
+
+const RAW_CLIENT_METHODS = new Set([
+  "$executeRaw",
+  "$executeRawUnsafe",
+  "$queryRaw",
+  "$queryRawUnsafe",
+]);
+
+const RAW_PRISMA_MEMBERS = new Set(["empty", "join", "raw", "sql"]);
+
+export function findPrismaRawSqlNodes(sourceText, filePath) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath),
+  );
+
+  if (sourceFile.parseDiagnostics.length > 0) {
+    return {
+      nodes: [],
+      parseError: formatParseDiagnostic(
+        sourceFile,
+        sourceFile.parseDiagnostics[0],
+      ),
+    };
+  }
+
+  const nodes = [];
+  const seenRanges = new Set();
+
+  const recordNode = (node, detected) => {
+    const start = node.getStart(sourceFile);
+    const end = node.getEnd();
+    const key = `${start}:${end}:${detected}`;
+
+    if (seenRanges.has(key)) {
+      return;
+    }
+
+    seenRanges.add(key);
+
+    const startPosition = sourceFile.getLineAndCharacterOfPosition(start);
+    const endPosition = sourceFile.getLineAndCharacterOfPosition(
+      Math.max(start, end - 1),
+    );
+
+    nodes.push({
+      detected,
+      startOffset: start,
+      endOffset: end,
+      line: startPosition.line + 1,
+      column: startPosition.character + 1,
+      startLine: startPosition.line + 1,
+      endLine: endPosition.line + 1,
+      text: normalizeText(node.getText(sourceFile)),
+    });
+  };
+
+  const visit = node => {
+    if (ts.isCallExpression(node)) {
+      if (isRawClientMethodAccess(node.expression)) {
+        recordNode(node, node.expression.getText(sourceFile));
+      } else if (isPrismaRawMemberAccess(node.expression)) {
+        recordNode(node, node.expression.getText(sourceFile));
+      }
+    } else if (ts.isTaggedTemplateExpression(node)) {
+      if (isRawClientMethodAccess(node.tag)) {
+        recordNode(node, node.tag.getText(sourceFile));
+      } else if (isPrismaRawMemberAccess(node.tag)) {
+        recordNode(node, node.tag.getText(sourceFile));
+      }
+    } else if (
+      isPrismaRawMemberAccess(node) &&
+      !isHandledPrismaRawMemberAccess(node)
+    ) {
+      recordNode(node, node.getText(sourceFile));
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return {
+    nodes: filterContainedNodes(nodes).sort(
+      (left, right) => left.line - right.line || left.column - right.column,
+    ),
+    parseError: null,
+  };
+}
+
+function filterContainedNodes(nodes) {
+  return nodes.filter(
+    (node, index) =>
+      !nodes.some(
+        (other, otherIndex) =>
+          index !== otherIndex &&
+          other.startOffset <= node.startOffset &&
+          node.endOffset <= other.endOffset &&
+          (other.startOffset < node.startOffset ||
+            node.endOffset < other.endOffset),
+      ),
+  );
+}
+
+export function isLineInsideRawSqlNode(line, nodes) {
+  return nodes.some(node => node.startLine <= line && line <= node.endLine);
+}
+
+function isRawClientMethodAccess(node) {
+  return (
+    ts.isPropertyAccessExpression(node) &&
+    RAW_CLIENT_METHODS.has(node.name.text)
+  );
+}
+
+function isPrismaRawMemberAccess(node) {
+  return (
+    ts.isPropertyAccessExpression(node) &&
+    node.expression.getText(node.getSourceFile()) === "Prisma" &&
+    RAW_PRISMA_MEMBERS.has(node.name.text)
+  );
+}
+
+function isHandledPrismaRawMemberAccess(node) {
+  const { parent } = node;
+
+  return (
+    (ts.isCallExpression(parent) && parent.expression === node) ||
+    (ts.isTaggedTemplateExpression(parent) && parent.tag === node)
+  );
+}
+
+function getScriptKind(filePath) {
+  switch (path.extname(filePath)) {
+    case ".tsx":
+      return ts.ScriptKind.TSX;
+    case ".jsx":
+      return ts.ScriptKind.JSX;
+    case ".js":
+    case ".mjs":
+    case ".cjs":
+      return ts.ScriptKind.JS;
+    case ".json":
+      return ts.ScriptKind.JSON;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+function formatParseDiagnostic(sourceFile, diagnostic) {
+  const position = sourceFile.getLineAndCharacterOfPosition(
+    diagnostic.start ?? 0,
+  );
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+
+  return {
+    line: position.line + 1,
+    column: position.character + 1,
+    message,
+  };
+}
+
+function normalizeText(text) {
+  return text.replace(/\s+/gu, " ").trim();
+}


### PR DESCRIPTION
## Summary
- Notion: https://www.notion.so/372c25603b0b81f99d37dd3ffe120fe8
- Add a changed-line Prisma raw SQL guard for `packages/api/src` production TypeScript files.
- Wire the guard into `pre-push` before MC/DC validation.
- Document the guard policy and cover add/remove/delete-only raw SQL cases with Node tests.
- Convert `ClubRoomTRepository.findClubLocationById` from raw SQL to Prisma Query API as an end-to-end guard exercise.

## Test
- `pnpm test:prisma-query-guard`
- `TEST_DATABASE_URL=mysql://root:test_password_123@127.0.0.1:3307/clubs_test pnpm --filter api test:unit -- --runTestsByPath src/feature/club/repository-old/club.club-room-t.repository.spec.ts`
- `pnpm --filter api exec eslint src/feature/club/repository-old/club.club-room-t.repository.ts src/feature/club/repository-old/club.club-room-t.repository.spec.ts`
- `pnpm exec prettier --check package.json scripts/prisma-query-guard/README.md scripts/prisma-query-guard/*.mjs .husky/pre-push --ignore-unknown`
- `sh .husky/pre-push`
- `pnpm build:api`

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text: 사용자에게 직접 보이는 변경은 없습니다.
<!-- clubs:patch-note:end -->