### PR TITLE
[TU-394] 첨부 PDF 새 탭 미리보기 추가

### DIFF
--- a/packages/web/src/common/components/File/ThumbnailPreview.tsx
+++ b/packages/web/src/common/components/File/ThumbnailPreview.tsx
@@ -5,8 +5,9 @@ import FlexWrapper from "../FlexWrapper";
 import Icon from "../Icon";
 import Typography from "../Typography";
 import ImagePreview from "./_atomic/ImagePreview";
+import PdfPreview from "./_atomic/PdfPreview";
 import UnsupportedPreview from "./_atomic/UnsupportedPreview";
-import { FileDetail, isPreviewSupported } from "./attachment";
+import { FileDetail, getFilePreviewType } from "./attachment";
 
 interface ThumbnailPreviewProps {
   file: FileDetail;
@@ -27,38 +28,42 @@ const ThumbnailPreview: React.FC<ThumbnailPreviewProps> = ({
   onClick,
   onDelete = () => {},
   disabled = false,
-}: ThumbnailPreviewProps) => (
-  <FlexWrapper gap={0} direction="column">
-    {!disabled && (
-      <DeleteButton onClick={() => onDelete(file)}>
-        <Icon type="close_outlined" size={16} color="BLACK" />
-      </DeleteButton>
-    )}
-    <FlexWrapper
-      gap={8}
-      direction="column"
-      style={{ width: "160px" }}
-      onClick={onClick}
-    >
-      {isPreviewSupported(file) ? (
-        <ImagePreview src={file.url} alt={file.name} />
-      ) : (
-        <UnsupportedPreview file={file} />
+}: ThumbnailPreviewProps) => {
+  const previewType = getFilePreviewType(file);
+
+  return (
+    <FlexWrapper gap={0} direction="column">
+      {!disabled && (
+        <DeleteButton onClick={() => onDelete(file)}>
+          <Icon type="close_outlined" size={16} color="BLACK" />
+        </DeleteButton>
       )}
-      <Typography
-        fs={14}
-        lh={16}
-        style={{
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-        }}
-        title={file.name}
+      <FlexWrapper
+        gap={8}
+        direction="column"
+        style={{ width: "160px", cursor: "pointer" }}
+        onClick={onClick}
       >
-        {file.name}
-      </Typography>
+        {previewType === "image" && (
+          <ImagePreview src={file.url} alt={file.name} />
+        )}
+        {previewType === "pdf" && <PdfPreview file={file} />}
+        {previewType === "unsupported" && <UnsupportedPreview file={file} />}
+        <Typography
+          fs={14}
+          lh={16}
+          style={{
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+          }}
+          title={file.name}
+        >
+          {file.name}
+        </Typography>
+      </FlexWrapper>
     </FlexWrapper>
-  </FlexWrapper>
-);
+  );
+};
 
 export default ThumbnailPreview;

--- a/packages/web/src/common/components/File/ThumbnailPreviewList.tsx
+++ b/packages/web/src/common/components/File/ThumbnailPreviewList.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from "react";
 import Viewer from "viewerjs";
 
 import FlexWrapper from "../FlexWrapper";
-import { FileDetail } from "./attachment";
+import { FileDetail, getFilePreviewType, openFileInNewTab } from "./attachment";
 import ThumbnailPreview from "./ThumbnailPreview";
 
 interface ThumbnailPreviewListProps {
@@ -20,7 +20,18 @@ const ThumbnailPreviewList: React.FC<ThumbnailPreviewListProps> = ({
   const viewerRef = useRef<HTMLDivElement>(null);
 
   const handleClick = (index: number) => {
-    const images = viewerRef.current!;
+    if (getFilePreviewType(fileList[index]) === "pdf") {
+      openFileInNewTab(fileList[index], (url, target, features) =>
+        window.open(url, target, features),
+      );
+      return;
+    }
+
+    if (!viewerRef.current) {
+      return;
+    }
+
+    const images = viewerRef.current;
 
     const viewer = new Viewer(images, {
       hidden: () => {

--- a/packages/web/src/common/components/File/_atomic/PdfPreview.tsx
+++ b/packages/web/src/common/components/File/_atomic/PdfPreview.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "styled-components";
+
+import noPreview from "@sparcs-clubs/web/assets/no-preview.png";
+import Icon from "@sparcs-clubs/web/common/components/Icon";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import colors from "@sparcs-clubs/web/styles/themes/colors";
+
+import { FileDetail } from "../attachment";
+
+interface PdfPreviewProps {
+  file: FileDetail;
+}
+
+const PdfPreviewWrapper = styled.div`
+  background-color: ${({ theme }) => theme.colors.GRAY[100]};
+  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
+  border-radius: 8px;
+  width: 160px;
+  height: 160px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const PdfPreview: React.FC<PdfPreviewProps> = ({ file }) => (
+  <PdfPreviewWrapper>
+    <Icon type="picture_as_pdf" size={28} color={colors.RED[600]} />
+    <Typography fs={14} lh={16} color="GRAY.300">
+      PDF 미리보기
+      <img src={noPreview.src} alt={file.name} style={{ display: "none" }} />
+    </Typography>
+  </PdfPreviewWrapper>
+);
+
+export default PdfPreview;

--- a/packages/web/src/common/components/File/attachment.spec.ts
+++ b/packages/web/src/common/components/File/attachment.spec.ts
@@ -1,0 +1,58 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getFilePreviewType, openFileInNewTab } from "./attachment";
+
+describe("getFilePreviewType", () => {
+  it("classifies PDF files separately from unsupported files", () => {
+    assert.equal(
+      getFilePreviewType({
+        id: "file-1",
+        name: "evidence.PDF",
+        url: "https://example.com/evidence.pdf",
+      }),
+      "pdf",
+    );
+  });
+
+  it("keeps image files in the image preview path", () => {
+    assert.equal(
+      getFilePreviewType({
+        id: "file-2",
+        name: "photo.jpg",
+        url: "https://example.com/photo.jpg",
+      }),
+      "image",
+    );
+  });
+
+  it("classifies unknown extensions as unsupported", () => {
+    assert.equal(
+      getFilePreviewType({
+        id: "file-3",
+        name: "receipt.xlsx",
+        url: "https://example.com/receipt.xlsx",
+      }),
+      "unsupported",
+    );
+  });
+
+  it("opens a file in a browser preview tab without sending referrer information", () => {
+    const calls: string[][] = [];
+
+    openFileInNewTab(
+      {
+        id: "file-4",
+        name: "evidence.pdf",
+        url: "https://example.com/evidence.pdf",
+      },
+      (url, target, features) => {
+        calls.push([url, target, features]);
+      },
+    );
+
+    assert.deepEqual(calls, [
+      ["https://example.com/evidence.pdf", "_blank", "noopener,noreferrer"],
+    ]);
+  });
+});

--- a/packages/web/src/common/components/File/attachment.ts
+++ b/packages/web/src/common/components/File/attachment.ts
@@ -4,9 +4,34 @@ export interface FileDetail {
   url: string;
 }
 
-export const isPreviewSupported = (file: FileDetail) => {
-  const fileExt = file.name.split(".").pop() || "unknown";
+export type FilePreviewType = "image" | "pdf" | "unsupported";
+export type FileOpen = (
+  url: string,
+  target: string,
+  features: string,
+) => unknown;
 
+const getFileExtension = (file: FileDetail) =>
+  (file.name.split(".").pop() || "unknown").toLowerCase();
+
+export const getFilePreviewType = (file: FileDetail): FilePreviewType => {
+  const fileExt = getFileExtension(file);
   const previewSupportFile = ["png", "jpeg", "jpg", "webp", "svg"];
-  return previewSupportFile.includes(fileExt.toLowerCase());
+
+  if (previewSupportFile.includes(fileExt)) {
+    return "image";
+  }
+
+  if (fileExt === "pdf") {
+    return "pdf";
+  }
+
+  return "unsupported";
+};
+
+export const isPreviewSupported = (file: FileDetail) =>
+  getFilePreviewType(file) === "image";
+
+export const openFileInNewTab = (file: FileDetail, open: FileOpen) => {
+  open(file.url, "_blank", "noopener,noreferrer");
 };


### PR DESCRIPTION
## Summary
- 공용 파일 썸네일에서 PDF 첨부 파일을 클릭하면 다운로드 대신 브라우저 새 탭에서 바로 열도록 변경
- PDF 첨부 파일 전용 미리보기 썸네일과 파일 타입 분류 테스트 추가

## Task Context
- Task ID: TU-394
- Notion: https://app.notion.com/p/358c25603b0b8015b434fa5d3e0bbed0

## Patch Note

<!-- clubs:patch-note:start -->
category: feature
text: 첨부 파일의 PDF를 다운로드하지 않고 새 탭에서 바로 확인할 수 있게 했습니다.
<!-- clubs:patch-note:end -->
