### PR TITLE
[TU-448] transaction guard repository command 감지 보완

### DIFF
--- a/scripts/transaction-guard/changed-transaction-guard.mjs
+++ b/scripts/transaction-guard/changed-transaction-guard.mjs
@@ -177,11 +177,20 @@ function readRepositorySources(repoRoot) {
   return walkFiles(sourceRoot)
     .map(filePath => path.relative(repoRoot, filePath))
     .filter(filePath => isApiProductionTypeScriptFile(filePath))
-    .filter(filePath => toPosixPath(filePath).includes("/repository/"))
+    .filter(filePath => isRepositoryIndexSourceFile(filePath))
     .map(filePath => ({
       filePath,
       sourceText: fs.readFileSync(path.resolve(repoRoot, filePath), "utf8"),
     }));
+}
+
+function isRepositoryIndexSourceFile(filePath) {
+  const posixPath = toPosixPath(filePath);
+
+  return (
+    posixPath.includes("/repository/") ||
+    /^packages\/api\/src\/common\/base\/[^/]*repository\.ts$/u.test(posixPath)
+  );
 }
 
 function walkFiles(directory) {

--- a/scripts/transaction-guard/changed-transaction-guard.test.mjs
+++ b/scripts/transaction-guard/changed-transaction-guard.test.mjs
@@ -289,6 +289,195 @@ export class OperationCommitteeRepository {
   assert.deepEqual(runGuard(workspace), []);
 });
 
