### PR TITLE
[TU-388] 지원금 이의제기 기간 신청 차단

### DIFF
--- a/packages/api/src/feature/funding/repository/funding.repository.spec.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.spec.ts
@@ -1,4 +1,88 @@
+import FundingRepository from "./funding.repository";
 import { buildFundingTransportationPassengerFindManyArgs } from "./funding.repository.util";
+
+const NOW = new Date("2026-06-03T12:00:00.000Z");
+
+const injectTestClock = <T extends object>(target: T): T =>
+  Object.assign(target, {
+    clock: {
+      now: () => NOW,
+    },
+  });
+
+const createUpdateManyDelegate = () => ({
+  updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+});
+
+const createRelatedFundingDelegate = () => ({
+  create: jest.fn().mockResolvedValue({}),
+  updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+});
+
+const createFundingTx = () => ({
+  funding: {
+    create: jest.fn().mockResolvedValue({ id: 401 }),
+    update: jest.fn().mockResolvedValue({}),
+    updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+  },
+  fundingFeedback: createUpdateManyDelegate(),
+  fundingTradeEvidenceFile: createRelatedFundingDelegate(),
+  fundingTradeDetailFile: createRelatedFundingDelegate(),
+  fundingClubSuppliesImageFile: createRelatedFundingDelegate(),
+  fundingClubSuppliesSoftwareEvidenceFile: createRelatedFundingDelegate(),
+  fundingFixtureImageFile: createRelatedFundingDelegate(),
+  fundingFixtureSoftwareEvidenceFile: createRelatedFundingDelegate(),
+  fundingNonCorporateTransactionFile: createRelatedFundingDelegate(),
+  fundingFoodExpenseFile: createRelatedFundingDelegate(),
+  fundingLaborContractFile: createRelatedFundingDelegate(),
+  fundingExternalEventParticipationFeeFile: createRelatedFundingDelegate(),
+  fundingPublicationFile: createRelatedFundingDelegate(),
+  fundingProfitMakingActivityFile: createRelatedFundingDelegate(),
+  fundingJointExpenseFile: createRelatedFundingDelegate(),
+  fundingEtcExpenseFile: createRelatedFundingDelegate(),
+  fundingTransportationPassenger: createRelatedFundingDelegate(),
+});
+
+const createFundingRequest = () =>
+  ({
+    club: { id: 101 },
+    purposeActivity: { id: 201 },
+    name: "funding",
+    expenditureDate: NOW,
+    expenditureAmount: 10000,
+    isFixture: false,
+    isTransportation: false,
+    isFoodExpense: false,
+    isLaborContract: false,
+    isExternalEventParticipationFee: false,
+    isPublication: false,
+    isProfitMakingActivity: false,
+    isJointExpense: false,
+    isEtcExpense: false,
+    isNonCorporateTransaction: false,
+    tradeDetailExplanation: "detail",
+    tradeEvidenceFiles: [],
+    tradeDetailFiles: [],
+  }) as never;
+
+const createFundingExtra = () =>
+  ({
+    activityD: { id: 301 },
+    fundingStatusEnum: 1,
+    approvedAmount: 0,
+  }) as never;
+
+const createRepository = (tx = createFundingTx()) => {
+  const txHost = { tx };
+  const prisma = {
+    $transaction: jest.fn(),
+  };
+  const repository = injectTestClock(
+    new FundingRepository(txHost as never, prisma as never),
+  );
+
+  return { prisma, repository, tx, txHost };
+};
 
 describe("buildFundingTransportationPassengerFindManyArgs", () => {
   it("shows submitted distinct transportation passengers without student_t filtering", () => {
@@ -18,5 +102,66 @@ describe("buildFundingTransportationPassengerFindManyArgs", () => {
         studentId: true,
       },
     });
+  });
+});
+
+describe("FundingRepository transactions", () => {
+  it("inserts a funding through TransactionHost tx", async () => {
+    const { prisma, repository, tx } = createRepository();
+    const fetchSpy = jest
+      .spyOn(repository, "fetch")
+      .mockResolvedValue({} as never);
+
+    await repository.insert(createFundingRequest(), createFundingExtra());
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.funding.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        clubId: 101,
+        purposeActivityId: 201,
+        activityDId: 301,
+      }),
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(401);
+  });
+
+  it("soft-deletes a funding through TransactionHost tx", async () => {
+    const { prisma, repository, tx } = createRepository();
+
+    await repository.delete(401);
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.funding.updateMany).toHaveBeenCalledWith({
+      where: { id: 401 },
+      data: { deletedAt: NOW, editedAt: NOW },
+    });
+    expect(tx.fundingFeedback.updateMany).toHaveBeenCalledWith({
+      where: { fundingId: 401 },
+      data: { deletedAt: NOW },
+    });
+  });
+
+  it("updates a funding through TransactionHost tx", async () => {
+    const { prisma, repository, tx } = createRepository();
+    const fetchSpy = jest
+      .spyOn(repository, "fetch")
+      .mockResolvedValue({} as never);
+
+    await repository.put(402, createFundingRequest(), createFundingExtra());
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.funding.update).toHaveBeenCalledWith({
+      where: { id: 402 },
+      data: expect.objectContaining({
+        purposeActivityId: 201,
+        fundingStatusEnum: 1,
+        editedAt: NOW,
+      }),
+    });
+    expect(tx.fundingTradeEvidenceFile.updateMany).toHaveBeenCalledWith({
+      where: { fundingId: 402 },
+      data: { deletedAt: NOW },
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(402);
   });
 });

