### PR TITLE
[TU-441] 지원금 과거 대시보드 동아리 정보 학기 기준 보정

### DIFF
--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -272,6 +272,7 @@ model Club {
   id           Int       @id @default(autoincrement())
   nameKr       String?   @unique @map("name_kr") @db.VarChar(30)
   nameEn       String?   @unique @map("name_en") @db.VarChar(100)
+  divisionId   Int       @map("division_id")
   description  String?   @db.Text
   foundingYear Int       @map("founding_year")
   createdAt    DateTime? @default(now()) @map("created_at") @db.Timestamp(0)

--- a/packages/api/src/feature/club/repository-old/club-old.repository.spec.ts
+++ b/packages/api/src/feature/club/repository-old/club-old.repository.spec.ts
@@ -1,0 +1,163 @@
+import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
+
+import { ClubOldRepository } from "./club-old.repository";
+
+describe("ClubOldRepository", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("fetchSummaries", () => {
+    it("uses Prisma Query API with requested semester ids", async () => {
+      const prisma = {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        club: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 201,
+              nameKr: "과거 동아리",
+              nameEn: "Historical Club",
+              divisionId: 601,
+              clubTs: [{ clubStatusEnumId: ClubTypeEnum.Provisional }],
+            },
+          ]),
+        },
+      };
+      const repository = new ClubOldRepository(
+        prisma as unknown as ConstructorParameters<typeof ClubOldRepository>[0],
+      );
+
+      const result = await repository.fetchSummaries([201], [7]);
+
+      expect(prisma.club.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: [201] },
+          deletedAt: null,
+          clubTs: {
+            some: {
+              semesterId: { in: [7] },
+              deletedAt: null,
+            },
+          },
+        },
+        select: {
+          id: true,
+          nameKr: true,
+          nameEn: true,
+          divisionId: true,
+          clubTs: {
+            where: {
+              semesterId: { in: [7] },
+              deletedAt: null,
+            },
+            select: {
+              clubStatusEnumId: true,
+            },
+          },
+        },
+      });
+      expect(prisma.$queryRaw).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 201,
+          name: "과거 동아리",
+          typeEnum: ClubTypeEnum.Provisional,
+          division: { id: 601 },
+        },
+      ]);
+    });
+
+    it("uses Prisma Query API with the current club semester when no semester ids are provided", async () => {
+      const now = new Date("2026-06-03T12:00:00.000Z");
+      jest.useFakeTimers().setSystemTime(now);
+
+      const prisma = {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        club: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 201,
+              nameKr: "현재 동아리",
+              nameEn: "Current Club",
+              divisionId: 601,
+              clubTs: [{ clubStatusEnumId: ClubTypeEnum.Regular }],
+            },
+          ]),
+        },
+      };
+      const repository = new ClubOldRepository(
+        prisma as unknown as ConstructorParameters<typeof ClubOldRepository>[0],
+      );
+
+      const result = await repository.fetchSummaries([201]);
+
+      const currentClubTWhere = {
+        startTerm: { lte: now },
+        OR: [{ endTerm: { gte: now } }, { endTerm: null }],
+        deletedAt: null,
+      };
+      expect(prisma.club.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: [201] },
+          deletedAt: null,
+          clubTs: {
+            some: currentClubTWhere,
+          },
+        },
+        select: {
+          id: true,
+          nameKr: true,
+          nameEn: true,
+          divisionId: true,
+          clubTs: {
+            where: currentClubTWhere,
+            select: {
+              clubStatusEnumId: true,
+            },
+          },
+        },
+      });
+      expect(prisma.$queryRaw).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 201,
+          name: "현재 동아리",
+          typeEnum: ClubTypeEnum.Regular,
+          division: { id: 601 },
+        },
+      ]);
+    });
+
+    it("uses the current club semester when an empty semester id list is provided", async () => {
+      const now = new Date("2026-06-03T12:00:00.000Z");
+      jest.useFakeTimers().setSystemTime(now);
+
+      const prisma = {
+        $queryRaw: jest.fn().mockResolvedValue([]),
+        club: {
+          findMany: jest.fn().mockResolvedValue([]),
+        },
+      };
+      const repository = new ClubOldRepository(
+        prisma as unknown as ConstructorParameters<typeof ClubOldRepository>[0],
+      );
+
+      await repository.fetchSummaries([201], []);
+
+      expect(prisma.club.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            clubTs: {
+              some: {
+                startTerm: { lte: now },
+                OR: [{ endTerm: { gte: now } }, { endTerm: null }],
+                deletedAt: null,
+              },
+            },
+          }),
+        }),
+      );
+      expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/api/src/feature/club/repository-old/club-old.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club-old.repository.ts
@@ -555,100 +555,58 @@ export class ClubOldRepository {
       return [];
     }
 