+test("fails when changed service code calls an inherited base repository write", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    "packages/api/src/common/base/base.repository.ts",
+    `
+export abstract class BaseRepository {
+  async patch(query, patchFunction) {
+    return this.runInTransaction(tx =>
+      this.patchImplementation(query, patchFunction, tx),
+    );
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    "packages/api/src/common/base/base.multi.repository.ts",
+    `
+export abstract class BaseMultiTableRepository extends BaseRepository {}
+`,
+  );
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class OperationCommitteeRepository extends BaseMultiTableRepository {}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  @Transactional()
+  async updateSecretKey(secretKey: string) {
+    return secretKey;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  @Transactional()
+  async updateSecretKey(secretKey: string) {
+    return this.operationCommitteeRepository.patch({ id: 1 }, old => old);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "inherited-repository-command-call");
+});
+
+test("passes when legacy inherited repository writes are untouched", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    "packages/api/src/common/base/base.repository.ts",
+    `
+export abstract class BaseRepository {
+  async delete(query) {
+    return this.runInTransaction(tx => this.deleteImplementation(query, tx));
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    "packages/api/src/common/base/base.single.repository.ts",
+    `
+export abstract class BaseSingleTableRepository extends BaseRepository {}
+`,
+  );
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class OperationCommitteeRepository extends BaseSingleTableRepository {}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  async deleteSecretKey() {
+    return this.operationCommitteeRepository.delete({ id: 1 });
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  async deleteSecretKey() {
+    return this.operationCommitteeRepository.delete({ id: 1 });
+  }
+
+  listSecretKeys() {
+    return [];
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("fails when changed service code calls a repository command with a manual transaction", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class OperationCommitteeRepository {
+  async patchStatus(param) {
+    return this.prisma.$transaction(tx => this.patchStatusTx(tx, param));
+  }
+
+  async patchStatusTx(tx, param) {
+    return tx.operationCommitteeSecretKey.update({
+      where: { id: param.id },
+      data: { status: "active" },
+    });
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  @Transactional()
+  async updateSecretKey(id: number) {
+    return id;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class OperationCommitteeService {
+  constructor(private readonly operationCommitteeRepository: OperationCommitteeRepository) {}
+
+  @Transactional()
+  async updateSecretKey(id: number) {
+    return this.operationCommitteeRepository.patchStatus({ id });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(
+    violations[0].kind,
+    "repository-command-uses-manual-transaction",
+  );
+});
+
 function runGuard(workspace) {
   const diff = execFileSync(
     "git",

--- a/scripts/transaction-guard/transaction-detector.mjs
+++ b/scripts/transaction-guard/transaction-detector.mjs
@@ -8,6 +8,19 @@ const MANUAL_TRANSACTION_METHODS = new Set([
   "withTransaction",
 ]);
 
+const BASE_REPOSITORY_CLASS_NAMES = new Set([
+  "BaseRepository",
+  "BaseSingleTableRepository",
+  "BaseMultiTableRepository",
+]);
+
+const BASE_REPOSITORY_WRITE_METHODS = new Set([
+  "create",
+  "put",
+  "patch",
+  "delete",
+]);
+
 const PRISMA_WRITE_METHODS = new Set([
   "create",
   "createMany",
@@ -151,6 +164,7 @@ export function findTransactionGuardNodes({
 }
 
 export function buildRepositoryCommandIndex(repositorySources) {
+  const classInfos = new Map();
   const index = new Map();
 
   for (const { filePath, sourceText } of repositorySources) {
@@ -160,23 +174,79 @@ export function buildRepositoryCommandIndex(repositorySources) {
     sourceFile.forEachChild(node => {
       if (!ts.isClassDeclaration(node) || !node.name) return;
 
-      const commandMethods = new Set();
+      const className = node.name.text;
+      const declaredCommands = new Map();
 
       for (const member of node.members) {
         if (!ts.isMethodDeclaration(member)) continue;
         const methodName = getPropertyNameText(member.name);
         if (!methodName) continue;
 
-        if (methodName.endsWith("Tx") || methodContainsCommandCall(member)) {
-          commandMethods.add(methodName);
+        const unsafeKinds = getMethodUnsafeKinds(member);
+        const requiresTransactional =
+          methodName.endsWith("Tx") || methodContainsCommandCall(member);
+
+        if (requiresTransactional || unsafeKinds.length > 0) {
+          declaredCommands.set(
+            methodName,
+            makeCommandInfo({
+              methodName,
+              ownerClassName: className,
+              requiresTransactional,
+              unsafeKinds,
+            }),
+          );
         }
       }
 
-      index.set(node.name.text, commandMethods);
+      classInfos.set(className, {
+        className,
+        extendsName: getExtendsClassName(node),
+        declaredCommands,
+      });
     });
   }
 
+  for (const classInfo of classInfos.values()) {
+    const commands = new Map(classInfo.declaredCommands);
+
+    if (inheritsFromBaseRepository(classInfo.className, classInfos)) {
+      for (const methodName of BASE_REPOSITORY_WRITE_METHODS) {
+        if (commands.has(methodName)) continue;
+
+        commands.set(
+          methodName,
+          makeCommandInfo({
+            methodName,
+            origin: "inherited",
+            ownerClassName: "BaseRepository",
+            requiresTransactional: true,
+            unsafeKinds: ["inherited-base-write"],
+          }),
+        );
+      }
+    }
+
+    index.set(classInfo.className, commands);
+  }
+
   return index;
+}
+
+function makeCommandInfo({
+  methodName,
+  origin = "declared",
+  ownerClassName,
+  requiresTransactional = false,
+  unsafeKinds = [],
+}) {
+  return {
+    methodName,
+    origin,
+    ownerClassName,
+    requiresTransactional,
+    unsafeKinds: [...new Set(unsafeKinds)],
+  };
 }
 
 function collectServiceTransactionViolations({
@@ -187,10 +257,11 @@ function collectServiceTransactionViolations({
   record,
 }) {
   for (const member of classNode.members) {
-    if (!ts.isMethodDeclaration(member) || hasTransactionalDecorator(member)) {
+    if (!ts.isMethodDeclaration(member)) {
       continue;
     }
 
+    const isTransactional = hasTransactionalDecorator(member);
     const commandCalls = [];
 
     const visit = node => {
@@ -212,12 +283,38 @@ function collectServiceTransactionViolations({
     visit(member);
 
     for (const commandCall of commandCalls) {
-      record(
-        member,
-        "service-command-without-transactional",
-        `${commandCall.repositoryProperty}.${commandCall.methodName}`,
-        "service methods that call repository command methods must be decorated with @Transactional",
+      const detected = `${commandCall.repositoryProperty}.${commandCall.methodName}`;
+
+      if (!isTransactional && commandCall.commandInfo.requiresTransactional) {
+        record(
+          member,
+          "service-command-without-transactional",
+          detected,
+          "service methods that call repository command methods must be decorated with @Transactional",
+        );
+      }
+
+      if (commandCall.commandInfo.origin === "inherited") {
+        record(
+          commandCall.node,
+          "inherited-repository-command-call",
+          detected,
+          "changed service code should call a concrete repository method instead of inherited BaseRepository write APIs",
+        );
+      }
+
+      const unsafeKinds = commandCall.commandInfo.unsafeKinds.filter(
+        kind => kind !== "inherited-base-write",
       );
+
+      if (unsafeKinds.length > 0) {
+        record(
+          commandCall.node,
+          "repository-command-uses-manual-transaction",
+          detected,
+          `repository command uses ${unsafeKinds.join(", ")} instead of TransactionHost.tx`,
+        );
+      }
     }
   }
 }
@@ -244,9 +341,11 @@ function getRepositoryCommandCall(
   if (!repositoryClassName) return null;
 
   const commandMethods = repositoryCommandIndex.get(repositoryClassName);
-  if (!commandMethods?.has(methodName)) return null;
+  const commandInfo = commandMethods?.get(methodName);
+  if (!commandInfo) return null;
 
   return {
+    commandInfo,
     methodName,
     repositoryProperty,
   };
@@ -291,6 +390,59 @@ function methodContainsCommandCall(method) {
   visit(method);
 
   return hasCommandCall;
+}
+
+function getMethodUnsafeKinds(method) {
+  const unsafeKinds = new Set();
+
+  const visit = node => {
+    if (ts.isCallExpression(node)) {
+      const propertyAccess = getPropertyAccess(node.expression);
+
+      if (
+        propertyAccess &&
+        MANUAL_TRANSACTION_METHODS.has(propertyAccess.name.text)
+      ) {
+        unsafeKinds.add("manual-transaction");
+      }
+
+      if (isRootPrismaCommandCall(node.expression)) {
+        unsafeKinds.add("root-prisma-write");
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(method);
+
+  return [...unsafeKinds];
+}
+
+function getExtendsClassName(classNode) {
+  const heritageClause = classNode.heritageClauses?.find(
+    clause => clause.token === ts.SyntaxKind.ExtendsKeyword,
+  );
+  const [heritageType] = heritageClause?.types ?? [];
+  const expression = heritageType?.expression;
+
+  return expression && ts.isIdentifier(expression) ? expression.text : null;
+}
+
+function inheritsFromBaseRepository(className, classInfos) {
+  let current = classInfos.get(className);
+  const seen = new Set();
+
+  while (current?.extendsName && !seen.has(current.extendsName)) {
+    if (BASE_REPOSITORY_CLASS_NAMES.has(current.extendsName)) {
+      return true;
+    }
+
+    seen.add(current.extendsName);
+    current = classInfos.get(current.extendsName);
+  }
+
+  return false;
 }
 
 function isRootPrismaCommandCall(expression) {

--- a/scripts/transaction-guard/transaction-detector.test.mjs
+++ b/scripts/transaction-guard/transaction-detector.test.mjs
@@ -139,3 +139,113 @@ class ExampleService {
     "operationCommitteeRepository.createSecretKey",
   );
 });
+
+test("flags inherited base repository writes as transaction commands and migration targets", () => {
+  const repositoryCommandIndex = buildRepositoryCommandIndex([
+    {
+      filePath: "packages/api/src/common/base/base.repository.ts",
+      sourceText: `
+class BaseRepository {
+  async create() {
+    return this.runInTransaction(async tx => tx.activity.create({ data: {} }));
+  }
+
+  async patch() {
+    return this.runInTransaction(async tx => tx.activity.update({ data: {} }));
+  }
+}
+`,
+    },
+    {
+      filePath: "packages/api/src/common/base/base.multi.repository.ts",
+      sourceText: `
+class BaseMultiTableRepository extends BaseRepository {}
+`,
+    },
+    {
+      filePath:
+        "packages/api/src/feature/activity/repository/activity.new.repository.ts",
+      sourceText: `
+class ActivityNewRepository extends BaseMultiTableRepository {
+  async approveExecutiveActivity() {
+    return this.txHost.tx.activity.updateMany({ data: {} });
+  }
+}
+`,
+    },
+  ]);
+  const serviceSourceText = `
+class ActivityServiceNew {
+  constructor(private readonly activityRepository: ActivityNewRepository) {}
+
+  async approve() {
+    return this.activityRepository.patch({ id: 1 }, activity => activity);
+  }
+}
+`;
+
+  const result = findTransactionGuardNodes({
+    sourceText: serviceSourceText,
+    filePath: "packages/api/src/feature/activity/service/activity.service.ts",
+    repositoryCommandIndex,
+  });
+
+  assert.deepEqual(
+    result.nodes.map(node => node.kind),
+    [
+      "service-command-without-transactional",
+      "inherited-repository-command-call",
+    ],
+  );
+});
+
+test("still asks changed code to migrate inherited writes even with @Transactional", () => {
+  const repositoryCommandIndex = buildRepositoryCommandIndex([
+    {
+      filePath: "packages/api/src/common/base/base.repository.ts",
+      sourceText: `
+class BaseRepository {
+  async create() {
+    return this.runInTransaction(async tx => tx.activity.create({ data: {} }));
+  }
+}
+`,
+    },
+    {
+      filePath: "packages/api/src/common/base/base.single.repository.ts",
+      sourceText: `
+class BaseSingleTableRepository extends BaseRepository {}
+`,
+    },
+    {
+      filePath:
+        "packages/api/src/feature/activity/repository/activity-comment.repository.ts",
+      sourceText: `
+class ActivityCommentRepository extends BaseSingleTableRepository {}
+`,
+    },
+  ]);
+  const serviceSourceText = `
+class ActivityServiceNew {
+  constructor(
+    private readonly activityCommentRepository: ActivityCommentRepository,
+  ) {}
+
+  @Transactional()
+  async comment() {
+    return this.activityCommentRepository.create({ activity: { id: 1 } });
+  }
+}
+`;
+
+  const result = findTransactionGuardNodes({
+    sourceText: serviceSourceText,
+    filePath: "packages/api/src/feature/activity/service/activity.service.ts",
+    repositoryCommandIndex,
+  });
+
+  assert.deepEqual(
+    result.nodes.map(node => node.kind),
+    ["inherited-repository-command-call"],
+  );
+});


### PR DESCRIPTION
## Summary
- 상속된 BaseRepository write method 호출을 changed service line에서 감지하도록 보완
- custom repository 내부 manual transaction/root Prisma write command 호출을 service 변경 지점에서 감지하도록 보완
- 기존 미수정 legacy는 changed-only 원칙으로 조용히 유지

## Task Context
- Task ID: TU-448
- Notion: https://app.notion.com/p/374c25603b0b813d9b9fd72db9ae98b1

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text: 사용자에게 직접 보이는 변경은 없습니다.
<!-- clubs:patch-note:end -->