--- a/packages/api/src/feature/funding/repository/funding.repository.ts
+++ b/packages/api/src/feature/funding/repository/funding.repository.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { TransactionHost } from "@nestjs-cls/transactional";
 import { Prisma } from "@prisma/client";
 
 import {
@@ -10,6 +11,7 @@ import {
 
 import { PrismaTransactionClient } from "@sparcs-clubs/api/common/base/base.repository";
 import { CLOCK, Clock } from "@sparcs-clubs/api/common/clock/clock";
+import { PrismaTransactionalAdapter } from "@sparcs-clubs/api/common/transaction/transaction.type";
 import { PrismaService } from "@sparcs-clubs/api/prisma/prisma.service";
 
 import { FundingDBResult, MFunding } from "../model/funding.model";
@@ -43,7 +45,10 @@ const fundingSummarySelect = {
 export default class FundingRepository {
   @Inject(CLOCK) private readonly clock: Clock;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly txHost: TransactionHost<PrismaTransactionalAdapter>,
+    private readonly prisma: PrismaService,
+  ) {}
 
   async withTransaction<Result>(
     callback: (tx: PrismaTransactionClient) => Promise<Result>,
@@ -60,7 +65,9 @@ export default class FundingRepository {
   }
 
   async find(id: number): Promise<MFunding | null> {
-    const result = await this.prisma.funding.findMany({
+    const { tx } = this.txHost;
+
+    const result = await tx.funding.findMany({
       where: { id, deletedAt: null },
     });
 
@@ -85,49 +92,49 @@ export default class FundingRepository {
       etcExpenseFiles,
       transportationPassengers,
     ] = await Promise.all([
-      this.prisma.fundingTradeEvidenceFile.findMany({
+      tx.fundingTradeEvidenceFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingTradeDetailFile.findMany({
+      tx.fundingTradeDetailFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingClubSuppliesImageFile.findMany({
+      tx.fundingClubSuppliesImageFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingClubSuppliesSoftwareEvidenceFile.findMany({
+      tx.fundingClubSuppliesSoftwareEvidenceFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingFixtureImageFile.findMany({
+      tx.fundingFixtureImageFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingFixtureSoftwareEvidenceFile.findMany({
+      tx.fundingFixtureSoftwareEvidenceFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingNonCorporateTransactionFile.findMany({
+      tx.fundingNonCorporateTransactionFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingFoodExpenseFile.findMany({
+      tx.fundingFoodExpenseFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingLaborContractFile.findMany({
+      tx.fundingLaborContractFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingExternalEventParticipationFeeFile.findMany({
+      tx.fundingExternalEventParticipationFeeFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingPublicationFile.findMany({
+      tx.fundingPublicationFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingProfitMakingActivityFile.findMany({
+      tx.fundingProfitMakingActivityFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingJointExpenseFile.findMany({
+      tx.fundingJointExpenseFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingEtcExpenseFile.findMany({
+      tx.fundingEtcExpenseFile.findMany({
         where: { fundingId: id, deletedAt: null },
       }),
-      this.prisma.fundingTransportationPassenger.findMany(
+      tx.fundingTransportationPassenger.findMany(
         buildFundingTransportationPassengerFindManyArgs(id),
       ),
     ]);
@@ -265,328 +272,325 @@ export default class FundingRepository {
     funding: IFundingRequest,
     extra: IFundingExtra,
   ): Promise<MFunding> {
-    const result = await this.prisma.$transaction<number>(async tx => {
-      // 1. Insert funding order
-      const fundingOrder = await tx.funding.create({
-        data: {
-          clubId: funding.club.id,
-          purposeActivityId: funding.purposeActivity.id,
-          activityDId: extra.activityD.id,
-          fundingStatusEnum: extra.fundingStatusEnum,
-          name: funding.name,
-          expenditureDate: funding.expenditureDate,
-          expenditureAmount: funding.expenditureAmount,
-          approvedAmount: extra.approvedAmount,
-          isFixture: funding.isFixture,
-          isTransportation: funding.isTransportation,
-          isFoodExpense: funding.isFoodExpense,
-          isLaborContract: funding.isLaborContract,
-          isExternalEventParticipationFee:
-            funding.isExternalEventParticipationFee,
-          isPublication: funding.isPublication,
-          isProfitMakingActivity: funding.isProfitMakingActivity,
-          isJointExpense: funding.isJointExpense,
-          isEtcExpense: funding.isEtcExpense,
-          isNonCorporateTransaction: funding.isNonCorporateTransaction,
-          tradeDetailExplanation: funding.tradeDetailExplanation,
-          // ClubOld supplies fields
-          clubSuppliesName: funding.clubSupplies?.name,
-          clubSuppliesEvidenceEnum: funding.clubSupplies?.evidenceEnum,
-          clubSuppliesClassEnum: funding.clubSupplies?.classEnum,
-          clubSuppliesPurpose: funding.clubSupplies?.purpose,
-          clubSuppliesSoftwareEvidence: funding.clubSupplies?.softwareEvidence,
-          numberOfClubSupplies: funding.clubSupplies?.number,
-          priceOfClubSupplies: funding.clubSupplies?.price,
-          // Fixture fields
-          fixtureName: funding.fixture?.name,
-          fixtureEvidenceEnum: funding.fixture?.evidenceEnum,
-          fixtureClassEnum: funding.fixture?.classEnum,
-          fixturePurpose: funding.fixture?.purpose,
-          fixtureSoftwareEvidence: funding.fixture?.softwareEvidence,
-          numberOfFixture: funding.fixture?.number,
-          priceOfFixture: funding.fixture?.price,
-          // Transportation fields
-          transportationEnum: funding.transportation?.enum,
-          origin: funding.transportation?.origin,
-          destination: funding.transportation?.destination,
-          purposeOfTransportation: funding.transportation?.purpose,
-          // Trader fields
-          traderName: funding.nonCorporateTransaction?.traderName,
-          traderAccountNumber:
-            funding.nonCorporateTransaction?.traderAccountNumber,
-          wasteExplanation: funding.nonCorporateTransaction?.wasteExplanation,
-          // Expense explanations
-          foodExpenseExplanation: funding.foodExpense?.explanation,
-          laborContractExplanation: funding.laborContract?.explanation,
-          externalEventParticipationFeeExplanation:
-            funding.externalEventParticipationFee?.explanation,
-          publicationExplanation: funding.publication?.explanation,
-          profitMakingActivityExplanation:
-            funding.profitMakingActivity?.explanation,
-          jointExpenseExplanation: funding.jointExpense?.explanation,
-          etcExpenseExplanation: funding.etcExpense?.explanation,
-        },
-      });
+    const { tx } = this.txHost;
 
-      const fundingId = fundingOrder.id;
-
-      // 3. Insert files and related data
-      await Promise.all([
-        // Trade files
-        ...funding.tradeEvidenceFiles.map(file =>
-          tx.fundingTradeEvidenceFile.create({
-            data: {
-              fundingId,
-              fileId: file.id,
-            },
-          }),
-        ),
-        ...funding.tradeDetailFiles.map(file =>
-          tx.fundingTradeDetailFile.create({
-            data: {
-              fundingId,
-              fileId: file.id,
-            },
-          }),
-        ),
-
-        // ClubOld supplies files
-        ...(funding.clubSupplies && funding.clubSupplies.imageFiles
-          ? funding.clubSupplies.imageFiles.map(file =>
-              tx.fundingClubSuppliesImageFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-        ...(funding.clubSupplies && funding.clubSupplies.softwareEvidenceFiles
-          ? funding.clubSupplies.softwareEvidenceFiles.map(file =>
-              tx.fundingClubSuppliesSoftwareEvidenceFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Fixture files
-        ...(funding.isFixture && funding.fixture.imageFiles
-          ? funding.fixture.imageFiles.map(file =>
-              tx.fundingFixtureImageFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-        ...(funding.isFixture && funding.fixture.softwareEvidenceFiles
-          ? funding.fixture.softwareEvidenceFiles.map(file =>
-              tx.fundingFixtureSoftwareEvidenceFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // NonCorporateTransaction files
-        ...(funding.isNonCorporateTransaction && funding.nonCorporateTransaction
-          ? funding.nonCorporateTransaction.files.map(file =>
-              tx.fundingNonCorporateTransactionFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Food expense files
-        ...(funding.isFoodExpense && funding.foodExpense
-          ? funding.foodExpense.files.map(file =>
-              tx.fundingFoodExpenseFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Labor contract files
-        ...(funding.isLaborContract && funding.laborContract
-          ? funding.laborContract.files.map(file =>
-              tx.fundingLaborContractFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // External event participation fee files
-        ...(funding.isExternalEventParticipationFee &&
-        funding.externalEventParticipationFee
-          ? funding.externalEventParticipationFee.files.map(file =>
-              tx.fundingExternalEventParticipationFeeFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Publication files
-        ...(funding.isPublication && funding.publication
-          ? funding.publication.files.map(file =>
-              tx.fundingPublicationFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Profit making activity files
-        ...(funding.isProfitMakingActivity && funding.profitMakingActivity
-          ? funding.profitMakingActivity.files.map(file =>
-              tx.fundingProfitMakingActivityFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Joint expense files
-        ...(funding.isJointExpense && funding.jointExpense
-          ? funding.jointExpense.files.map(file =>
-              tx.fundingJointExpenseFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Etc expense files
-        ...(funding.isEtcExpense && funding.etcExpense
-          ? funding.etcExpense.files.map(file =>
-              tx.fundingEtcExpenseFile.create({
-                data: {
-                  fundingId,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Transportation passengers
-        ...(funding.isTransportation && funding.transportation
-          ? funding.transportation.passengers.map(passenger =>
-              tx.fundingTransportationPassenger.create({
-                data: {
-                  fundingId,
-                  studentId: passenger.id,
-                },
-              }),
-            )
-          : []),
-      ]);
-
-      return fundingId;
+    // 1. Insert funding order
+    const fundingOrder = await tx.funding.create({
+      data: {
+        clubId: funding.club.id,
+        purposeActivityId: funding.purposeActivity.id,
+        activityDId: extra.activityD.id,
+        fundingStatusEnum: extra.fundingStatusEnum,
+        name: funding.name,
+        expenditureDate: funding.expenditureDate,
+        expenditureAmount: funding.expenditureAmount,
+        approvedAmount: extra.approvedAmount,
+        isFixture: funding.isFixture,
+        isTransportation: funding.isTransportation,
+        isFoodExpense: funding.isFoodExpense,
+        isLaborContract: funding.isLaborContract,
+        isExternalEventParticipationFee:
+          funding.isExternalEventParticipationFee,
+        isPublication: funding.isPublication,
+        isProfitMakingActivity: funding.isProfitMakingActivity,
+        isJointExpense: funding.isJointExpense,
+        isEtcExpense: funding.isEtcExpense,
+        isNonCorporateTransaction: funding.isNonCorporateTransaction,
+        tradeDetailExplanation: funding.tradeDetailExplanation,
+        // ClubOld supplies fields
+        clubSuppliesName: funding.clubSupplies?.name,
+        clubSuppliesEvidenceEnum: funding.clubSupplies?.evidenceEnum,
+        clubSuppliesClassEnum: funding.clubSupplies?.classEnum,
+        clubSuppliesPurpose: funding.clubSupplies?.purpose,
+        clubSuppliesSoftwareEvidence: funding.clubSupplies?.softwareEvidence,
+        numberOfClubSupplies: funding.clubSupplies?.number,
+        priceOfClubSupplies: funding.clubSupplies?.price,
+        // Fixture fields
+        fixtureName: funding.fixture?.name,
+        fixtureEvidenceEnum: funding.fixture?.evidenceEnum,
+        fixtureClassEnum: funding.fixture?.classEnum,
+        fixturePurpose: funding.fixture?.purpose,
+        fixtureSoftwareEvidence: funding.fixture?.softwareEvidence,
+        numberOfFixture: funding.fixture?.number,
+        priceOfFixture: funding.fixture?.price,
+        // Transportation fields
+        transportationEnum: funding.transportation?.enum,
+        origin: funding.transportation?.origin,
+        destination: funding.transportation?.destination,
+        purposeOfTransportation: funding.transportation?.purpose,
+        // Trader fields
+        traderName: funding.nonCorporateTransaction?.traderName,
+        traderAccountNumber:
+          funding.nonCorporateTransaction?.traderAccountNumber,
+        wasteExplanation: funding.nonCorporateTransaction?.wasteExplanation,
+        // Expense explanations
+        foodExpenseExplanation: funding.foodExpense?.explanation,
+        laborContractExplanation: funding.laborContract?.explanation,
+        externalEventParticipationFeeExplanation:
+          funding.externalEventParticipationFee?.explanation,
+        publicationExplanation: funding.publication?.explanation,
+        profitMakingActivityExplanation:
+          funding.profitMakingActivity?.explanation,
+        jointExpenseExplanation: funding.jointExpense?.explanation,
+        etcExpenseExplanation: funding.etcExpense?.explanation,
+      },
     });
 
+    const fundingId = fundingOrder.id;
+
+    // 3. Insert files and related data
+    await Promise.all([
+      // Trade files
+      ...funding.tradeEvidenceFiles.map(file =>
+        tx.fundingTradeEvidenceFile.create({
+          data: {
+            fundingId,
+            fileId: file.id,
+          },
+        }),
+      ),
+      ...funding.tradeDetailFiles.map(file =>
+        tx.fundingTradeDetailFile.create({
+          data: {
+            fundingId,
+            fileId: file.id,
+          },
+        }),
+      ),
+
+      // ClubOld supplies files
+      ...(funding.clubSupplies && funding.clubSupplies.imageFiles
+        ? funding.clubSupplies.imageFiles.map(file =>
+            tx.fundingClubSuppliesImageFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+      ...(funding.clubSupplies && funding.clubSupplies.softwareEvidenceFiles
+        ? funding.clubSupplies.softwareEvidenceFiles.map(file =>
+            tx.fundingClubSuppliesSoftwareEvidenceFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Fixture files
+      ...(funding.isFixture && funding.fixture.imageFiles
+        ? funding.fixture.imageFiles.map(file =>
+            tx.fundingFixtureImageFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+      ...(funding.isFixture && funding.fixture.softwareEvidenceFiles
+        ? funding.fixture.softwareEvidenceFiles.map(file =>
+            tx.fundingFixtureSoftwareEvidenceFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // NonCorporateTransaction files
+      ...(funding.isNonCorporateTransaction && funding.nonCorporateTransaction
+        ? funding.nonCorporateTransaction.files.map(file =>
+            tx.fundingNonCorporateTransactionFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Food expense files
+      ...(funding.isFoodExpense && funding.foodExpense
+        ? funding.foodExpense.files.map(file =>
+            tx.fundingFoodExpenseFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Labor contract files
+      ...(funding.isLaborContract && funding.laborContract
+        ? funding.laborContract.files.map(file =>
+            tx.fundingLaborContractFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // External event participation fee files
+      ...(funding.isExternalEventParticipationFee &&
+      funding.externalEventParticipationFee
+        ? funding.externalEventParticipationFee.files.map(file =>
+            tx.fundingExternalEventParticipationFeeFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Publication files
+      ...(funding.isPublication && funding.publication
+        ? funding.publication.files.map(file =>
+            tx.fundingPublicationFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Profit making activity files
+      ...(funding.isProfitMakingActivity && funding.profitMakingActivity
+        ? funding.profitMakingActivity.files.map(file =>
+            tx.fundingProfitMakingActivityFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Joint expense files
+      ...(funding.isJointExpense && funding.jointExpense
+        ? funding.jointExpense.files.map(file =>
+            tx.fundingJointExpenseFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Etc expense files
+      ...(funding.isEtcExpense && funding.etcExpense
+        ? funding.etcExpense.files.map(file =>
+            tx.fundingEtcExpenseFile.create({
+              data: {
+                fundingId,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Transportation passengers
+      ...(funding.isTransportation && funding.transportation
+        ? funding.transportation.passengers.map(passenger =>
+            tx.fundingTransportationPassenger.create({
+              data: {
+                fundingId,
+                studentId: passenger.id,
+              },
+            }),
+          )
+        : []),
+    ]);
+
     // 4. Return the newly created funding
-    return this.fetch(result);
+    return this.fetch(fundingId);
   }
 
   async delete(id: number): Promise<void> {
-    await this.prisma.$transaction(async tx => {
-      const now = this.clock.now();
+    const { tx } = this.txHost;
+    const now = this.clock.now();
 
-      // Soft delete funding order and all related records
-      await Promise.all([
-        tx.funding.updateMany({
-          where: { id },
-          data: { deletedAt: now, editedAt: now },
-        }),
-        tx.fundingFeedback.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingTradeEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingTradeDetailFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingClubSuppliesImageFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingClubSuppliesSoftwareEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFixtureImageFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFixtureSoftwareEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingNonCorporateTransactionFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFoodExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingLaborContractFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingExternalEventParticipationFeeFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingPublicationFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingProfitMakingActivityFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingJointExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingEtcExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingTransportationPassenger.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-      ]);
-    });
+    // Soft delete funding order and all related records
+    await Promise.all([
+      tx.funding.updateMany({
+        where: { id },
+        data: { deletedAt: now, editedAt: now },
+      }),
+      tx.fundingFeedback.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingTradeEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingTradeDetailFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingClubSuppliesImageFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingClubSuppliesSoftwareEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFixtureImageFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFixtureSoftwareEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingNonCorporateTransactionFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFoodExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingLaborContractFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingExternalEventParticipationFeeFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingPublicationFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingProfitMakingActivityFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingJointExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingEtcExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingTransportationPassenger.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+    ]);
   }
 
   async put(
@@ -594,311 +598,310 @@ export default class FundingRepository {
     funding: IFundingRequest,
     extra: IFundingExtra,
   ): Promise<MFunding> {
-    return this.prisma.$transaction(async tx => {
-      const now = this.clock.now();
+    const { tx } = this.txHost;
+    const now = this.clock.now();
 
-      // Update funding table
-      await tx.funding.update({
-        where: { id },
-        data: {
-          purposeActivityId: funding.purposeActivity.id,
-          fundingStatusEnum: extra.fundingStatusEnum,
-          name: funding.name,
-          expenditureDate: funding.expenditureDate,
-          expenditureAmount: funding.expenditureAmount,
-          approvedAmount: extra.approvedAmount,
-          isFixture: funding.isFixture,
-          isTransportation: funding.isTransportation,
-          isFoodExpense: funding.isFoodExpense,
-          isLaborContract: funding.isLaborContract,
-          isExternalEventParticipationFee:
-            funding.isExternalEventParticipationFee,
-          isPublication: funding.isPublication,
-          isProfitMakingActivity: funding.isProfitMakingActivity,
-          isJointExpense: funding.isJointExpense,
-          isEtcExpense: funding.isEtcExpense,
-          isNonCorporateTransaction: funding.isNonCorporateTransaction,
-          tradeDetailExplanation: funding.tradeDetailExplanation,
-          // ClubOld supplies fields
-          clubSuppliesName: funding.clubSupplies?.name,
-          clubSuppliesEvidenceEnum: funding.clubSupplies?.evidenceEnum,
-          clubSuppliesClassEnum: funding.clubSupplies?.classEnum,
-          clubSuppliesPurpose: funding.clubSupplies?.purpose,
-          clubSuppliesSoftwareEvidence: funding.clubSupplies?.softwareEvidence,
-          numberOfClubSupplies: funding.clubSupplies?.number,
-          priceOfClubSupplies: funding.clubSupplies?.price,
-          // Fixture fields
-          fixtureName: funding.fixture?.name,
-          fixtureEvidenceEnum: funding.fixture?.evidenceEnum,
-          fixtureClassEnum: funding.fixture?.classEnum,
-          fixturePurpose: funding.fixture?.purpose,
-          fixtureSoftwareEvidence: funding.fixture?.softwareEvidence,
-          numberOfFixture: funding.fixture?.number,
-          priceOfFixture: funding.fixture?.price,
-          // Transportation fields
-          transportationEnum: funding.transportation?.enum,
-          origin: funding.transportation?.origin,
-          destination: funding.transportation?.destination,
-          purposeOfTransportation: funding.transportation?.purpose,
-          // Trader fields
-          traderName: funding.nonCorporateTransaction?.traderName,
-          traderAccountNumber:
-            funding.nonCorporateTransaction?.traderAccountNumber,
-          wasteExplanation: funding.nonCorporateTransaction?.wasteExplanation,
-          // Expense explanations
-          foodExpenseExplanation: funding.foodExpense?.explanation,
-          laborContractExplanation: funding.laborContract?.explanation,
-          externalEventParticipationFeeExplanation:
-            funding.externalEventParticipationFee?.explanation,
-          publicationExplanation: funding.publication?.explanation,
-          profitMakingActivityExplanation:
-            funding.profitMakingActivity?.explanation,
-          jointExpenseExplanation: funding.jointExpense?.explanation,
-          etcExpenseExplanation: funding.etcExpense?.explanation,
-          editedAt: now,
-        },
-      });
-
-      // Soft delete all related records
-      await Promise.all([
-        tx.fundingTradeEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingTradeDetailFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingClubSuppliesImageFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingClubSuppliesSoftwareEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFixtureImageFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFixtureSoftwareEvidenceFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingNonCorporateTransactionFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingFoodExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingLaborContractFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingExternalEventParticipationFeeFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingPublicationFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingProfitMakingActivityFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingJointExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingEtcExpenseFile.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-        tx.fundingTransportationPassenger.updateMany({
-          where: { fundingId: id },
-          data: { deletedAt: now },
-        }),
-      ]);
-
-      // Insert new related records
-      await Promise.all([
-        // Trade files
-        ...funding.tradeEvidenceFiles.map(file =>
-          tx.fundingTradeEvidenceFile.create({
-            data: {
-              fundingId: id,
-              fileId: file.id,
-            },
-          }),
-        ),
-        ...funding.tradeDetailFiles.map(file =>
-          tx.fundingTradeDetailFile.create({
-            data: {
-              fundingId: id,
-              fileId: file.id,
-            },
-          }),
-        ),
-
-        // ClubOld supplies files
-        ...(funding.clubSupplies && funding.clubSupplies.imageFiles
-          ? funding.clubSupplies.imageFiles.map(file =>
-              tx.fundingClubSuppliesImageFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-        ...(funding.clubSupplies && funding.clubSupplies.softwareEvidenceFiles
-          ? funding.clubSupplies.softwareEvidenceFiles.map(file =>
-              tx.fundingClubSuppliesSoftwareEvidenceFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Fixture files
-        ...(funding.isFixture && funding.fixture.imageFiles
-          ? funding.fixture.imageFiles.map(file =>
-              tx.fundingFixtureImageFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-        ...(funding.isFixture && funding.fixture.softwareEvidenceFiles
-          ? funding.fixture.softwareEvidenceFiles.map(file =>
-              tx.fundingFixtureSoftwareEvidenceFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // NonCorporateTransaction files
-        ...(funding.isNonCorporateTransaction && funding.nonCorporateTransaction
-          ? funding.nonCorporateTransaction.files.map(file =>
-              tx.fundingNonCorporateTransactionFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Food expense files
-        ...(funding.isFoodExpense && funding.foodExpense
-          ? funding.foodExpense.files.map(file =>
-              tx.fundingFoodExpenseFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Labor contract files
-        ...(funding.isLaborContract && funding.laborContract
-          ? funding.laborContract.files.map(file =>
-              tx.fundingLaborContractFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // External event participation fee files
-        ...(funding.isExternalEventParticipationFee &&
-        funding.externalEventParticipationFee
-          ? funding.externalEventParticipationFee.files.map(file =>
-              tx.fundingExternalEventParticipationFeeFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Publication files
-        ...(funding.isPublication && funding.publication
-          ? funding.publication.files.map(file =>
-              tx.fundingPublicationFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Profit making activity files
-        ...(funding.isProfitMakingActivity && funding.profitMakingActivity
-          ? funding.profitMakingActivity.files.map(file =>
-              tx.fundingProfitMakingActivityFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Joint expense files
-        ...(funding.isJointExpense && funding.jointExpense
-          ? funding.jointExpense.files.map(file =>
-              tx.fundingJointExpenseFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Etc expense files
-        ...(funding.isEtcExpense && funding.etcExpense
-          ? funding.etcExpense.files.map(file =>
-              tx.fundingEtcExpenseFile.create({
-                data: {
-                  fundingId: id,
-                  fileId: file.id,
-                },
-              }),
-            )
-          : []),
-
-        // Transportation passengers
-        ...(funding.isTransportation && funding.transportation
-          ? funding.transportation.passengers.map(passenger =>
-              tx.fundingTransportationPassenger.create({
-                data: {
-                  fundingId: id,
-                  studentId: passenger.id,
-                },
-              }),
-            )
-          : []),
-      ]);
-
-      return this.fetch(id);
+    // Update funding table
+    await tx.funding.update({
+      where: { id },
+      data: {
+        purposeActivityId: funding.purposeActivity.id,
+        fundingStatusEnum: extra.fundingStatusEnum,
+        name: funding.name,
+        expenditureDate: funding.expenditureDate,
+        expenditureAmount: funding.expenditureAmount,
+        approvedAmount: extra.approvedAmount,
+        isFixture: funding.isFixture,
+        isTransportation: funding.isTransportation,
+        isFoodExpense: funding.isFoodExpense,
+        isLaborContract: funding.isLaborContract,
+        isExternalEventParticipationFee:
+          funding.isExternalEventParticipationFee,
+        isPublication: funding.isPublication,
+        isProfitMakingActivity: funding.isProfitMakingActivity,
+        isJointExpense: funding.isJointExpense,
+        isEtcExpense: funding.isEtcExpense,
+        isNonCorporateTransaction: funding.isNonCorporateTransaction,
+        tradeDetailExplanation: funding.tradeDetailExplanation,
+        // ClubOld supplies fields
+        clubSuppliesName: funding.clubSupplies?.name,
+        clubSuppliesEvidenceEnum: funding.clubSupplies?.evidenceEnum,
+        clubSuppliesClassEnum: funding.clubSupplies?.classEnum,
+        clubSuppliesPurpose: funding.clubSupplies?.purpose,
+        clubSuppliesSoftwareEvidence: funding.clubSupplies?.softwareEvidence,
+        numberOfClubSupplies: funding.clubSupplies?.number,
+        priceOfClubSupplies: funding.clubSupplies?.price,
+        // Fixture fields
+        fixtureName: funding.fixture?.name,
+        fixtureEvidenceEnum: funding.fixture?.evidenceEnum,
+        fixtureClassEnum: funding.fixture?.classEnum,
+        fixturePurpose: funding.fixture?.purpose,
+        fixtureSoftwareEvidence: funding.fixture?.softwareEvidence,
+        numberOfFixture: funding.fixture?.number,
+        priceOfFixture: funding.fixture?.price,
+        // Transportation fields
+        transportationEnum: funding.transportation?.enum,
+        origin: funding.transportation?.origin,
+        destination: funding.transportation?.destination,
+        purposeOfTransportation: funding.transportation?.purpose,
+        // Trader fields
+        traderName: funding.nonCorporateTransaction?.traderName,
+        traderAccountNumber:
+          funding.nonCorporateTransaction?.traderAccountNumber,
+        wasteExplanation: funding.nonCorporateTransaction?.wasteExplanation,
+        // Expense explanations
+        foodExpenseExplanation: funding.foodExpense?.explanation,
+        laborContractExplanation: funding.laborContract?.explanation,
+        externalEventParticipationFeeExplanation:
+          funding.externalEventParticipationFee?.explanation,
+        publicationExplanation: funding.publication?.explanation,
+        profitMakingActivityExplanation:
+          funding.profitMakingActivity?.explanation,
+        jointExpenseExplanation: funding.jointExpense?.explanation,
+        etcExpenseExplanation: funding.etcExpense?.explanation,
+        editedAt: now,
+      },
     });
+
+    // Soft delete all related records
+    await Promise.all([
+      tx.fundingTradeEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingTradeDetailFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingClubSuppliesImageFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingClubSuppliesSoftwareEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFixtureImageFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFixtureSoftwareEvidenceFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingNonCorporateTransactionFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingFoodExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingLaborContractFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingExternalEventParticipationFeeFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingPublicationFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingProfitMakingActivityFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingJointExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingEtcExpenseFile.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+      tx.fundingTransportationPassenger.updateMany({
+        where: { fundingId: id },
+        data: { deletedAt: now },
+      }),
+    ]);
+
+    // Insert new related records
+    await Promise.all([
+      // Trade files
+      ...funding.tradeEvidenceFiles.map(file =>
+        tx.fundingTradeEvidenceFile.create({
+          data: {
+            fundingId: id,
+            fileId: file.id,
+          },
+        }),
+      ),
+      ...funding.tradeDetailFiles.map(file =>
+        tx.fundingTradeDetailFile.create({
+          data: {
+            fundingId: id,
+            fileId: file.id,
+          },
+        }),
+      ),
+
+      // ClubOld supplies files
+      ...(funding.clubSupplies && funding.clubSupplies.imageFiles
+        ? funding.clubSupplies.imageFiles.map(file =>
+            tx.fundingClubSuppliesImageFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+      ...(funding.clubSupplies && funding.clubSupplies.softwareEvidenceFiles
+        ? funding.clubSupplies.softwareEvidenceFiles.map(file =>
+            tx.fundingClubSuppliesSoftwareEvidenceFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Fixture files
+      ...(funding.isFixture && funding.fixture.imageFiles
+        ? funding.fixture.imageFiles.map(file =>
+            tx.fundingFixtureImageFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+      ...(funding.isFixture && funding.fixture.softwareEvidenceFiles
+        ? funding.fixture.softwareEvidenceFiles.map(file =>
+            tx.fundingFixtureSoftwareEvidenceFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // NonCorporateTransaction files
+      ...(funding.isNonCorporateTransaction && funding.nonCorporateTransaction
+        ? funding.nonCorporateTransaction.files.map(file =>
+            tx.fundingNonCorporateTransactionFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Food expense files
+      ...(funding.isFoodExpense && funding.foodExpense
+        ? funding.foodExpense.files.map(file =>
+            tx.fundingFoodExpenseFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Labor contract files
+      ...(funding.isLaborContract && funding.laborContract
+        ? funding.laborContract.files.map(file =>
+            tx.fundingLaborContractFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // External event participation fee files
+      ...(funding.isExternalEventParticipationFee &&
+      funding.externalEventParticipationFee
+        ? funding.externalEventParticipationFee.files.map(file =>
+            tx.fundingExternalEventParticipationFeeFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Publication files
+      ...(funding.isPublication && funding.publication
+        ? funding.publication.files.map(file =>
+            tx.fundingPublicationFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Profit making activity files
+      ...(funding.isProfitMakingActivity && funding.profitMakingActivity
+        ? funding.profitMakingActivity.files.map(file =>
+            tx.fundingProfitMakingActivityFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Joint expense files
+      ...(funding.isJointExpense && funding.jointExpense
+        ? funding.jointExpense.files.map(file =>
+            tx.fundingJointExpenseFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Etc expense files
+      ...(funding.isEtcExpense && funding.etcExpense
+        ? funding.etcExpense.files.map(file =>
+            tx.fundingEtcExpenseFile.create({
+              data: {
+                fundingId: id,
+                fileId: file.id,
+              },
+            }),
+          )
+        : []),
+
+      // Transportation passengers
+      ...(funding.isTransportation && funding.transportation
+        ? funding.transportation.passengers.map(passenger =>
+            tx.fundingTransportationPassenger.create({
+              data: {
+                fundingId: id,
+                studentId: passenger.id,
+              },
+            }),
+          )
+        : []),
+    ]);
+
+    return this.fetch(id);
   }
 
   async patchSummaryTx(

--- a/packages/api/src/feature/funding/service/funding.service.spec.ts
+++ b/packages/api/src/feature/funding/service/funding.service.spec.ts
@@ -1,6 +1,13 @@
-import { FundingStatusEnum } from "@clubs/interface/common/enum/funding.enum";
+import {
+  FundingDeadlineEnum,
+  FundingStatusEnum,
+} from "@clubs/interface/common/enum/funding.enum";
 
 import FundingService from "./funding.service";
+
+jest.mock("@nestjs-cls/transactional", () => ({
+  Transactional: () => () => undefined,
+}));
 
 type FundingServiceDependencies = ConstructorParameters<typeof FundingService>;
 
@@ -29,9 +36,19 @@ const funding = {
   commentedExecutive: { id: latestCommentedExecutive.id },
 };
 const activity = { id: 501, name: "활동" };
+const studentId = 701;
+const now = new Date("2026-02-01");
+const fundingBody = {
+  club: { id: club.id },
+  expenditureDate: new Date("2026-01-15"),
+};
 
 const createFundingService = () => {
   const fundingRepository = {
+    insert: jest.fn().mockResolvedValue({ id: funding.id }),
+    put: jest.fn().mockResolvedValue({}),
+    delete: jest.fn().mockResolvedValue({}),
+    fetch: jest.fn().mockResolvedValue(funding),
     fetchSummaries: jest.fn(),
     fetchCommentedSummaries: jest.fn(),
   };
@@ -46,6 +63,7 @@ const createFundingService = () => {
     findExecutiveSummary: jest.fn().mockResolvedValue(chargedExecutive),
   };
   const clubPublicService = {
+    checkStudentDelegate: jest.fn().mockResolvedValue(undefined),
     fetchSummary: jest.fn().mockResolvedValue(club),
     fetchSummaries: jest.fn().mockResolvedValue([club]),
     fetchDivisionSummaries: jest.fn().mockResolvedValue([division]),
@@ -59,6 +77,24 @@ const createFundingService = () => {
   const activityDurationPublicService = {
     load: jest.fn().mockResolvedValue(activityDuration),
   };
+  const fundingDeadlinePublicService = {
+    search: jest.fn(({ deadlineEnum }) => {
+      const deadlineEnums = Array.isArray(deadlineEnum)
+        ? deadlineEnum
+        : [deadlineEnum];
+
+      if (deadlineEnums.includes(FundingDeadlineEnum.Exception)) {
+        return Promise.resolve([
+          {
+            id: 1,
+            deadlineEnum: FundingDeadlineEnum.Exception,
+          },
+        ]);
+      }
+
+      return Promise.resolve([]);
+    }),
+  };
 
   const service = new FundingService(
     fundingRepository as FundingServiceDependencies[0],
@@ -69,10 +105,14 @@ const createFundingService = () => {
     activityPublicService as FundingServiceDependencies[5],
     semesterPublicService as FundingServiceDependencies[6],
     activityDurationPublicService as FundingServiceDependencies[7],
-    {} as FundingServiceDependencies[8],
+    fundingDeadlinePublicService as FundingServiceDependencies[8],
     {} as FundingServiceDependencies[9],
     {} as FundingServiceDependencies[10],
   );
+
+  (service as unknown as { clock: { now: () => Date } }).clock = {
+    now: jest.fn(() => now),
+  };
 
   return {
     service,
@@ -80,8 +120,66 @@ const createFundingService = () => {
     fundingCommentRepository,
     clubPublicService,
     activityDurationPublicService,
+    fundingDeadlinePublicService,
   };
 };
+
+describe("FundingService funding deadline validation", () => {
+  it("rejects creating a funding during the exception period", async () => {
+    const { service, fundingRepository, fundingDeadlinePublicService } =
+      createFundingService();
+
+    await expect(
+      service.postStudentFunding(fundingBody as never, studentId),
+    ).rejects.toThrow();
+
+    expect(fundingDeadlinePublicService.search).toHaveBeenCalledWith({
+      date: now,
+      deadlineEnum: [FundingDeadlineEnum.Writing],
+    });
+    expect(fundingRepository.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects editing a funding during the exception period", async () => {
+    const { service, fundingRepository, fundingDeadlinePublicService } =
+      createFundingService();
+
+    await expect(
+      service.putStudentFunding(
+        fundingBody as never,
+        { id: funding.id },
+        studentId,
+      ),
+    ).rejects.toThrow();
+
+    expect(fundingDeadlinePublicService.search).toHaveBeenCalledWith({
+      date: now,
+      deadlineEnum: [
+        FundingDeadlineEnum.Writing,
+        FundingDeadlineEnum.Modification,
+      ],
+    });
+    expect(fundingRepository.put).not.toHaveBeenCalled();
+  });
+
+  it("rejects deleting a funding during the exception period", async () => {
+    const { service, fundingRepository, fundingDeadlinePublicService } =
+      createFundingService();
+
+    await expect(
+      service.deleteStudentFunding(studentId, { id: funding.id }),
+    ).rejects.toThrow();
+
+    expect(fundingDeadlinePublicService.search).toHaveBeenCalledWith({
+      date: now,
+      deadlineEnum: [
+        FundingDeadlineEnum.Writing,
+        FundingDeadlineEnum.Modification,
+      ],
+    });
+    expect(fundingRepository.delete).not.toHaveBeenCalled();
+  });
+});
 
 describe("FundingService historical semester club summaries", () => {
   it("loads executive dashboard club summaries for the requested semester", async () => {

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -1,4 +1,5 @@
 import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
+import { Transactional } from "@nestjs-cls/transactional";
 
 import { IActivityDuration } from "@clubs/domain/semester/activity-duration";
 
@@ -108,15 +109,13 @@ export default class FundingService {
     private readonly operationCommitteeService: OperationCommitteeService,
   ) {}
 
+  @Transactional()
   async postStudentFunding(
     body: ApiFnd001RequestBody,
     studentId: number,
   ): Promise<ApiFnd001ResponseCreated> {
     await this.clubPublicService.checkStudentDelegate(studentId, body.club.id);
-    await this.checkDeadline([
-      FundingDeadlineEnum.Writing,
-      FundingDeadlineEnum.Exception,
-    ]);
+    await this.checkDeadline([FundingDeadlineEnum.Writing]);
 
     const activityD = await this.validateExpenditureDate(body.expenditureDate);
 
@@ -425,6 +424,7 @@ export default class FundingService {
     return undefined;
   }
 
+  @Transactional()
   async putStudentFunding(
     body: ApiFnd003RequestBody,
     param: ApiFnd003RequestParam,
@@ -434,7 +434,6 @@ export default class FundingService {
     await this.checkDeadline([
       FundingDeadlineEnum.Writing,
       FundingDeadlineEnum.Modification,
-      FundingDeadlineEnum.Exception,
     ]);
 
     const activityD = await this.validateExpenditureDate(body.expenditureDate);
@@ -449,6 +448,7 @@ export default class FundingService {
     });
   }
 
+  @Transactional()
   async deleteStudentFunding(
     studentId: number,
     param: ApiFnd004RequestParam,
@@ -461,7 +461,6 @@ export default class FundingService {
     await this.checkDeadline([
       FundingDeadlineEnum.Writing,
       FundingDeadlineEnum.Modification,
-      FundingDeadlineEnum.Exception,
     ]);
     await this.fundingRepository.delete(param.id);
     return {};


### PR DESCRIPTION
## Summary
- 지원금 이의제기 기간에는 학생 지원금 생성, 수정, 삭제 API가 통과하지 않도록 deadline 검증에서 Exception을 제외했습니다.
- 변경된 지원금 command service 메서드에 @Transactional()을 적용했습니다.
- FundingRepository의 생성, 수정, 삭제 경로가 자체 Prisma transaction 대신 TransactionHost.tx를 사용하도록 맞춰 service transaction context에 묶이게 했습니다.
- 이의제기 기간 회귀 테스트와 FundingRepository transaction-host 회귀 테스트를 추가했습니다.

## Task Context
- Task ID: TU-388
- Notion: https://app.notion.com/p/358c25603b0b80c6a90afd3321b350ea
- Rebased onto origin/dev: 045a6832ff475a8343a1662ed994772bd8ff7a54

## Verification
- SERVER_PORT=3000 SECRET_KEY=test DATABASE_URL=mysql://test:test@localhost:3306/test TEST_DATABASE_URL=mysql://test:test@localhost:3306/test pnpm --filter api test:unit -- funding.repository.spec.ts funding.service.spec.ts
- SERVER_PORT=3000 SECRET_KEY=test DATABASE_URL=mysql://test:test@localhost:3306/test TEST_DATABASE_URL=mysql://test:test@localhost:3306/test pnpm --filter api test:unit
- pnpm lint
- pnpm format:check:changed
- SERVER_PORT=3000 SECRET_KEY=test DATABASE_URL=mysql://test:test@localhost:3306/test TEST_DATABASE_URL=mysql://test:test@localhost:3306/test pnpm mcdc:changed --fail-on-missing
- pnpm transaction-guard:changed && pnpm prisma-query:changed
- git push --force-with-lease origin TU-388 pre-push hooks: format, lint, Prisma raw SQL guard, transaction guard, MC/DC changed

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 지원금 이의제기 기간에는 지원금 신청, 수정, 삭제가 진행되지 않도록 수정했습니다.
<!-- clubs:patch-note:end -->