-    const whereConditions: Prisma.Sql[] = [];
+    const targetSemesterIds = semesterIds ?? [];
+    const hasTargetSemesters = targetSemesterIds.length > 0;
+    const currentTerm = new Date();
+    const clubTWhere: Prisma.ClubTWhereInput = hasTargetSemesters
+      ? {
+          semesterId: { in: targetSemesterIds },
+          deletedAt: null,
+        }
+      : {
+          startTerm: { lte: currentTerm },
+          OR: [{ endTerm: { gte: currentTerm } }, { endTerm: null }],
+          deletedAt: null,
+        };
 
-    whereConditions.push(Prisma.sql`c.id IN (${Prisma.join(clubIds)})`);
-
-    if (semesterIds && semesterIds.length > 0) {
-      whereConditions.push(
-        Prisma.sql`ct.semester_id IN (${Prisma.join(semesterIds)})`,
-      );
-    } else {
-      whereConditions.push(
-        Prisma.sql`ct.start_term <= NOW() AND (ct.end_term >= NOW() OR ct.end_term IS NULL)`,
-      );
-    }
-    whereConditions.push(Prisma.sql`c.deleted_at IS NULL`);
-    whereConditions.push(Prisma.sql`ct.deleted_at IS NULL`);
-
-    const whereClause = Prisma.sql`${Prisma.join(whereConditions, " AND ")}`;
-
-    const result = await this.prisma.$queryRaw<
-      Array<{
-        clubId: number;
-        nameKr: string;
-        nameEn: string;
-        description: string | null;
-        foundingYear: number;
-        divisionId: number;
-        clubCreatedAt: Date | null;
-        clubDeletedAt: Date | null;
-        ctId: number | null;
-        clubStatusEnumId: number | null;
-        characteristicKr: string | null;
-        characteristicEn: string | null;
-        professorId: number | null;
-        semesterId: number | null;
-        ctStartTerm: Date | null;
-        ctEndTerm: Date | null;
-        ctCreatedAt: Date | null;
-        ctDeletedAt: Date | null;
-      }>
-    >(Prisma.sql`
-      SELECT c.id AS clubId,
-             c.name_kr AS nameKr,
-             c.name_en AS nameEn,
-             c.description AS description,
-             c.founding_year AS foundingYear,
-             c.division_id AS divisionId,
-             c.created_at AS clubCreatedAt,
-             c.deleted_at AS clubDeletedAt,
-             ct.id AS ctId,
-             ct.club_status_enum_id AS clubStatusEnumId,
-             ct.characteristic_kr AS characteristicKr,
-             ct.characteristic_en AS characteristicEn,
-             ct.professor_id AS professorId,
-             ct.semester_id AS semesterId,
-             ct.start_term AS ctStartTerm,
-             ct.end_term AS ctEndTerm,
-             ct.created_at AS ctCreatedAt,
-             ct.deleted_at AS ctDeletedAt
-      FROM club c
-      LEFT JOIN club_t ct ON c.id = ct.club_id
-      WHERE ${whereClause}
-    `);
-
-    return result.map(row =>
-      VClubSummary.fromDBResult({
-        club: {
-          id: row.clubId,
-          nameKr: row.nameKr,
-          nameEn: row.nameEn,
-          divisionId: row.divisionId,
-          description: row.description,
-          foundingYear: row.foundingYear,
-          createdAt: row.clubCreatedAt,
-          deletedAt: row.clubDeletedAt,
+    const clubs = await this.prisma.club.findMany({
+      where: {
+        id: { in: clubIds },
+        deletedAt: null,
+        clubTs: {
+          some: clubTWhere,
         },
-        club_t: row.ctId
-          ? {
-              id: row.ctId,
-              clubId: row.clubId,
-              clubStatusEnumId: row.clubStatusEnumId,
-              characteristicKr: row.characteristicKr,
-              characteristicEn: row.characteristicEn,
-              professorId: row.professorId,
-              semesterId: row.semesterId,
-              startTerm: row.ctStartTerm,
-              endTerm: row.ctEndTerm,
-              createdAt: row.ctCreatedAt,
-              deletedAt: row.ctDeletedAt,
-            }
-          : undefined,
-      }),
+      },
+      select: {
+        id: true,
+        nameKr: true,
+        nameEn: true,
+        divisionId: true,
+        clubTs: {
+          where: clubTWhere,
+          select: {
+            clubStatusEnumId: true,
+          },
+        },
+      },
+    });
+
+    return clubs.flatMap(club =>
+      club.clubTs.map(clubT =>
+        VClubSummary.fromDBResult({
+          club: {
+            id: club.id,
+            nameKr: club.nameKr,
+            nameEn: club.nameEn,
+            divisionId: club.divisionId,
+          },
+          club_t: {
+            clubStatusEnumId: clubT.clubStatusEnumId,
+          },
+        }),
+      ),
     );
   }
-
   async findOne(
     clubId: number,
     semester: ISemester,

--- a/packages/api/src/feature/funding/service/funding.service.spec.ts
+++ b/packages/api/src/feature/funding/service/funding.service.spec.ts
@@ -4,8 +4,9 @@ import FundingService from "./funding.service";
 
 type FundingServiceDependencies = ConstructorParameters<typeof FundingService>;
 
-const activityDuration = { id: 301 };
-const club = { id: 201, name: "동아리" };
+const activityDuration = { id: 301, semester: { id: 1 } };
+const division = { id: 601, name: "분과" };
+const club = { id: 201, name: "동아리", division };
 const chargedExecutive = {
   id: 101,
   name: "담당자",
@@ -47,6 +48,7 @@ const createFundingService = () => {
   const clubPublicService = {
     fetchSummary: jest.fn().mockResolvedValue(club),
     fetchSummaries: jest.fn().mockResolvedValue([club]),
+    fetchDivisionSummaries: jest.fn().mockResolvedValue([division]),
   };
   const activityPublicService = {
     fetchSummaries: jest.fn().mockResolvedValue([activity]),
@@ -76,8 +78,57 @@ const createFundingService = () => {
     service,
     fundingRepository,
     fundingCommentRepository,
+    clubPublicService,
+    activityDurationPublicService,
   };
 };
+
+describe("FundingService historical semester club summaries", () => {
+  it("loads executive dashboard club summaries for the requested semester", async () => {
+    const {
+      service,
+      fundingRepository,
+      clubPublicService,
+      activityDurationPublicService,
+    } = createFundingService();
+    const semesterId = 7;
+    activityDurationPublicService.load.mockResolvedValue({
+      ...activityDuration,
+      semester: { id: semesterId },
+    });
+    fundingRepository.fetchSummaries.mockResolvedValue([funding]);
+
+    await service.getExecutiveFundings(chargedExecutive.id, { semesterId });
+
+    expect(clubPublicService.fetchSummaries).toHaveBeenCalledWith(
+      [club.id],
+      [semesterId],
+    );
+  });
+
+  it("returns the requested semester club summary for club brief", async () => {
+    const { service, fundingRepository, clubPublicService } =
+      createFundingService();
+    const semesterId = 7;
+    const currentClub = { ...club, name: "현재 동아리" };
+    const historicalClub = { ...club, name: "과거 동아리" };
+    fundingRepository.fetchSummaries.mockResolvedValue([funding]);
+    clubPublicService.fetchSummary.mockResolvedValue(currentClub);
+    clubPublicService.fetchSummaries.mockResolvedValue([historicalClub]);
+
+    const result = await service.getExecutiveFundingsClubBrief(
+      chargedExecutive.id,
+      { clubId: club.id },
+      { semesterId },
+    );
+
+    expect(result.club).toEqual(historicalClub);
+    expect(clubPublicService.fetchSummaries).toHaveBeenCalledWith(
+      [club.id],
+      [semesterId],
+    );
+  });
+});
 
 describe("FundingService final commented executive", () => {
   it("uses the latest funding feedback by descending id for club brief", async () => {

--- a/packages/api/src/feature/funding/service/funding.service.spec.ts
+++ b/packages/api/src/feature/funding/service/funding.service.spec.ts
@@ -128,6 +128,25 @@ describe("FundingService historical semester club summaries", () => {
       [semesterId],
     );
   });
+
+  it("falls back to current club summary when requested semester summary is missing", async () => {
+    const { service, fundingRepository, clubPublicService } =
+      createFundingService();
+    const semesterId = 7;
+    const currentClub = { ...club, name: "현재 동아리" };
+    fundingRepository.fetchSummaries.mockResolvedValue([funding]);
+    clubPublicService.fetchSummaries.mockResolvedValue([]);
+    clubPublicService.fetchSummary.mockResolvedValue(currentClub);
+
+    const result = await service.getExecutiveFundingsClubBrief(
+      chargedExecutive.id,
+      { clubId: club.id },
+      { semesterId },
+    );
+
+    expect(result.club).toEqual(currentClub);
+    expect(clubPublicService.fetchSummary).toHaveBeenCalledWith(club.id);
+  });
 });
 
 describe("FundingService final commented executive", () => {

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -636,7 +636,8 @@ export default class FundingService {
     // );
 
     const clubs = await this.clubPublicService.fetchSummaries(
-      fundings.map(funding => funding.club.id),
+      Array.from(new Set(fundings.map(funding => funding.club.id))),
+      [semesterId],
     );
     const devisions = await this.clubPublicService.fetchDivisionSummaries(
       clubs.map(club => club.division.id),
@@ -837,8 +838,6 @@ export default class FundingService {
       activityDuration.id,
     );
 
-    const club = await this.clubPublicService.fetchSummary(param.clubId);
-
     const chargedExecutiveId = fundings
       .filter(funding => funding.club.id === param.clubId)
       .filter(funding => funding.chargedExecutive)
@@ -875,8 +874,18 @@ export default class FundingService {
     );
 
     const clubs = await this.clubPublicService.fetchSummaries(
-      fundings.map(funding => funding.club.id),
+      Array.from(
+        new Set([param.clubId, ...fundings.map(funding => funding.club.id)]),
+      ),
+      [semesterId],
     );
+    const club = clubs.find(c => c.id === param.clubId);
+    if (!club) {
+      throw new HttpException(
+        "Club not found at semester",
+        HttpStatus.NOT_FOUND,
+      );
+    }
 
     const pastActivityDurations =
       query.semesterId === undefined

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -879,13 +879,9 @@ export default class FundingService {
       ),
       [semesterId],
     );
-    const club = clubs.find(c => c.id === param.clubId);
-    if (!club) {
-      throw new HttpException(
-        "Club not found at semester",
-        HttpStatus.NOT_FOUND,
-      );
-    }
+    const club =
+      clubs.find(c => c.id === param.clubId) ??
+      (await this.clubPublicService.fetchSummary(param.clubId));
 
     const pastActivityDurations =
       query.semesterId === undefined

--- a/packages/api/test/helpers/db-seed.ts
+++ b/packages/api/test/helpers/db-seed.ts
@@ -138,6 +138,7 @@ export async function seedTestClub(divisionId?: number) {
     data: {
       nameKr: TEST_CLUB.nameKr,
       nameEn: TEST_CLUB.nameEn,
+      divisionId: finalDivisionId,
       description: TEST_CLUB.description,
       foundingYear: TEST_CLUB.foundingYear,
     },


### PR DESCRIPTION
## Summary
- 지원금 집행부 대시보드와 동아리 brief의 동아리 요약 조회를 선택 학기 기준으로 보정했습니다.
- 지원금 경로에서 사용하는 ClubOldRepository.fetchSummaries를 raw SQL에서 Prisma Query API로 전환했습니다.
- 학기 기준 조회와 Prisma Query 전환을 검증하는 unit test를 추가했습니다.

## Task Context
- Task ID: TU-441
- Notion: https://www.notion.so/373c25603b0b8191aa9ec0497a630497

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 지원금 과거 대시보드에서 동아리 유형이 선택한 학기 기준으로 표시되도록 수정했습니다.
<!-- clubs:patch-note:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when accessing club information for specific semesters, returning proper error messages instead of unexpected fallbacks.

* **Refactor**
  * Enhanced club data retrieval mechanisms to support more accurate semester-specific club information queries.
  * Strengthened club division tracking for improved data consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->