### PR TITLE
[TU-439] 과거 활동보고서/지원금 feedback 생성 차단

### DIFF
--- a/packages/api/src/feature/activity/repository/activity-comment.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity-comment.repository.ts
@@ -1,9 +1,11 @@
 import { Injectable } from "@nestjs/common";
+import { TransactionHost } from "@nestjs-cls/transactional";
 
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
 
 import { BaseTableFieldMapKeys } from "@sparcs-clubs/api/common/base/base.repository";
 import { BaseSingleTableRepository } from "@sparcs-clubs/api/common/base/base.single.repository";
+import { PrismaTransactionalAdapter } from "@sparcs-clubs/api/common/transaction/transaction.type";
 import {
   IActivityCommentCreate,
   MActivityComment,
@@ -31,8 +33,28 @@ export class ActivityCommentRepository extends BaseSingleTableRepository<
   ActivityCommentOrderByKeys,
   ActivityCommentQuerySupport
 > {
-  constructor() {
+  constructor(
+    private readonly txHost: TransactionHost<PrismaTransactionalAdapter>,
+  ) {
     super("activityFeedback", MActivityComment);
+  }
+
+  async createExecutiveReviewComment(param: {
+    activityId: number;
+    executiveId: number;
+    content: string;
+    activityStatusEnum: ActivityStatusEnum;
+  }): Promise<MActivityComment> {
+    const result = await this.txHost.tx.activityFeedback.create({
+      data: {
+        activityId: param.activityId,
+        executiveId: param.executiveId,
+        comment: param.content,
+        activityStatusEnum: param.activityStatusEnum,
+      },
+    });
+
+    return this.dbToModelMapping(result);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/src/feature/activity/repository/activity.new.repository.ts
+++ b/packages/api/src/feature/activity/repository/activity.new.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { TransactionHost } from "@nestjs-cls/transactional";
 
 import {
   ActivityStatusEnum,
@@ -13,6 +14,7 @@ import {
   PrismaMultiTableConfig,
 } from "@sparcs-clubs/api/common/base/base.multi.repository";
 import { BaseTableFieldMapKeys } from "@sparcs-clubs/api/common/base/base.repository";
+import { PrismaTransactionalAdapter } from "@sparcs-clubs/api/common/transaction/transaction.type";
 import {
   IActivityCreate,
   MActivity,
@@ -69,8 +71,49 @@ export class ActivityNewRepository extends BaseMultiTableRepository<
   ActivityOrderByKeys,
   ActivityQuerySupport
 > {
-  constructor() {
+  constructor(
+    private readonly txHost: TransactionHost<PrismaTransactionalAdapter>,
+  ) {
     super(activityTableConfig, MActivity, "activityId");
+  }
+
+  async approveExecutiveActivity(param: {
+    activityId: number;
+    commentedAt: Date;
+  }): Promise<boolean> {
+    const result = await this.txHost.tx.activity.updateMany({
+      where: {
+        id: param.activityId,
+        deletedAt: null,
+        activityStatusEnumId: { not: ActivityStatusEnum.Approved },
+      },
+      data: {
+        activityStatusEnumId: ActivityStatusEnum.Approved,
+        commentedAt: param.commentedAt,
+        updatedAt: this.clock.now(),
+      },
+    });
+
+    return result.count > 0;
+  }
+
+  async sendBackExecutiveActivity(param: {
+    activityId: number;
+    commentedAt: Date;
+  }): Promise<boolean> {
+    const result = await this.txHost.tx.activity.updateMany({
+      where: {
+        id: param.activityId,
+        deletedAt: null,
+      },
+      data: {
+        activityStatusEnumId: ActivityStatusEnum.Rejected,
+        commentedAt: param.commentedAt,
+        updatedAt: this.clock.now(),
+      },
+    });
+
+    return result.count > 0;
   }
 
   protected dbToModelMapping(result: ActivityDbSelect): MActivity {

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -11,6 +11,10 @@ import { MActivity } from "../model/activity.model.new";
 import { MActivityComment } from "../model/activity-comment.model";
 import ActivityService from "./activity.service.new";
 
+jest.mock("@nestjs-cls/transactional", () => ({
+  Transactional: () => () => undefined,
+}));
+
 type ActivityStub = {
   id: number;
   name: string;
@@ -155,9 +159,11 @@ describe("ActivityService", () => {
   ) => {
     const currentActivity = { ...activity, ...activityOverrides };
     const activityRepository = {
+      approveExecutiveActivity: jest.fn().mockResolvedValue(true),
       fetch: jest.fn().mockResolvedValue(currentActivity),
       put: jest.fn().mockResolvedValue(new MActivity(currentActivity)),
       patch: jest.fn().mockResolvedValue([new MActivity(currentActivity)]),
+      sendBackExecutiveActivity: jest.fn().mockResolvedValue(true),
     };
     const activityComment = new MActivityComment({
       id: 1,
@@ -168,6 +174,9 @@ describe("ActivityService", () => {
       executive: { id: 7 },
     });
     const activityCommentRepository = {
+      createExecutiveReviewComment: jest
+        .fn()
+        .mockResolvedValue(activityComment),
       create: jest.fn().mockResolvedValue([activityComment]),
     };
     const clubPublicService = {
@@ -297,30 +306,20 @@ describe("ActivityService", () => {
       param: { activityId: activity.id },
     });
 
-    expect(activityRepository.patch.mock.calls[0][0]).toEqual({
-      id: activity.id,
-      activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
+    expect(activityRepository.approveExecutiveActivity).toHaveBeenCalledWith({
+      activityId: activity.id,
+      commentedAt,
     });
-    const patchActivity = activityRepository.patch.mock.calls[0][1] as (
-      model: MActivity,
-    ) => MActivity;
-    const updatedActivity = patchActivity(
-      new MActivity({
-        ...activity,
-        activityStatusEnum: ActivityStatusEnum.Applied,
-      }),
-    );
-
-    expect(updatedActivity.activityStatusEnum).toBe(
-      ActivityStatusEnum.Approved,
-    );
-    expect(updatedActivity.commentedAt).toEqual(commentedAt);
-    expect(activityCommentRepository.create).toHaveBeenCalledWith({
-      activity: { id: activity.id },
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).toHaveBeenCalledWith({
+      activityId: activity.id,
       content: "활동이 승인되었습니다",
-      executive: { id: 7 },
+      executiveId: 7,
       activityStatusEnum: ActivityStatusEnum.Approved,
     });
+    expect(activityRepository.patch).not.toHaveBeenCalled();
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 
   it("rejects executive approval for activity reports from another semester before feedback mutation", async () => {
@@ -347,14 +346,16 @@ describe("ActivityService", () => {
     ).rejects.toThrow("current semester");
 
     expect(activityDurationPublicService.getById).toHaveBeenCalledWith(99);
-    expect(activityRepository.patch).not.toHaveBeenCalled();
-    expect(activityCommentRepository.create).not.toHaveBeenCalled();
+    expect(activityRepository.approveExecutiveActivity).not.toHaveBeenCalled();
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).not.toHaveBeenCalled();
   });
 
   it("does not create approval feedback when the activity report is already approved", async () => {
     const { activityCommentRepository, activityRepository, service } =
       createService();
-    activityRepository.patch.mockResolvedValueOnce([]);
+    activityRepository.approveExecutiveActivity.mockResolvedValueOnce(false);
 
     await expect(
       service.patchExecutiveActivityApproval({
@@ -363,18 +364,22 @@ describe("ActivityService", () => {
       }),
     ).rejects.toThrow("the activity is already approved");
 
-    expect(activityRepository.patch.mock.calls[0][0]).toEqual({
-      id: activity.id,
-      activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
+    expect(activityRepository.approveExecutiveActivity).toHaveBeenCalledWith({
+      activityId: activity.id,
+      commentedAt: expect.any(Date),
     });
-    expect(activityCommentRepository.create).not.toHaveBeenCalled();
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).not.toHaveBeenCalled();
   });
 
   it("throws when approval feedback insertion fails", async () => {
     const { activityCommentRepository, service } = createService(undefined, {
       activityStatusEnum: ActivityStatusEnum.Applied,
     });
-    activityCommentRepository.create.mockResolvedValueOnce([]);
+    activityCommentRepository.createExecutiveReviewComment.mockResolvedValueOnce(
+      null,
+    );
 
     await expect(
       service.patchExecutiveActivityApproval({
@@ -397,21 +402,20 @@ describe("ActivityService", () => {
       body: sendBackBody,
     });
 
-    const patchActivity = activityRepository.patch.mock.calls[0][1] as (
-      model: MActivity,
-    ) => MActivity;
-    const updatedActivity = patchActivity(new MActivity(activity));
-
-    expect(updatedActivity.activityStatusEnum).toBe(
-      ActivityStatusEnum.Rejected,
-    );
-    expect(updatedActivity.commentedAt).toEqual(commentedAt);
-    expect(activityCommentRepository.create).toHaveBeenCalledWith({
-      activity: { id: activity.id },
+    expect(activityRepository.sendBackExecutiveActivity).toHaveBeenCalledWith({
+      activityId: activity.id,
+      commentedAt,
+    });
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).toHaveBeenCalledWith({
+      activityId: activity.id,
       content: sendBackBody.comment,
-      executive: { id: 8 },
+      executiveId: 8,
       activityStatusEnum: ActivityStatusEnum.Rejected,
     });
+    expect(activityRepository.patch).not.toHaveBeenCalled();
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 
   it("rejects executive send-back for activity reports from another semester before feedback mutation", async () => {
@@ -439,14 +443,16 @@ describe("ActivityService", () => {
     ).rejects.toThrow("current semester");
 
     expect(activityDurationPublicService.getById).toHaveBeenCalledWith(99);
-    expect(activityRepository.patch).not.toHaveBeenCalled();
-    expect(activityCommentRepository.create).not.toHaveBeenCalled();
+    expect(activityRepository.sendBackExecutiveActivity).not.toHaveBeenCalled();
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).not.toHaveBeenCalled();
   });
 
   it("does not create send-back feedback when the status update fails", async () => {
     const { activityCommentRepository, activityRepository, service } =
       createService();
-    activityRepository.patch.mockResolvedValueOnce([]);
+    activityRepository.sendBackExecutiveActivity.mockResolvedValueOnce(false);
 
     await expect(
       service.patchExecutiveActivitySendBack({
@@ -456,12 +462,16 @@ describe("ActivityService", () => {
       }),
     ).rejects.toThrow("failed to send back activity");
 
-    expect(activityCommentRepository.create).not.toHaveBeenCalled();
+    expect(
+      activityCommentRepository.createExecutiveReviewComment,
+    ).not.toHaveBeenCalled();
   });
 
   it("throws when send-back feedback insertion fails", async () => {
     const { activityCommentRepository, service } = createService();
-    activityCommentRepository.create.mockResolvedValueOnce([]);
+    activityCommentRepository.createExecutiveReviewComment.mockResolvedValueOnce(
+      null,
+    );
 
     await expect(
       service.patchExecutiveActivitySendBack({

--- a/packages/api/src/feature/activity/service/activity.service.new.spec.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.spec.ts
@@ -100,6 +100,7 @@ describe("ActivityService", () => {
 
   const activityDuration = {
     id: 10,
+    semester: { id: 1 },
     startTerm: new Date("2026-03-01T00:00:00.000Z"),
     endTerm: new Date("2026-06-30T14:59:59.999Z"),
   };
@@ -218,8 +219,10 @@ describe("ActivityService", () => {
     return {
       activityRepository,
       activityCommentRepository,
+      activityDurationPublicService,
       filePublicService,
       registrationPublicService,
+      semesterPublicService,
       service,
     };
   };
@@ -320,6 +323,34 @@ describe("ActivityService", () => {
     });
   });
 
+  it("rejects executive approval for activity reports from another semester before feedback mutation", async () => {
+    const {
+      activityCommentRepository,
+      activityDurationPublicService,
+      activityRepository,
+      service,
+    } = createService(undefined, {
+      activityDuration: { id: 99 },
+      activityStatusEnum: ActivityStatusEnum.Applied,
+    });
+    activityDurationPublicService.getById.mockResolvedValueOnce({
+      ...activityDuration,
+      id: 99,
+      semester: { id: 2 },
+    });
+
+    await expect(
+      service.patchExecutiveActivityApproval({
+        executiveId: 7,
+        param: { activityId: activity.id },
+      }),
+    ).rejects.toThrow("current semester");
+
+    expect(activityDurationPublicService.getById).toHaveBeenCalledWith(99);
+    expect(activityRepository.patch).not.toHaveBeenCalled();
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
+  });
+
   it("does not create approval feedback when the activity report is already approved", async () => {
     const { activityCommentRepository, activityRepository, service } =
       createService();
@@ -381,6 +412,35 @@ describe("ActivityService", () => {
       executive: { id: 8 },
       activityStatusEnum: ActivityStatusEnum.Rejected,
     });
+  });
+
+  it("rejects executive send-back for activity reports from another semester before feedback mutation", async () => {
+    const {
+      activityCommentRepository,
+      activityDurationPublicService,
+      activityRepository,
+      service,
+    } = createService(undefined, {
+      activityDuration: { id: 99 },
+      activityStatusEnum: ActivityStatusEnum.Applied,
+    });
+    activityDurationPublicService.getById.mockResolvedValueOnce({
+      ...activityDuration,
+      id: 99,
+      semester: { id: 2 },
+    });
+
+    await expect(
+      service.patchExecutiveActivitySendBack({
+        executiveId: 8,
+        param: { activityId: activity.id },
+        body: { comment: "보완 필요" },
+      }),
+    ).rejects.toThrow("current semester");
+
+    expect(activityDurationPublicService.getById).toHaveBeenCalledWith(99);
+    expect(activityRepository.patch).not.toHaveBeenCalled();
+    expect(activityCommentRepository.create).not.toHaveBeenCalled();
   });
 
   it("does not create send-back feedback when the status update fails", async () => {

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -109,6 +109,22 @@ export default class ActivityService {
     }
   }
 
+  private async assertActivityDurationIsInCurrentSemester(
+    activityDId: number,
+  ): Promise<void> {
+    const [activityDuration, currentSemesterId] = await Promise.all([
+      this.activityDurationPublicService.getById(activityDId),
+      this.semesterPublicService.loadId(),
+    ]);
+
+    if (activityDuration.semester.id !== currentSemesterId) {
+      throw new HttpException(
+        "The activity duration is not in the current semester",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
   /**
    * @param activityDId 조회하고 싶은 활동기간 id, 없을 경우 직전 활동기간의 id를 사용합니다.
    * @param clubId 동아리 id
@@ -914,6 +930,13 @@ export default class ActivityService {
     param: ApiAct016RequestParam;
   }): Promise<ApiAct016ResponseOk> {
     // TODO: transaction 추가
+    const activity = await this.activityRepository.fetch(
+      param.param.activityId,
+    );
+    await this.assertActivityDurationIsInCurrentSemester(
+      activity.activityDuration.id,
+    );
+
     const commentedAt = this.clock.now();
     const updatedActivities = await this.activityRepository.patch(
       {
@@ -952,6 +975,13 @@ export default class ActivityService {
     body: ApiAct017RequestBody;
   }): Promise<ApiAct017ResponseOk> {
     // TODO: transaction 추가
+    const activity = await this.activityRepository.fetch(
+      param.param.activityId,
+    );
+    await this.assertActivityDurationIsInCurrentSemester(
+      activity.activityDuration.id,
+    );
+
     const commentedAt = this.clock.now();
     const updatedActivities = await this.activityRepository.patch(
       {

--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -1,4 +1,5 @@
 import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
+import { Transactional } from "@nestjs-cls/transactional";
 
 import { ActivityStatusEnum } from "@clubs/domain/activity/activity";
 import {
@@ -925,11 +926,11 @@ export default class ActivityService {
   /**
    * @description patchExecutiveActivityApproval의 서비스 진입점입니다.
    */
+  @Transactional()
   async patchExecutiveActivityApproval(param: {
     executiveId: number;
     param: ApiAct016RequestParam;
   }): Promise<ApiAct016ResponseOk> {
-    // TODO: transaction 추가
     const activity = await this.activityRepository.fetch(
       param.param.activityId,
     );
@@ -938,27 +939,25 @@ export default class ActivityService {
     );
 
     const commentedAt = this.clock.now();
-    const updatedActivities = await this.activityRepository.patch(
-      {
-        id: param.param.activityId,
-        activityStatusEnumId: { ne: ActivityStatusEnum.Approved },
-      },
-      MActivity.updateReviewStatus(ActivityStatusEnum.Approved, commentedAt),
-    );
-    if (updatedActivities.length === 0)
+    const isUpdated = await this.activityRepository.approveExecutiveActivity({
+      activityId: param.param.activityId,
+      commentedAt,
+    });
+    if (!isUpdated)
       throw new HttpException(
         "the activity is already approved",
         HttpStatus.BAD_REQUEST,
       );
 
-    const insertedComments = await this.activityCommentRepository.create({
-      activity: { id: param.param.activityId },
-      content: "활동이 승인되었습니다", // feedback에 승인을 기록하기 위한 임의의 문자열
-      // TODO?: 활동 승인 시에도 content를 넣을까요?
-      executive: { id: param.executiveId },
-      activityStatusEnum: ActivityStatusEnum.Approved,
-    });
-    if (insertedComments.length === 0)
+    const insertedComment =
+      await this.activityCommentRepository.createExecutiveReviewComment({
+        activityId: param.param.activityId,
+        content: "활동이 승인되었습니다", // feedback에 승인을 기록하기 위한 임의의 문자열
+        // TODO?: 활동 승인 시에도 content를 넣을까요?
+        executiveId: param.executiveId,
+        activityStatusEnum: ActivityStatusEnum.Approved,
+      });
+    if (!insertedComment)
       throw new HttpException("unreachable", HttpStatus.INTERNAL_SERVER_ERROR);
 
     return {};
@@ -969,12 +968,12 @@ export default class ActivityService {
    * @description patchExecutiveActivitySendBack의 서비스 진입점입니다.
    * 동시성을 고려하지 않고 구현했습니다.
    */
+  @Transactional()
   async patchExecutiveActivitySendBack(param: {
     executiveId: number;
     param: ApiAct017RequestParam;
     body: ApiAct017RequestBody;
   }): Promise<ApiAct017ResponseOk> {
-    // TODO: transaction 추가
     const activity = await this.activityRepository.fetch(
       param.param.activityId,
     );
@@ -983,25 +982,24 @@ export default class ActivityService {
     );
 
     const commentedAt = this.clock.now();
-    const updatedActivities = await this.activityRepository.patch(
-      {
-        id: param.param.activityId,
-      },
-      MActivity.updateReviewStatus(ActivityStatusEnum.Rejected, commentedAt),
-    );
-    if (updatedActivities.length === 0)
+    const isUpdated = await this.activityRepository.sendBackExecutiveActivity({
+      activityId: param.param.activityId,
+      commentedAt,
+    });
+    if (!isUpdated)
       throw new HttpException(
         "failed to send back activity",
         HttpStatus.BAD_REQUEST,
       );
 
-    const insertedComments = await this.activityCommentRepository.create({
-      activity: { id: param.param.activityId },
-      content: param.body.comment,
-      executive: { id: param.executiveId },
-      activityStatusEnum: ActivityStatusEnum.Rejected,
-    });
-    if (insertedComments.length === 0)
+    const insertedComment =
+      await this.activityCommentRepository.createExecutiveReviewComment({
+        activityId: param.param.activityId,
+        content: param.body.comment,
+        executiveId: param.executiveId,
+        activityStatusEnum: ActivityStatusEnum.Rejected,
+      });
+    if (!insertedComment)
       throw new HttpException("unreachable", HttpStatus.INTERNAL_SERVER_ERROR);
 
     return {};

--- a/packages/api/src/feature/funding/service/funding.service.spec.ts
+++ b/packages/api/src/feature/funding/service/funding.service.spec.ts
@@ -27,6 +27,7 @@ const latestCommentedExecutive = {
 const funding = {
   id: 401,
   name: "지원금 항목",
+  activityD: { id: activityDuration.id },
   expenditureAmount: 10000,
   approvedAmount: 8000,
   fundingStatusEnum: FundingStatusEnum.Approved,
@@ -51,8 +52,17 @@ const createFundingService = () => {
     fetch: jest.fn().mockResolvedValue(funding),
     fetchSummaries: jest.fn(),
     fetchCommentedSummaries: jest.fn(),
+    patchStatusTx: jest.fn().mockResolvedValue(funding),
   };
   const fundingCommentRepository = {
+    create: jest.fn().mockResolvedValue([
+      {
+        funding: { id: funding.id },
+        approvedAmount: funding.approvedAmount,
+        fundingStatusEnum: funding.fundingStatusEnum,
+        isFinalComment: jest.fn().mockReturnValue(true),
+      },
+    ]),
     find: jest.fn(),
   };
   const userPublicService = {
@@ -72,10 +82,14 @@ const createFundingService = () => {
     fetchSummaries: jest.fn().mockResolvedValue([activity]),
   };
   const semesterPublicService = {
-    loadId: jest.fn(),
+    loadId: jest.fn().mockResolvedValue(activityDuration.semester.id),
   };
   const activityDurationPublicService = {
     load: jest.fn().mockResolvedValue(activityDuration),
+    getById: jest.fn().mockResolvedValue(activityDuration),
+  };
+  const prisma = {
+    $transaction: jest.fn(async callback => callback({})),
   };
   const fundingDeadlinePublicService = {
     search: jest.fn(({ deadlineEnum }) => {
@@ -106,7 +120,7 @@ const createFundingService = () => {
     semesterPublicService as FundingServiceDependencies[6],
     activityDurationPublicService as FundingServiceDependencies[7],
     fundingDeadlinePublicService as FundingServiceDependencies[8],
-    {} as FundingServiceDependencies[9],
+    prisma as FundingServiceDependencies[9],
     {} as FundingServiceDependencies[10],
   );
 
@@ -121,6 +135,7 @@ const createFundingService = () => {
     clubPublicService,
     activityDurationPublicService,
     fundingDeadlinePublicService,
+    prisma,
   };
 };
 
@@ -279,5 +294,42 @@ describe("FundingService final commented executive", () => {
     expect(result.fundings[0].commentedExecutive).toEqual(
       latestCommentedExecutive,
     );
+  });
+});
+
+describe("FundingService executive review semester guard", () => {
+  it("rejects funding comments for fundings from another semester before feedback mutation", async () => {
+    const {
+      activityDurationPublicService,
+      fundingCommentRepository,
+      fundingRepository,
+      prisma,
+      service,
+    } = createFundingService();
+    fundingRepository.fetch.mockResolvedValueOnce({
+      ...funding,
+      activityD: { id: 999 },
+      fundingStatusEnum: FundingStatusEnum.Applied,
+    });
+    activityDurationPublicService.getById.mockResolvedValueOnce({
+      ...activityDuration,
+      id: 999,
+      semester: { id: 2 },
+    });
+
+    await expect(
+      service.postExecutiveFundingComment(
+        chargedExecutive.id,
+        funding.id,
+        FundingStatusEnum.Approved,
+        funding.expenditureAmount,
+        "승인합니다",
+      ),
+    ).rejects.toThrow("current semester");
+
+    expect(activityDurationPublicService.getById).toHaveBeenCalledWith(999);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(fundingCommentRepository.create).not.toHaveBeenCalled();
+    expect(fundingRepository.patchStatusTx).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/feature/funding/service/funding.service.ts
+++ b/packages/api/src/feature/funding/service/funding.service.ts
@@ -109,6 +109,22 @@ export default class FundingService {
     private readonly operationCommitteeService: OperationCommitteeService,
   ) {}
 
+  private async assertActivityDurationIsInCurrentSemester(
+    activityDId: number,
+  ): Promise<void> {
+    const [activityDuration, currentSemesterId] = await Promise.all([
+      this.activityDurationPublicService.getById(activityDId),
+      this.semesterPublicService.loadId(),
+    ]);
+
+    if (activityDuration.semester.id !== currentSemesterId) {
+      throw new HttpException(
+        "The activity duration is not in the current semester",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
   @Transactional()
   async postStudentFunding(
     body: ApiFnd001RequestBody,
@@ -1045,6 +1061,7 @@ export default class FundingService {
    * @description 집행부원으로서 지원금 신청에 comment를 남깁니다.
    * @returns
    */
+  @Transactional()
   async postExecutiveFundingComment(
     executiveId: IExecutive["id"],
     id: IFunding["id"],
@@ -1060,12 +1077,15 @@ export default class FundingService {
       throw new HttpException(preFetchValidationError, HttpStatus.BAD_REQUEST);
     }
 
-    const { expenditureAmount } = await this.fundingRepository.fetch(id);
+    const targetFunding = await this.fundingRepository.fetch(id);
+    await this.assertActivityDurationIsInCurrentSemester(
+      targetFunding.activityD.id,
+    );
 
     const amountValidationError = getFundingCommentAmountValidationError({
       fundingStatusEnum,
       approvedAmount,
-      expenditureAmount,
+      expenditureAmount: targetFunding.expenditureAmount,
     });
     if (amountValidationError) {
       throw new HttpException(amountValidationError, HttpStatus.BAD_REQUEST);

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -305,7 +305,8 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
 
         {profile.type === UserTypeEnum.Executive &&
           !isOperatingCommittee &&
-          activityDeadline?.canApprove && (
+          activityDeadline?.canApprove &&
+          !isPastActivityReport && (
             <ExecutiveActivityReportApprovalSection
               comments={filterActivityComments(data.comments)}
               clubId={data.clubId}


### PR DESCRIPTION
## Summary
- 과거 ActivityD가 현재 semester에 속하지 않으면 활동보고서 집행부 승인/반려를 거부
- 과거 ActivityD가 현재 semester에 속하지 않으면 지원금 집행부 feedback 생성을 거부
- 과거 활동보고서 상세에서 집행부 승인/반려 섹션을 숨김

## Task Context
- Task ID: TU-439
- Notion: https://app.notion.com/p/373c25603b0b8103934efb421bc18b74

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 과거 활동보고서와 지원금 상세에서 집행부 승인/반려 feedback이 새로 생성되지 않도록 수정했습니다.
<!-- clubs:patch-note:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Executive approval and rejection workflows now automatically create feedback comments as part of the process.
  * Added validation to ensure activity approvals only apply to activities in the current semester.

* **Bug Fixes**
  * Fixed: Past activity reports no longer display the approval section in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->