### PR TITLE
[TU-433] 활동반기 삭제 가드 추가

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -1,11 +1,88 @@
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
-import { ActivityDeadlineEnum } from "@clubs/domain/semester/deadline";
+import { ActivityDurationTypeEnum } from "@clubs/domain/semester/activity-duration";
+import {
+  ActivityDeadlineEnum,
+  RegistrationDeadlineEnum,
+} from "@clubs/domain/semester/deadline";
 
 import { ActivityTypeEnum } from "@clubs/interface/common/enum/activity.enum";
 
 import { MActivity } from "../model/activity.model.new";
 import { MActivityComment } from "../model/activity-comment.model";
 import ActivityService from "./activity.service.new";
+
+type ActivityStub = {
+  id: number;
+  name: string;
+  activityTypeEnum: number;
+  activityStatusEnum: ActivityStatusEnum;
+  durations: {
+    startTerm: Date;
+    endTerm: Date;
+  }[];
+};
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function createRegistrationActivityDuration(id: number, semesterId: number) {
+  return {
+    id,
+    semester: { id: semesterId },
+    activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
+    year: 2026,
+    name: "봄 신규등록",
+    startTerm: new Date("2025-02-24T00:00:00.000Z"),
+    endTerm: new Date("2026-03-02T23:59:00.000Z"),
+  };
+}
+
+function createProvisionalListService({
+  activeRegistrationDeadline = null,
+  registrationActivityDurations = [],
+  activitiesByActivityDurationId = {},
+}: {
+  activeRegistrationDeadline?: { semester: { id: number } } | null;
+  registrationActivityDurations?: ReturnType<
+    typeof createRegistrationActivityDuration
+  >[];
+  activitiesByActivityDurationId?: Record<number, ActivityStub[]>;
+} = {}) {
+  const activityRepository = {
+    find: jest.fn(({ activityDId }: { activityDId: number }) =>
+      Promise.resolve(activitiesByActivityDurationId[activityDId] ?? []),
+    ),
+  };
+  const activityDurationPublicService = {
+    search: jest.fn().mockResolvedValue(registrationActivityDurations),
+  };
+  const registrationDeadlinePublicService = {
+    searchOne: jest.fn().mockResolvedValue(activeRegistrationDeadline),
+  };
+  const unusedDependency = {} as never;
+
+  const service = new ActivityService(
+    activityRepository as never,
+    unusedDependency,
+    unusedDependency,
+    activityDurationPublicService as never,
+    unusedDependency,
+    unusedDependency,
+    unusedDependency,
+    unusedDependency,
+    unusedDependency,
+    registrationDeadlinePublicService as never,
+    unusedDependency,
+    unusedDependency,
+    unusedDependency,
+  );
+
+  return {
+    activityDurationPublicService,
+    activityRepository,
+    registrationDeadlinePublicService,
+    service,
+  };
+}
 
 describe("ActivityService", () => {
   afterEach(() => {
@@ -322,5 +399,168 @@ describe("ActivityService", () => {
         body: { comment: "보완 필요" },
       }),
     ).rejects.toThrow("unreachable");
+  });
+});
+
+describe("ActivityService provisional activities", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("loads activities from the requested registration semester", async () => {
+    const activityDuration = createRegistrationActivityDuration(30, 19);
+    const activity = {
+      id: 1,
+      name: "Training",
+      activityTypeEnum: 1,
+      activityStatusEnum: ActivityStatusEnum.Applied,
+      durations: [
+        {
+          startTerm: new Date("2025-03-01T00:00:00.000Z"),
+          endTerm: new Date("2025-03-02T00:00:00.000Z"),
+        },
+      ],
+    };
+    const {
+      activityDurationPublicService,
+      activityRepository,
+      registrationDeadlinePublicService,
+      service,
+    } = createProvisionalListService({
+      registrationActivityDurations: [activityDuration],
+      activitiesByActivityDurationId: {
+        30: [activity],
+      },
+    });
+
+    await expect(
+      service.getExecutiveProvisionalActivities({
+        query: { clubId: 111, semesterId: 19 },
+      }),
+    ).resolves.toEqual({
+      activities: [
+        {
+          id: 1,
+          name: "Training",
+          activityTypeEnumId: 1,
+          activityStatusEnumId: ActivityStatusEnum.Applied,
+          durations: activity.durations,
+        },
+      ],
+    });
+
+    expect(activityDurationPublicService.search).toHaveBeenCalledWith({
+      semesterId: 19,
+      activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
+    });
+    expect(activityRepository.find).toHaveBeenCalledWith({
+      clubId: 111,
+      activityDId: 30,
+    });
+    expect(registrationDeadlinePublicService.searchOne).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the active registration deadline semester", async () => {
+    const activityDuration = createRegistrationActivityDuration(30, 19);
+    const {
+      activityDurationPublicService,
+      registrationDeadlinePublicService,
+      service,
+    } = createProvisionalListService({
+      activeRegistrationDeadline: { semester: { id: 19 } },
+      registrationActivityDurations: [activityDuration],
+    });
+
+    await expect(
+      service.getStudentProvisionalActivities({
+        studentId: 1,
+        query: { clubId: 111 },
+      }),
+    ).resolves.toEqual({ activities: [] });
+
+    expect(registrationDeadlinePublicService.searchOne).toHaveBeenCalledWith({
+      date: NOW,
+      deadlineEnum: RegistrationDeadlineEnum.ClubRegistrationApplication,
+    });
+    expect(activityDurationPublicService.search).toHaveBeenCalledWith({
+      semesterId: 19,
+      activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
+    });
+  });
+
+  it("returns an empty list when there is no registration context", async () => {
+    const { activityDurationPublicService, activityRepository, service } =
+      createProvisionalListService();
+
+    await expect(
+      service.getExecutiveProvisionalActivities({
+        query: { clubId: 111 },
+      }),
+    ).resolves.toEqual({ activities: [] });
+
+    expect(activityDurationPublicService.search).not.toHaveBeenCalled();
+    expect(activityRepository.find).not.toHaveBeenCalled();
+  });
+
+  it("sorts activities by start term and then end term", async () => {
+    const firstActivity = {
+      id: 2,
+      name: "First",
+      activityTypeEnum: 1,
+      activityStatusEnum: ActivityStatusEnum.Applied,
+      durations: [
+        {
+          startTerm: new Date("2025-02-01T00:00:00.000Z"),
+          endTerm: new Date("2025-02-03T00:00:00.000Z"),
+        },
+      ],
+    };
+    const secondActivity = {
+      id: 1,
+      name: "Second",
+      activityTypeEnum: 2,
+      activityStatusEnum: ActivityStatusEnum.Approved,
+      durations: [
+        {
+          startTerm: new Date("2025-02-02T00:00:00.000Z"),
+          endTerm: new Date("2025-02-04T00:00:00.000Z"),
+        },
+      ],
+    };
+    const { service } = createProvisionalListService({
+      registrationActivityDurations: [
+        createRegistrationActivityDuration(30, 19),
+      ],
+      activitiesByActivityDurationId: {
+        30: [secondActivity, firstActivity],
+      },
+    });
+
+    await expect(
+      service.getProfessorProvisionalActivities({
+        query: { clubId: 111, semesterId: 19 },
+      }),
+    ).resolves.toEqual({
+      activities: [
+        {
+          id: 2,
+          name: "First",
+          activityTypeEnumId: 1,
+          activityStatusEnumId: ActivityStatusEnum.Applied,
+          durations: firstActivity.durations,
+        },
+        {
+          id: 1,
+          name: "Second",
+          activityTypeEnumId: 2,
+          activityStatusEnumId: ActivityStatusEnum.Approved,
+          durations: secondActivity.durations,
+        },
+      ],
+    });
   });
 });

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -749,35 +749,76 @@ export default class ActivityService {
     );
   }
 
