### PR TITLE
[TU-438] fix duplicate comment toast keys

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -264,6 +264,7 @@ export default class ActivityService {
       activityStatusEnumId: activity.activityStatusEnum,
       comments: comments.map(e => ({
         // TODO?: status 추가하기?
+        id: e.id,
         content: e.content,
         createdAt: e.createdAt,
       })),
@@ -1161,6 +1162,7 @@ export default class ActivityService {
       })),
       activityStatusEnumId: activity.activityStatusEnum,
       comments: comments.map(e => ({
+        id: e.id,
         content: e.content,
         createdAt: e.createdAt,
       })),
@@ -1221,6 +1223,7 @@ export default class ActivityService {
       })),
       activityStatusEnumId: activity.activityStatusEnum,
       comments: comments.map(e => ({
+        id: e.id,
         content: e.content,
         createdAt: e.createdAt,
       })),

--- a/packages/interface/src/api/activity/endpoint/apiAct002.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct002.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { zActivity } from "@clubs/domain/activity/activity";
 import { zClub } from "@clubs/domain/club/club";
 
+import { zActivityCommentSummary } from "@clubs/interface/api/activity/type/activity.type";
 import { registry } from "@clubs/interface/open-api";
 
 const url = (activityId: number) =>
@@ -48,12 +49,7 @@ const responseBodyMap = {
     ),
     activityStatusEnumId: zActivity.shape.activityStatusEnum,
     // TODO: domain object로 교체
-    comments: z.array(
-      z.object({
-        content: z.string(),
-        createdAt: z.coerce.date(),
-      }),
-    ),
+    comments: z.array(zActivityCommentSummary),
     // TODO: domain object로 교체
     updatedAt: z.coerce.date(),
     // TODO: domain object로 교체

--- a/packages/web/src/common/components/Toast/CommentToast.tsx
+++ b/packages/web/src/common/components/Toast/CommentToast.tsx
@@ -11,6 +11,7 @@ import Typography from "../Typography";
 export type CommentToastColorType = { background: string; border: string };
 
 interface Reason {
+  id?: React.Key;
   datetime: Date;
   reason: React.ReactNode;
   status?: string;
@@ -99,11 +100,11 @@ const CommentToast: React.FC<CommentToastProps> = ({
           </Typography>
         </div>
         <div className="CommentToast-reasons">
-          {reasons.map(reason => (
+          {reasons.map((reason, index) => (
             <FlexWrapper
               direction="column"
               gap={4}
-              key={formatDotDetailDate(reason.datetime)}
+              key={reason.id ?? `${reason.datetime.getTime()}-${index}`}
             >
               <Typography fs={14} lh={16} fw="REGULAR" color="GRAY.600">
                 {formatDotDetailDate(reason.datetime)}{" "}

--- a/packages/web/src/features/activity-report/_mock/mock.ts
+++ b/packages/web/src/features/activity-report/_mock/mock.ts
@@ -274,6 +274,7 @@ export const mockActivityDetailData: ApiAct002ResponseOkTemp = {
   ],
   comments: [
     {
+      id: 1,
       content: "그냥 맘에 안듬",
       createdAt: new Date(),
     },

--- a/packages/web/src/features/activity-report/components/ActivityReportStatusSection.tsx
+++ b/packages/web/src/features/activity-report/components/ActivityReportStatusSection.tsx
@@ -30,6 +30,7 @@ const ActivityReportStatusSection: React.FC<
         <CommentToast
           title="코멘트"
           reasons={comments.map(comment => ({
+            id: comment.id,
             datetime: comment.createdAt,
             reason: comment.content,
           }))}
@@ -42,6 +43,7 @@ const ActivityReportStatusSection: React.FC<
       <CommentToast
         title="코멘트"
         reasons={comments.map(comment => ({
+          id: comment.id,
           datetime: comment.createdAt,
           reason: comment.content,
         }))}

--- a/packages/web/src/features/activity-report/services/useGetActivityReport.ts
+++ b/packages/web/src/features/activity-report/services/useGetActivityReport.ts
@@ -82,6 +82,7 @@ defineAxiosMock(mock => {
       activityStatusEnumId: ActivityStatusEnum.Rejected,
       comments: [
         {
+          id: 1,
           content: "그냥 맘에 안듬",
           createdAt: new Date(),
         },

--- a/packages/web/src/features/register-club/components/activity-report/EditActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/EditActivityReportModal.tsx
@@ -97,6 +97,7 @@ const EditActivityReportModal: React.FC<EditActivityReportModalProps> = ({
               <CommentToast
                 title="반려 사유"
                 reasons={filterActivityComments(data.comments).map(comment => ({
+                  id: comment.id,
                   datetime: comment.createdAt,
                   reason: comment.content,
                 }))}

--- a/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
@@ -209,6 +209,7 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
               <CommentToast
                 title="반려 사유"
                 reasons={data.comments.map(comment => ({
+                  id: comment.id,
                   datetime: comment.createdAt,
                   reason: comment.content,
                 }))}

--- a/packages/web/src/types/comment.ts
+++ b/packages/web/src/types/comment.ts
@@ -1,4 +1,5 @@
 export type Comment = {
+  id?: number;
   content: string;
   createdAt: Date;
 };


### PR DESCRIPTION
## Summary
- Include activity comment IDs in activity detail responses.
- Use comment IDs as CommentToast keys and keep a safe fallback for comments without IDs.

## Task Context
- Task ID: TU-438
- Notion: https://www.notion.so/373c25603b0b81ae9720cf633e7cbda9

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 활동보고서 코멘트가 같은 시간에 여러 개 등록되어도 화면에서 중복되거나 누락되지 않도록 수정했습니다.
<!-- clubs:patch-note:end -->

