### PR TITLE
[TU-401] 집행부 활동보고서 지도교수 승인 현황 표시

### DIFF
--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -633,6 +633,7 @@ model Activity {
   chargedExecutiveId   Int?      @map("charged_executive_id")
   professorApprovedAt  DateTime? @map("professor_approved_at") @db.Timestamp(0)
   commentedAt          DateTime? @map("commented_at") @db.Timestamp(0)
+  /// @deprecated Use the latest non-deleted `activity_feedback.executive_id` for the final reviewer.
   commentedExecutiveId Int?      @map("commented_executive_id")
   editedAt             DateTime  @default(now()) @map("edited_at") @db.Timestamp(0)
   createdAt            DateTime  @default(now()) @map("created_at") @db.Timestamp(0)

--- a/packages/api/src/feature/activity/model/activity.model.new.ts
+++ b/packages/api/src/feature/activity/model/activity.model.new.ts
@@ -51,6 +51,15 @@ export class MActivity extends MEntity implements IActivity {
       });
   }
 
+  static updateReviewStatus(status: ActivityStatusEnum, commentedAt: Date) {
+    return (model: MActivity) =>
+      new MActivity({
+        ...model,
+        activityStatusEnum: status,
+        commentedAt,
+      });
+  }
+
   static updateChargedExecutive(executiveId: number) {
     return (model: MActivity) =>
       new MActivity({

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -63,11 +63,13 @@ describe("ActivityService", () => {
 
   const createService = (
     activityDeadlines = [{ deadlineEnum: ActivityDeadlineEnum.Writing }],
+    activityOverrides: Partial<typeof activity> = {},
   ) => {
+    const currentActivity = { ...activity, ...activityOverrides };
     const activityRepository = {
-      fetch: jest.fn().mockResolvedValue(activity),
-      put: jest.fn().mockResolvedValue(new MActivity(activity)),
-      patch: jest.fn().mockResolvedValue([new MActivity(activity)]),
+      fetch: jest.fn().mockResolvedValue(currentActivity),
+      put: jest.fn().mockResolvedValue(new MActivity(currentActivity)),
+      patch: jest.fn().mockResolvedValue([new MActivity(currentActivity)]),
     };
     const activityCommentRepository = {
       create: jest.fn().mockResolvedValue([{}]),
@@ -186,17 +188,28 @@ describe("ActivityService", () => {
     const commentedAt = new Date("2026-05-01T12:00:00.000Z");
     jest.useFakeTimers().setSystemTime(commentedAt);
     const { activityCommentRepository, activityRepository, service } =
-      createService();
+      createService(undefined, {
+        activityStatusEnum: ActivityStatusEnum.Applied,
+      });
 
     await service.patchExecutiveActivityApproval({
       executiveId: 7,
       param: { activityId: activity.id },
     });
 
+    expect(activityRepository.patch.mock.calls[0][0]).toEqual({
+      id: activity.id,
+      activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
+    });
     const patchActivity = activityRepository.patch.mock.calls[0][1] as (
       model: MActivity,
     ) => MActivity;
-    const updatedActivity = patchActivity(new MActivity(activity));
+    const updatedActivity = patchActivity(
+      new MActivity({
+        ...activity,
+        activityStatusEnum: ActivityStatusEnum.Applied,
+      }),
+    );
 
     expect(updatedActivity.activityStatusEnum).toBe(
       ActivityStatusEnum.Approved,
@@ -208,6 +221,25 @@ describe("ActivityService", () => {
       executive: { id: 7 },
       activityStatusEnum: ActivityStatusEnum.Approved,
     });
+  });
+
+  it("does not create approval feedback when the activity report is already approved", async () => {
+    const { activityCommentRepository, activityRepository, service } =
+      createService();
+    activityRepository.patch.mockResolvedValueOnce([]);
+
+    await expect(
+      service.patchExecutiveActivityApproval({
+        executiveId: 7,
+        param: { activityId: activity.id },
+      }),
+    ).rejects.toThrow("the activity is already approved");
+
+    expect(activityRepository.patch.mock.calls[0][0]).toEqual({
+      id: activity.id,
+      activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
+    });
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 
   it("sets commentedAt when an executive sends back an activity report", async () => {
@@ -238,5 +270,21 @@ describe("ActivityService", () => {
       executive: { id: 8 },
       activityStatusEnum: ActivityStatusEnum.Rejected,
     });
+  });
+
+  it("does not create send-back feedback when the status update fails", async () => {
+    const { activityCommentRepository, activityRepository, service } =
+      createService();
+    activityRepository.patch.mockResolvedValueOnce([]);
+
+    await expect(
+      service.patchExecutiveActivitySendBack({
+        executiveId: 8,
+        param: { activityId: activity.id },
+        body: { comment: "보완 필요" },
+      }),
+    ).rejects.toThrow("failed to send back activity");
+
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -4,6 +4,7 @@ import { ActivityDeadlineEnum } from "@clubs/domain/semester/deadline";
 import { ActivityTypeEnum } from "@clubs/interface/common/enum/activity.enum";
 
 import { MActivity } from "../model/activity.model.new";
+import { MActivityComment } from "../model/activity-comment.model";
 import ActivityService from "./activity.service.new";
 
 describe("ActivityService", () => {
@@ -71,8 +72,16 @@ describe("ActivityService", () => {
       put: jest.fn().mockResolvedValue(new MActivity(currentActivity)),
       patch: jest.fn().mockResolvedValue([new MActivity(currentActivity)]),
     };
+    const activityComment = new MActivityComment({
+      id: 1,
+      activity: { id: currentActivity.id },
+      content: "review comment",
+      activityStatusEnum: currentActivity.activityStatusEnum,
+      createdAt: reviewedAt,
+      executive: { id: 7 },
+    });
     const activityCommentRepository = {
-      create: jest.fn().mockResolvedValue([{}]),
+      create: jest.fn().mockResolvedValue([activityComment]),
     };
     const clubPublicService = {
       checkIsStudentDelegate: jest.fn().mockResolvedValue(undefined),
@@ -242,6 +251,20 @@ describe("ActivityService", () => {
     expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 
+  it("throws when approval feedback insertion fails", async () => {
+    const { activityCommentRepository, service } = createService(undefined, {
+      activityStatusEnum: ActivityStatusEnum.Applied,
+    });
+    activityCommentRepository.create.mockResolvedValueOnce([]);
+
+    await expect(
+      service.patchExecutiveActivityApproval({
+        executiveId: 7,
+        param: { activityId: activity.id },
+      }),
+    ).rejects.toThrow("unreachable");
+  });
+
   it("sets commentedAt when an executive sends back an activity report", async () => {
     const commentedAt = new Date("2026-05-02T12:00:00.000Z");
     jest.useFakeTimers().setSystemTime(commentedAt);
@@ -286,5 +309,18 @@ describe("ActivityService", () => {
     ).rejects.toThrow("failed to send back activity");
 
     expect(activityCommentRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("throws when send-back feedback insertion fails", async () => {
+    const { activityCommentRepository, service } = createService();
+    activityCommentRepository.create.mockResolvedValueOnce([]);
+
+    await expect(
+      service.patchExecutiveActivitySendBack({
+        executiveId: 8,
+        param: { activityId: activity.id },
+        body: { comment: "보완 필요" },
+      }),
+    ).rejects.toThrow("unreachable");
   });
 });

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -7,6 +7,10 @@ import { MActivity } from "../model/activity.model.new";
 import ActivityService from "./activity.service.new";
 
 describe("ActivityService", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   const activityDuration = {
     id: 10,
     startTerm: new Date("2026-03-01T00:00:00.000Z"),
@@ -14,6 +18,7 @@ describe("ActivityService", () => {
   };
   const approvedAt = new Date("2026-04-01T00:00:00.000Z");
   const editedAt = new Date("2026-04-02T00:00:00.000Z");
+  const reviewedAt = new Date("2026-04-03T00:00:00.000Z");
   const activity = {
     id: 1,
     name: "original activity",
@@ -36,7 +41,7 @@ describe("ActivityService", () => {
     club: { id: 20 },
     editedAt,
     professorApprovedAt: approvedAt,
-    commentedAt: null,
+    commentedAt: reviewedAt,
     commentedExecutive: null,
   };
   const body = {
@@ -62,6 +67,10 @@ describe("ActivityService", () => {
     const activityRepository = {
       fetch: jest.fn().mockResolvedValue(activity),
       put: jest.fn().mockResolvedValue(new MActivity(activity)),
+      patch: jest.fn().mockResolvedValue([new MActivity(activity)]),
+    };
+    const activityCommentRepository = {
+      create: jest.fn().mockResolvedValue([{}]),
     };
     const clubPublicService = {
       checkIsStudentDelegate: jest.fn().mockResolvedValue(undefined),
@@ -94,7 +103,7 @@ describe("ActivityService", () => {
     const service = new ActivityService(
       activityRepository as never,
       {} as never,
-      {} as never,
+      activityCommentRepository as never,
       activityDurationPublicService as never,
       activityDeadlinePublicService as never,
       semesterPublicService as never,
@@ -109,6 +118,7 @@ describe("ActivityService", () => {
 
     return {
       activityRepository,
+      activityCommentRepository,
       filePublicService,
       registrationPublicService,
       service,
@@ -126,6 +136,7 @@ describe("ActivityService", () => {
       .calls[0][0] as MActivity;
     expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
     expect(updatedActivity.professorApprovedAt).toBeNull();
+    expect(updatedActivity.commentedAt).toBeNull();
   });
 
   it("keeps professor approval when a regular activity report is edited during the modification period", async () => {
@@ -139,6 +150,7 @@ describe("ActivityService", () => {
       .calls[0][0] as MActivity;
     expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
     expect(updatedActivity.professorApprovedAt).toBeUndefined();
+    expect(updatedActivity.commentedAt).toBeNull();
   });
 
   it("rejects regular activity report edits outside writing and modification periods", async () => {
@@ -164,8 +176,67 @@ describe("ActivityService", () => {
       .calls[0][0] as MActivity;
     expect(updatedActivity.activityStatusEnum).toBe(ActivityStatusEnum.Applied);
     expect(updatedActivity.professorApprovedAt).toBeUndefined();
+    expect(updatedActivity.commentedAt).toBeNull();
     expect(
       registrationPublicService.resetClubRegistrationStatusEnum,
     ).toHaveBeenCalledWith(activity.club.id);
+  });
+
+  it("sets commentedAt when an executive approves an activity report", async () => {
+    const commentedAt = new Date("2026-05-01T12:00:00.000Z");
+    jest.useFakeTimers().setSystemTime(commentedAt);
+    const { activityCommentRepository, activityRepository, service } =
+      createService();
+
+    await service.patchExecutiveActivityApproval({
+      executiveId: 7,
+      param: { activityId: activity.id },
+    });
+
+    const patchActivity = activityRepository.patch.mock.calls[0][1] as (
+      model: MActivity,
+    ) => MActivity;
+    const updatedActivity = patchActivity(new MActivity(activity));
+
+    expect(updatedActivity.activityStatusEnum).toBe(
+      ActivityStatusEnum.Approved,
+    );
+    expect(updatedActivity.commentedAt).toEqual(commentedAt);
+    expect(activityCommentRepository.create).toHaveBeenCalledWith({
+      activity: { id: activity.id },
+      content: "활동이 승인되었습니다",
+      executive: { id: 7 },
+      activityStatusEnum: ActivityStatusEnum.Approved,
+    });
+  });
+
+  it("sets commentedAt when an executive sends back an activity report", async () => {
+    const commentedAt = new Date("2026-05-02T12:00:00.000Z");
+    jest.useFakeTimers().setSystemTime(commentedAt);
+    const { activityCommentRepository, activityRepository, service } =
+      createService();
+    const sendBackBody = { comment: "보완 필요" };
+
+    await service.patchExecutiveActivitySendBack({
+      executiveId: 8,
+      param: { activityId: activity.id },
+      body: sendBackBody,
+    });
+
+    const patchActivity = activityRepository.patch.mock.calls[0][1] as (
+      model: MActivity,
+    ) => MActivity;
+    const updatedActivity = patchActivity(new MActivity(activity));
+
+    expect(updatedActivity.activityStatusEnum).toBe(
+      ActivityStatusEnum.Rejected,
+    );
+    expect(updatedActivity.commentedAt).toEqual(commentedAt);
+    expect(activityCommentRepository.create).toHaveBeenCalledWith({
+      activity: { id: activity.id },
+      content: sendBackBody.comment,
+      executive: { id: 8 },
+      activityStatusEnum: ActivityStatusEnum.Rejected,
+    });
   });
 });

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -867,13 +867,14 @@ export default class ActivityService {
   }): Promise<ApiAct016ResponseOk> {
     // TODO: transaction 추가
     const commentedAt = new Date();
-    const isApprovalSucceed = await this.activityRepository.patch(
+    const updatedActivities = await this.activityRepository.patch(
       {
         id: param.param.activityId,
+        activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
       },
       MActivity.updateReviewStatus(ActivityStatusEnum.Approved, commentedAt),
     );
-    if (!isApprovalSucceed)
+    if (updatedActivities.length === 0)
       throw new HttpException(
         "the activity is already approved",
         HttpStatus.BAD_REQUEST,
@@ -904,12 +905,17 @@ export default class ActivityService {
   }): Promise<ApiAct017ResponseOk> {
     // TODO: transaction 추가
     const commentedAt = new Date();
-    await this.activityRepository.patch(
+    const updatedActivities = await this.activityRepository.patch(
       {
         id: param.param.activityId,
       },
       MActivity.updateReviewStatus(ActivityStatusEnum.Rejected, commentedAt),
     );
+    if (updatedActivities.length === 0)
+      throw new HttpException(
+        "failed to send back activity",
+        HttpStatus.BAD_REQUEST,
+      );
 
     const isInsertionSucceed = await this.activityCommentRepository.create({
       activity: { id: param.param.activityId },

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -420,7 +420,7 @@ export default class ActivityService {
         club: { id: activity.club.id },
         editedAt: new Date(),
         professorApprovedAt: shouldResetProfessorApproval ? null : undefined,
-        commentedAt: undefined,
+        commentedAt: null,
         commentedExecutive: undefined,
       }),
     );
@@ -735,6 +735,7 @@ export default class ActivityService {
       activityDuration: { id: activity.activityDuration.id },
       activityStatusEnum: ActivityStatusEnum.Applied,
       professorApprovedAt: undefined,
+      commentedAt: null,
     });
     if (!isUpdateSucceed)
       throw new HttpException(
@@ -865,11 +866,12 @@ export default class ActivityService {
     param: ApiAct016RequestParam;
   }): Promise<ApiAct016ResponseOk> {
     // TODO: transaction 추가
+    const commentedAt = new Date();
     const isApprovalSucceed = await this.activityRepository.patch(
       {
         id: param.param.activityId,
       },
-      MActivity.updateStatus(ActivityStatusEnum.Approved),
+      MActivity.updateReviewStatus(ActivityStatusEnum.Approved, commentedAt),
     );
     if (!isApprovalSucceed)
       throw new HttpException(
@@ -901,11 +903,12 @@ export default class ActivityService {
     body: ApiAct017RequestBody;
   }): Promise<ApiAct017ResponseOk> {
     // TODO: transaction 추가
+    const commentedAt = new Date();
     await this.activityRepository.patch(
       {
         id: param.param.activityId,
       },
-      MActivity.updateStatus(ActivityStatusEnum.Rejected),
+      MActivity.updateReviewStatus(ActivityStatusEnum.Rejected, commentedAt),
     );
 
     const isInsertionSucceed = await this.activityCommentRepository.create({

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -880,14 +880,14 @@ export default class ActivityService {
         HttpStatus.BAD_REQUEST,
       );
 
-    const isInsertionSucceed = await this.activityCommentRepository.create({
+    const insertedComments = await this.activityCommentRepository.create({
       activity: { id: param.param.activityId },
       content: "활동이 승인되었습니다", // feedback에 승인을 기록하기 위한 임의의 문자열
       // TODO?: 활동 승인 시에도 content를 넣을까요?
       executive: { id: param.executiveId },
       activityStatusEnum: ActivityStatusEnum.Approved,
     });
-    if (!isInsertionSucceed)
+    if (insertedComments.length === 0)
       throw new HttpException("unreachable", HttpStatus.INTERNAL_SERVER_ERROR);
 
     return {};
@@ -917,13 +917,13 @@ export default class ActivityService {
         HttpStatus.BAD_REQUEST,
       );
 
-    const isInsertionSucceed = await this.activityCommentRepository.create({
+    const insertedComments = await this.activityCommentRepository.create({
       activity: { id: param.param.activityId },
       content: param.body.comment,
       executive: { id: param.executiveId },
       activityStatusEnum: ActivityStatusEnum.Rejected,
     });
-    if (!isInsertionSucceed)
+    if (insertedComments.length === 0)
       throw new HttpException("unreachable", HttpStatus.INTERNAL_SERVER_ERROR);
 
     return {};

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -319,6 +319,12 @@ export default class ActivityOldService {
           e.clubId === club.id &&
           e.activityStatusEnumId === ActivityStatusEnum.Rejected,
       ).length;
+      const clubActivities = activitiesOnActivityD.filter(
+        e => e.clubId === club.id,
+      );
+      const professorApprovedActivitiesCount = clubActivities.filter(
+        e => e.professorApprovedAt !== null,
+      ).length;
       const chargedExecutive = clubChargedExecutiveMap.has(club.id)
         ? executiveMap.get(clubChargedExecutiveMap.get(club.id))
         : undefined;
@@ -331,6 +337,7 @@ export default class ActivityOldService {
         pendingActivitiesCount,
         approvedActivitiesCount,
         rejectedActivitiesCount,
+        professorApprovedActivitiesCount,
         advisor: club.professor?.name,
         chargedExecutive,
       };

--- a/packages/api/src/feature/activity/service/activity.service.ts
+++ b/packages/api/src/feature/activity/service/activity.service.ts
@@ -304,27 +304,26 @@ export default class ActivityOldService {
     logger.debug(`current activated executives: ${executives.length}`);
 
     const items: ApiAct023ResponseOk["items"] = clubList.map(club => {
-      const pendingActivitiesCount = activitiesOnActivityD.filter(
-        e =>
-          e.clubId === club.id &&
-          e.activityStatusEnumId === ActivityStatusEnum.Applied,
-      ).length;
-      const approvedActivitiesCount = activitiesOnActivityD.filter(
-        e =>
-          e.clubId === club.id &&
-          e.activityStatusEnumId === ActivityStatusEnum.Approved,
-      ).length;
-      const rejectedActivitiesCount = activitiesOnActivityD.filter(
-        e =>
-          e.clubId === club.id &&
-          e.activityStatusEnumId === ActivityStatusEnum.Rejected,
-      ).length;
       const clubActivities = activitiesOnActivityD.filter(
         e => e.clubId === club.id,
       );
-      const professorApprovedActivitiesCount = clubActivities.filter(
-        e => e.professorApprovedAt !== null,
-      ).length;
+      const pendingActivities = clubActivities.filter(
+        e => e.activityStatusEnumId === ActivityStatusEnum.Applied,
+      );
+      const approvedActivities = clubActivities.filter(
+        e => e.activityStatusEnumId === ActivityStatusEnum.Approved,
+      );
+      const rejectedActivities = clubActivities.filter(
+        e => e.activityStatusEnumId === ActivityStatusEnum.Rejected,
+      );
+      const professorApprovedActivitiesCount = [
+        ...pendingActivities,
+        ...approvedActivities,
+        ...rejectedActivities,
+      ].filter(e => e.professorApprovedAt !== null).length;
+      const pendingActivitiesCount = pendingActivities.length;
+      const approvedActivitiesCount = approvedActivities.length;
+      const rejectedActivitiesCount = rejectedActivities.length;
       const chargedExecutive = clubChargedExecutiveMap.has(club.id)
         ? executiveMap.get(clubChargedExecutiveMap.get(club.id))
         : undefined;

--- a/packages/interface/src/api/activity/endpoint/apiAct023.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct023.ts
@@ -47,6 +47,7 @@ const responseBodyMap = {
         pendingActivitiesCount: z.coerce.number().int().min(0),
         approvedActivitiesCount: z.coerce.number().int().min(0),
         rejectedActivitiesCount: z.coerce.number().int().min(0),
+        professorApprovedActivitiesCount: z.coerce.number().int().min(0),
         chargedExecutive: z
           .object({
             id: zId,

--- a/packages/web/src/features/activity-report/components/executive/ExecutiveActivityClubTable.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutiveActivityClubTable.tsx
@@ -70,6 +70,32 @@ const columns = [
   }),
   columnHelper.accessor(
     row => {
+      if (!row.advisor) return "-";
+
+      const {
+        pendingActivitiesCount,
+        approvedActivitiesCount,
+        rejectedActivitiesCount,
+        professorApprovedActivitiesCount,
+      } = row;
+      const total =
+        pendingActivitiesCount +
+        approvedActivitiesCount +
+        rejectedActivitiesCount;
+      const approvedRate = total
+        ? (professorApprovedActivitiesCount / total) * 100
+        : 0;
+      if (total === 0) return "-";
+      return `${approvedRate.toFixed(2)}% (${professorApprovedActivitiesCount} / ${total})`;
+    },
+    {
+      header: "지도교수 승인율 (승인 / 전체)",
+      cell: info => info.getValue(),
+      size: 220,
+    },
+  ),
+  columnHelper.accessor(
+    row => {
       const {
         pendingActivitiesCount,
         approvedActivitiesCount,

--- a/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
+++ b/packages/web/src/features/activity-report/services/executive/useGetExecutiveActivities.ts
@@ -56,6 +56,7 @@ defineAxiosMock(mock => {
           pendingActivitiesCount: 1,
           approvedActivitiesCount: 1,
           rejectedActivitiesCount: 1,
+          professorApprovedActivitiesCount: 1,
           advisor: undefined,
           chargedExecutive: undefined,
         },


### PR DESCRIPTION
## Summary
- 집행부 활동보고서 동아리 목록에 지도교수 승인율을 표시합니다.
- 집행부 승인/반려 시 현재 제출본의 commentedAt을 저장합니다.
- 대표자 수정/재제출 시 commentedAt을 null로 초기화해 이전 검토일시가 남지 않도록 합니다.

## Test
- NODE_ENV=test SERVER_PORT=3000 SECRET_KEY=test DATABASE_URL=mysql://root:root@127.0.0.1:3306/clubs_test TEST_DATABASE_URL=mysql://root:root@127.0.0.1:3306/clubs_test pnpm --dir packages/api exec jest --config ./test/jest-unit.json src/feature/activity/service/activity.service.new.spec.ts --runInBand
- pnpm format:check:changed
- pnpm --filter api build
- pnpm --filter api lint
- pnpm --filter @clubs/interface build
- pnpm --filter @clubs/interface lint
- pnpm --filter web lint
- pnpm --filter web build
- pnpm mcdc:changed --fail-on-missing

## Patch Note
<!-- clubs:patch-note:start -->
category: feature
text:
  - 집행부 활동보고서 화면에서 지도교수 승인 현황을 확인할 수 있도록 개선했습니다.
  - 활동보고서의 최종 검토 시간이 표시되지 않던 문제를 수정했습니다.
<!-- clubs:patch-note:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Executive activity reports gain a professor approval-rate column showing advisor-approved vs total activities per club.
  * Executive approve/send-back actions now set review timestamps and create corresponding feedback entries.

* **Bug Fixes**
  * Student edit flows explicitly clear review timestamps to avoid stale data.

* **Tests**
  * Expanded tests cover approval/send-back flows, feedback creation, and timer cleanup.

* **Documentation**
  * Marked the old reviewer field as deprecated and pointed to using feedback records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->