+  private async getRegistrationActivityDuration(
+    semesterId: number,
+  ): Promise<IActivityDuration | null> {
+    const activityDurations = await this.activityDurationPublicService.search({
+      semesterId,
+      activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
+    });
+
+    if (activityDurations.length === 0) {
+      return null;
+    }
+
+    if (activityDurations.length > 1) {
+      throw new HttpException(
+        "Multiple registration activity durations found",
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    return activityDurations[0];
+  }
+
+  private async getProvisionalActivityDuration(param: {
+    semesterId?: number;
+  }): Promise<IActivityDuration | null> {
+    if (param.semesterId !== undefined) {
+      return this.getRegistrationActivityDuration(param.semesterId);
+    }
+
+    const activeRegistrationDeadline =
+      await this.registrationDeadlinePublicService.searchOne({
+        date: new Date(),
+        deadlineEnum: RegistrationDeadlineEnum.ClubRegistrationApplication,
+      });
+
+    if (activeRegistrationDeadline === null) {
+      return null;
+    }
+
+    return this.getRegistrationActivityDuration(
+      activeRegistrationDeadline.semester.id,
+    );
+  }
+
   /**
    * @param clubId 동아리 ID
    * @description REG-011, 012, 013에서 공통적으로 이용하는 동아리 활동 전체조회 입니다.
    * @returns 해당 동아리가 작성한 모든 활동을 REG-011의 리턴 타입에 맞추어 가져옵니다.
    */
-  private async getProvisionalActivities(param: { clubId: number }) {
-    const activityDId = await this.activityDurationPublicService.loadId({
-      date: new Date(),
-      activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
+  private async getProvisionalActivities(param: {
+    clubId: number;
+    semesterId?: number;
+  }) {
+    const activityDuration = await this.getProvisionalActivityDuration({
+      semesterId: param.semesterId,
     });
-    const resultNow = await this.activityRepository.find({
+
+    if (activityDuration === null) {
+      return [];
+    }
+
+    const result = await this.activityRepository.find({
       clubId: param.clubId,
-      activityDId,
+      activityDId: activityDuration.id,
     });
-    // 25 봄 한정. TODO: 25봄 등록 이후 삭제 필요
-    // Ascend 의 이전 학기 등록 시 활보를 가져오기 위해 이전 학기의 목록을 가져옵니다.
-    const prevActivityDId = await this.activityDurationPublicService.loadId({
-      semesterId:
-        (await this.semesterPublicService.loadId({
-          date: new Date(),
-        })) - 1,
-      activityDurationTypeEnum: ActivityDurationTypeEnum.Registration,
-    });
-    const prevActivities = await this.activityRepository.find({
-      clubId: param.clubId,
-      activityDId: prevActivityDId,
-    });
-    const result = [...resultNow, ...prevActivities];
-    // Ascend 특별처리 End
+
+    if (result.length === 0) {
+      return [];
+    }
+
     const activities = await Promise.all(
       result.map(async activity => {
         // 가장 빠른 startTerm을 추출
@@ -831,6 +872,7 @@ export default class ActivityService {
     // });
     const activities = await this.getProvisionalActivities({
       clubId: param.query.clubId,
+      semesterId: param.query.semesterId,
     });
     return { activities };
   }
@@ -845,6 +887,7 @@ export default class ActivityService {
     // 집행부원은 아직 검사하는 권한이 없습니다.
     const activities = await this.getProvisionalActivities({
       clubId: param.query.clubId,
+      semesterId: param.query.semesterId,
     });
     return { activities };
   }
@@ -855,6 +898,7 @@ export default class ActivityService {
     // 교수님은 아직 검사하는 권한이 없습니다.
     const activities = await this.getProvisionalActivities({
       clubId: param.query.clubId,
+      semesterId: param.query.semesterId,
     });
     return { activities };
   }

--- a/packages/api/src/feature/registration/repository/club-registration.repository.ts
+++ b/packages/api/src/feature/registration/repository/club-registration.repository.ts
@@ -32,6 +32,8 @@ type ClubRegistrationListResponse = Pick<
   ApiReg014ResponseOk,
   "items" | "total" | "offset"
 >;
+type Reg011DetailNoSemester = Omit<ApiReg011ResponseOk, "semesterId">;
+type Reg015DetailNoSemester = Omit<ApiReg015ResponseOk, "semesterId">;
 
 @Injectable()
 export class ClubRegistrationRepository {
@@ -73,6 +75,22 @@ export class ClubRegistrationRepository {
     });
 
     return registration;
+  }
+
+  async findSemesterIdByRegistrationId(
+    applyId: number,
+  ): Promise<number | null> {
+    const registration = await this.prisma.registration.findFirst({
+      where: {
+        id: applyId,
+        deletedAt: null,
+      },
+      select: {
+        semesterId: true,
+      },
+    });
+
+    return registration?.semesterId ?? null;
   }
 
   async createRegistration(
@@ -385,8 +403,8 @@ export class ClubRegistrationRepository {
   async getStudentRegistrationsClubRegistration(
     studentId: number,
     applyId: number,
-  ): Promise<ApiReg011ResponseOk> {
-    const result = await this.prisma.$transaction<ApiReg011ResponseOk>(
+  ): Promise<Reg011DetailNoSemester> {
+    const result = await this.prisma.$transaction<Reg011DetailNoSemester>(
       async tx => {
         const cur = new Date();
         const rows = await (tx as unknown as PrismaClient).$queryRaw<
@@ -679,8 +697,8 @@ export class ClubRegistrationRepository {
 
   async getExecutiveRegistrationsClubRegistration(
     applyId: number,
-  ): Promise<ApiReg015ResponseOk> {
-    const result = await this.prisma.$transaction<ApiReg015ResponseOk>(
+  ): Promise<Reg015DetailNoSemester> {
+    const result = await this.prisma.$transaction<Reg015DetailNoSemester>(
       async tx => {
         const cur = new Date();
         const rows = await (tx as unknown as PrismaClient).$queryRaw<

--- a/packages/api/src/feature/registration/service/registration.service.ts
+++ b/packages/api/src/feature/registration/service/registration.service.ts
@@ -132,6 +132,19 @@ export class RegistrationService {
     return this.getPastSemestersWithRegistrations(targetSemester, semesterIds);
   }
 
+  private async getRegistrationSemesterId(applyId: number): Promise<number> {
+    const semesterId =
+      await this.clubRegistrationRepository.findSemesterIdByRegistrationId(
+        applyId,
+      );
+
+    if (semesterId === null) {
+      throw new HttpException("Registration not found", HttpStatus.BAD_REQUEST);
+    }
+
+    return semesterId;
+  }
+
   /**
    * @description 동아리 대표자인지 검증하는 로직은 repository쪽에서 진행됩니다.
    */
@@ -594,11 +607,13 @@ export class RegistrationService {
     //     // RegistrationDeadlineEnum.ClubRegistrationExecutiveFeedback,
     //   ],
     // });
-    const result =
-      await this.clubRegistrationRepository.getStudentRegistrationsClubRegistration(
+    const [result, semesterId] = await Promise.all([
+      this.clubRegistrationRepository.getStudentRegistrationsClubRegistration(
         studentId,
         applyId,
-      );
+      ),
+      this.getRegistrationSemesterId(applyId),
+    ]);
     if (result.externalInstructionFile) {
       result.externalInstructionFile.url =
         await this.filePublicService.getFileUrl(
@@ -615,7 +630,7 @@ export class RegistrationService {
         result.activityPlanFile.id,
       );
     }
-    return result;
+    return { ...result, semesterId };
   }
 
   /**
@@ -680,10 +695,12 @@ export class RegistrationService {
   async getExecutiveRegistrationsClubRegistration(
     applyId: number,
   ): Promise<ApiReg015ResponseOk> {
-    const result =
-      await this.clubRegistrationRepository.getExecutiveRegistrationsClubRegistration(
+    const [result, semesterId] = await Promise.all([
+      this.clubRegistrationRepository.getExecutiveRegistrationsClubRegistration(
         applyId,
-      );
+      ),
+      this.getRegistrationSemesterId(applyId),
+    ]);
     if (result.externalInstructionFile) {
       result.externalInstructionFile.url =
         await this.filePublicService.getFileUrl(
@@ -700,7 +717,7 @@ export class RegistrationService {
         result.activityPlanFile.id,
       );
     }
-    return result;
+    return { ...result, semesterId };
   }
 
   async patchExecutiveRegistrationsClubRegistrationApproval(
@@ -844,6 +861,7 @@ export class RegistrationService {
 
     return {
       id: result.registration.id,
+      semesterId: result.registration.semesterId,
       registrationTypeEnumId:
         result.registration.registrationApplicationTypeEnumId,
       registrationStatusEnumId:

--- a/packages/api/src/feature/semester/publicService/registration.deadline.public.service.ts
+++ b/packages/api/src/feature/semester/publicService/registration.deadline.public.service.ts
@@ -13,6 +13,7 @@ import { SemesterPublicService } from "./semester.public.service";
 
 type RegistrationDeadlineSearchQuery = {
   semesterId?: number;
+  date?: Date;
   deadlineEnum?: RegistrationDeadlineEnum;
 };
 

--- a/packages/api/src/feature/semester/repository/activity.duration.repository.ts
+++ b/packages/api/src/feature/semester/repository/activity.duration.repository.ts
@@ -165,4 +165,26 @@ export class ActivityDurationRepository extends BaseSingleTableRepository<
         }),
     );
   }
+
+  async countActivitiesByDurationId(
+    activityDurationId: MActivityDuration["id"],
+  ): Promise<number> {
+    return this.prisma.activity.count({
+      where: {
+        activityDId: activityDurationId,
+        deletedAt: null,
+      },
+    });
+  }
+
+  async countFundingsByDurationId(
+    activityDurationId: MActivityDuration["id"],
+  ): Promise<number> {
+    return this.prisma.funding.count({
+      where: {
+        activityDId: activityDurationId,
+        deletedAt: null,
+      },
+    });
+  }
 }

--- a/packages/api/src/feature/semester/service/activity-duration.service.spec.ts
+++ b/packages/api/src/feature/semester/service/activity-duration.service.spec.ts
@@ -1,0 +1,108 @@
+import { ActivityDurationService } from "./activity-duration.service";
+
+const ACTIVITY_DURATION_ID = 30;
+const ACTIVITY_DURATION = {
+  id: ACTIVITY_DURATION_ID,
+  semester: { id: 19 },
+};
+
+function createService({
+  activityCount = 0,
+  fundingCount = 0,
+  deadlines = [],
+}: {
+  activityCount?: number;
+  fundingCount?: number;
+  deadlines?: unknown[];
+} = {}) {
+  const activityDurationRepository = {
+    find: jest.fn().mockResolvedValue([ACTIVITY_DURATION]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    countActivitiesByDurationId: jest.fn().mockResolvedValue(activityCount),
+    countFundingsByDurationId: jest.fn().mockResolvedValue(fundingCount),
+  };
+  const activityDeadlineRepository = {
+    find: jest.fn().mockResolvedValue(deadlines),
+  };
+  const semesterRepository = {};
+
+  const service = new ActivityDurationService(
+    activityDurationRepository as never,
+    activityDeadlineRepository as never,
+    semesterRepository as never,
+  );
+
+  return {
+    activityDeadlineRepository,
+    activityDurationRepository,
+    service,
+  };
+}
+
+describe("ActivityDurationService.deleteActivityDuration", () => {
+  it("deletes an activity duration when there are no active references", async () => {
+    const { activityDurationRepository, service } = createService();
+
+    await expect(
+      service.deleteActivityDuration(ACTIVITY_DURATION_ID),
+    ).resolves.toEqual({});
+
+    expect(
+      activityDurationRepository.countActivitiesByDurationId,
+    ).toHaveBeenCalledWith(ACTIVITY_DURATION_ID);
+    expect(
+      activityDurationRepository.countFundingsByDurationId,
+    ).toHaveBeenCalledWith(ACTIVITY_DURATION_ID);
+    expect(activityDurationRepository.delete).toHaveBeenCalledWith({
+      id: ACTIVITY_DURATION_ID,
+    });
+  });
+
+  it("does not delete an activity duration with active activities", async () => {
+    const { activityDurationRepository, service } = createService({
+      activityCount: 1,
+    });
+
+    await expect(
+      service.deleteActivityDuration(ACTIVITY_DURATION_ID),
+    ).rejects.toThrow(
+      "활동반기에 연결된 활동보고서가 있어 삭제할 수 없습니다.",
+    );
+
+    expect(activityDurationRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("does not delete an activity duration with active fundings", async () => {
+    const { activityDurationRepository, service } = createService({
+      fundingCount: 1,
+    });
+
+    await expect(
+      service.deleteActivityDuration(ACTIVITY_DURATION_ID),
+    ).rejects.toThrow(
+      "활동반기에 연결된 지원금 신청이 있어 삭제할 수 없습니다.",
+    );
+
+    expect(activityDurationRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("does not check activities or fundings when deadlines exist", async () => {
+    const { activityDurationRepository, service } = createService({
+      deadlines: [{ id: 1 }],
+    });
+
+    await expect(
+      service.deleteActivityDuration(ACTIVITY_DURATION_ID),
+    ).rejects.toThrow(
+      "활동반기에 연결된 활동보고서 기한이 있어 삭제할 수 없습니다.",
+    );
+
+    expect(
+      activityDurationRepository.countActivitiesByDurationId,
+    ).not.toHaveBeenCalled();
+    expect(
+      activityDurationRepository.countFundingsByDurationId,
+    ).not.toHaveBeenCalled();
+    expect(activityDurationRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/feature/semester/service/activity-duration.service.ts
+++ b/packages/api/src/feature/semester/service/activity-duration.service.ts
@@ -257,6 +257,29 @@ export class ActivityDurationService {
       );
     }
 
+    const [activityCount, fundingCount] = await Promise.all([
+      this.activityDurationRepository.countActivitiesByDurationId(
+        activityDurationId,
+      ),
+      this.activityDurationRepository.countFundingsByDurationId(
+        activityDurationId,
+      ),
+    ]);
+
+    if (activityCount > 0) {
+      throw new HttpException(
+        "활동반기에 연결된 활동보고서가 있어 삭제할 수 없습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (fundingCount > 0) {
+      throw new HttpException(
+        "활동반기에 연결된 지원금 신청이 있어 삭제할 수 없습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     await this.activityDurationRepository.delete({
       id: activityDurationId,
     } as Parameters<typeof this.activityDurationRepository.delete>[0]);

--- a/packages/interface/src/api/activity/endpoint/apiAct011.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct011.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { zActivity } from "@clubs/domain/activity/activity";
 import { zClub } from "@clubs/domain/club/club";
+import { zSemester } from "@clubs/domain/semester/semester";
 
 import { registry } from "@clubs/interface/open-api";
 
@@ -11,7 +12,10 @@ const method = "GET";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({ clubId: zClub.shape.id });
+const requestQuery = z.object({
+  clubId: zClub.shape.id,
+  semesterId: zSemester.shape.id.optional(),
+});
 
 const requestBody = z.object({});
 

--- a/packages/interface/src/api/activity/endpoint/apiAct012.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct012.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
 import { zClub } from "@clubs/domain/club/club";
+import { zSemester } from "@clubs/domain/semester/semester";
 
 import { registry } from "@clubs/interface/open-api";
 
@@ -17,7 +18,10 @@ const method = "GET";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({ clubId: zClub.shape.id });
+const requestQuery = z.object({
+  clubId: zClub.shape.id,
+  semesterId: zSemester.shape.id.optional(),
+});
 
 const requestBody = z.object({});
 

--- a/packages/interface/src/api/activity/endpoint/apiAct013.ts
+++ b/packages/interface/src/api/activity/endpoint/apiAct013.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
 import { zClub } from "@clubs/domain/club/club";
+import { zSemester } from "@clubs/domain/semester/semester";
 
 import { registry } from "@clubs/interface/open-api";
 
@@ -17,7 +18,10 @@ const method = "GET";
 
 const requestParam = z.object({});
 
-const requestQuery = z.object({ clubId: zClub.shape.id });
+const requestQuery = z.object({
+  clubId: zClub.shape.id,
+  semesterId: zSemester.shape.id.optional(),
+});
 
 const requestBody = z.object({});
 

--- a/packages/interface/src/api/registration/endpoint/apiReg011.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg011.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClubName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
@@ -33,6 +35,7 @@ const responseBodyMap = {
   [HttpStatusCode.Ok]: z
     .object({
       id: z.coerce.number().int().min(1),
+      semesterId: zSemester.shape.id,
       registrationTypeEnumId: z.nativeEnum(RegistrationTypeEnum),
       registrationStatusEnumId: z.nativeEnum(RegistrationStatusEnum),
       clubId: z.coerce.number().int().min(1).optional(),

--- a/packages/interface/src/api/registration/endpoint/apiReg015.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg015.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClubName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
@@ -32,6 +34,7 @@ const responseBodyMap = {
   [HttpStatusCode.Ok]: z
     .object({
       id: z.coerce.number().int().min(1),
+      semesterId: zSemester.shape.id,
       registrationTypeEnumId: z.nativeEnum(RegistrationTypeEnum),
       registrationStatusEnumId: z.nativeEnum(RegistrationStatusEnum),
       clubId: z.coerce.number().int().min(1).optional(),

--- a/packages/interface/src/api/registration/endpoint/apiReg022.ts
+++ b/packages/interface/src/api/registration/endpoint/apiReg022.ts
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { z } from "zod";
 
+import { zSemester } from "@clubs/domain/semester/semester";
+
 import { zClubName } from "@clubs/interface/common/commonString";
 import {
   RegistrationStatusEnum,
@@ -32,6 +34,7 @@ const responseBodyMap = {
   [HttpStatusCode.Ok]: z
     .object({
       id: z.coerce.number().int().min(1),
+      semesterId: zSemester.shape.id,
       registrationTypeEnumId: z.nativeEnum(RegistrationTypeEnum),
       registrationStatusEnumId: z.nativeEnum(RegistrationStatusEnum),
       clubId: z.coerce.number().int().min(1).optional(),

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubActFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubActFrame.tsx
@@ -10,14 +10,17 @@ import MyRegisterClubActTable from "../components/MyRegisterClubActTable";
 interface MyRegisterClubActFrameProps {
   profile: string;
   clubId: number;
+  semesterId?: number;
 }
 
 const MyRegisterClubActFrame: React.FC<MyRegisterClubActFrameProps> = ({
   profile,
   clubId,
+  semesterId,
 }) => {
   const { data, isLoading, isError } = useProvisionalActivities(profile, {
     clubId,
+    semesterId,
   });
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>

--- a/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
+++ b/packages/web/src/features/my/register-club/frames/MyRegisterClubEditFrame.tsx
@@ -203,7 +203,10 @@ const MyRegisterClubEditFrame: React.FC<RegisterClubMainFrameProps> = ({
             }}
           />
           {type === RegistrationTypeEnum.Promotional && clubId && (
-            <ActivityReportFrame clubId={clubId} />
+            <ActivityReportFrame
+              clubId={clubId}
+              semesterId={initialData?.semesterId}
+            />
           )}
           <ClubRulesFrame
             isNewProvisional={type === RegistrationTypeEnum.NewProvisional}

--- a/packages/web/src/features/register-club/components/activity-report/ActivityReportFrame.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/ActivityReportFrame.tsx
@@ -16,6 +16,7 @@ import CreateActivityReportModal from "./CreateActivityReportModal";
 
 interface ActivityReportFrameProps {
   clubId: number;
+  semesterId?: number;
 }
 
 const OptionOuter = styled.div`
@@ -38,10 +39,12 @@ const StyledCard = styled(Card)`
 
 const ActivityReportFrame: React.FC<ActivityReportFrameProps> = ({
   clubId,
+  semesterId,
 }) => {
   const { profile } = useAuth();
   const { data, isLoading, isError } = useGetActivityReportsForPromotional({
     clubId,
+    semesterId,
   });
 
   const openCreateActivityReportModal = useCallback(() => {

--- a/packages/web/src/features/register-club/frames/RegisterClubDetailFrame.tsx
+++ b/packages/web/src/features/register-club/frames/RegisterClubDetailFrame.tsx
@@ -205,6 +205,7 @@ const RegisterClubDetailFrame: React.FC<ClubRegisterDetail> = ({
             <MyRegisterClubActFrame
               profile={profile}
               clubId={clubDetail.clubId}
+              semesterId={clubDetail.semesterId}
             />
           )}
         {clubDetail.professor && (

--- a/packages/web/src/features/register-club/services/useGetActivityReportsForPromotional.tsx
+++ b/packages/web/src/features/register-club/services/useGetActivityReportsForPromotional.tsx
@@ -12,7 +12,7 @@ export const useGetActivityReportsForPromotional = (
   query: ApiAct011RequestQuery,
 ) =>
   useQuery<ISuccessResponseType, Error>({
-    queryKey: [apiAct011.url(), query.clubId],
+    queryKey: [apiAct011.url(), query],
     queryFn: async (): Promise<ISuccessResponseType> => {
       const { data } = await axiosClientWithAuth.get(apiAct011.url(), {
         params: query,


### PR DESCRIPTION
## Summary
- 신규등록용 활동보고서 조회 기준을 현재 날짜가 아니라 등록 신청서의 semester 기준 활동기간으로 변경했습니다.
- 활동반기 삭제 시 연결된 활동보고서 또는 지원금 신청이 있으면 삭제를 막도록 검증을 추가했습니다.
- 관련 단위 테스트와 push 훅의 format/lint/MC/DC 검사를 통과했습니다.
- `pnpm build:api`와 `pnpm --filter web build`를 통과했습니다.

## Task Context
- Task ID: TU-433

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text:
- 등록 신청서 상세 화면에서 신규등록용 활동보고서가 올바른 활동기간을 기준으로 표시되도록 수정했습니다.
- 활동보고서나 지원금 신청이 연결된 활동반기를 실수로 삭제할 수 없도록 수정했습니다.
<!-- clubs:patch-note:end -->
