### PR TITLE
[TU-449] Base Repository 점진적 제거 가드 추가

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,6 +9,8 @@ set -e
 
 pnpm format:check:changed
 pnpm lint
+pnpm base-repository-guard:changed
 pnpm prisma-query:changed
+pnpm soft-delete-guard:changed
 pnpm transaction-guard:changed
 pnpm mcdc:changed --fail-on-missing

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "mcdc": "node scripts/mcdc/cli.mjs",
     "mcdc:changed": "node scripts/mcdc/jest-runner.mjs --changed-from origin/dev --source packages/api/src --min-conditions 2",
     "mcdc:jest": "node scripts/mcdc/jest-runner.mjs",
+    "base-repository-guard:changed": "node scripts/base-repository-guard/changed-base-repository-guard.mjs --changed-from origin/dev",
     "prisma-query:changed": "node scripts/prisma-query-guard/changed-raw-sql.mjs --changed-from origin/dev",
+    "soft-delete-guard:changed": "node scripts/soft-delete-guard/changed-soft-delete-guard.mjs --changed-from origin/dev",
     "start": "turbo run start",
     "clean": "turbo run clean",
     "lint": "turbo run lint",
@@ -33,15 +35,20 @@
     "prepare": "husky",
     "test": "turbo run test --filter=api",
     "test:mcdc": "node --test scripts/mcdc/*.test.mjs",
+    "test:base-repository-guard": "node --test scripts/base-repository-guard/*.test.mjs",
+    "test:eslint-config": "node --test packages/eslint-config/*.test.mjs packages/eslint-config/custom_rules/*.test.mjs",
     "test:injectable-runtime-dependencies": "node --test packages/eslint-config/custom_rules/eslint-plugin-injectable-runtime-dependencies.test.mjs",
     "test:prisma-query-guard": "node --test scripts/prisma-query-guard/*.test.mjs",
+    "test:soft-delete-guard": "node --test scripts/soft-delete-guard/*.test.mjs",
     "test:transaction-guard": "node --test scripts/transaction-guard/*.test.mjs",
     "transaction-guard:all": "node scripts/transaction-guard/scan-transaction-guard.mjs",
     "transaction-guard:changed": "node scripts/transaction-guard/changed-transaction-guard.mjs --changed-from origin/dev",
     "test:api": "turbo run test --filter=api"
   },
   "_scriptComments": {
+    "base-repository-guard:changed": "Pre-push validator. Blocks changed service/repository methods from relying on inherited BaseRepository write APIs.",
     "prisma-query:changed": "Pre-push validator. Blocks Prisma raw SQL APIs on changed packages/api/src lines while allowing untouched brownfield raw SQL debt.",
+    "soft-delete-guard:changed": "Pre-push validator. Requires explicit active/deleted/include-deleted intent on changed Prisma calls for models with deletedAt.",
     "test:prisma-query-guard": "Node test fixtures for the changed-line Prisma raw SQL guard."
   },
   "lint-staged": {

--- a/packages/api/src/common/util/soft-delete.ts
+++ b/packages/api/src/common/util/soft-delete.ts
@@ -1,0 +1,15 @@
+export function activeOnly<TWhere extends object>(
+  where: TWhere,
+): TWhere & { deletedAt: null } {
+  return { ...where, deletedAt: null };
+}
+
+export function onlyDeleted<TWhere extends object>(
+  where: TWhere,
+): TWhere & { deletedAt: { not: null } } {
+  return { ...where, deletedAt: { not: null } };
+}
+
+export function withDeleted<TWhere extends object>(where: TWhere): TWhere {
+  return where;
+}

--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -69,6 +69,7 @@ export const baseConfig = tseslint.config(
     },
     rules: {
       "curly": "off",
+      "dot-notation": "error",
       "import/extensions": "off",
       "import/no-extraneous-dependencies": "off",
       "import/no-unresolved": "off",

--- a/packages/eslint-config/base.test.mjs
+++ b/packages/eslint-config/base.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ESLint } from "eslint";
+
+import { baseConfig } from "./base.mjs";
+
+test("base config explicitly requires dot notation for value property access", () => {
+  assert.equal(readProjectDotNotationRule(), "error");
+});
+
+test("base config rejects string-literal bracket access without rejecting type indexed access", async () => {
+  const badMessages = await lintApiSource(`
+const repository = { create: () => 1 };
+const value = repository["create"]();
+export { value };
+`);
+
+  assert.ok(
+    badMessages.some(message => message.ruleId === "dot-notation"),
+    'expected dot-notation to report repository["create"]',
+  );
+
+  const goodMessages = await lintApiSource(`
+interface IModel {
+  name: string;
+}
+
+type Name = IModel["name"];
+const value: Name = "name";
+export { value };
+`);
+
+  assert.deepEqual(goodMessages, []);
+});
+
+function readProjectDotNotationRule() {
+  const config = baseConfig.find(
+    item => item.name === "global parameter settings for all packages",
+  );
+  const rule = config?.rules?.["dot-notation"];
+
+  return Array.isArray(rule) ? rule[0] : rule;
+}
+
+async function lintApiSource(sourceText) {
+  const eslint = new ESLint({
+    overrideConfig: baseConfig,
+    overrideConfigFile: true,
+  });
+  const [result] = await eslint.lintText(sourceText.trimStart(), {
+    filePath: "packages/api/src/app.controller.ts",
+  });
+
+  return result.messages.map(({ ruleId, message }) => ({ ruleId, message }));
+}

--- a/scripts/base-repository-guard/README.md
+++ b/scripts/base-repository-guard/README.md
@@ -1,0 +1,36 @@
+# BaseRepository guard
+
+`base-repository-guard:changed` blocks new or touched usages of inherited
+`BaseRepository` write APIs in `packages/api/src` production TypeScript files.
+
+The guard blocks:
+
+- service methods that call `create`, `put`, `patch`, or `delete` on an
+  injected repository whose class extends `BaseRepository`,
+  `BaseSingleTableRepository`, or `BaseMultiTableRepository`, unless that
+  repository class implements the same-named method itself.
+- service methods that call repository methods such as `createTx` when those
+  methods wrap `this.create`, `this.put`, `this.patch`, `this.delete`, or the
+  same methods through `super`.
+- service methods that call the same forbidden APIs through simple const
+  aliases, such as `const repository = this.noticeRepository`.
+- service methods that call or extract forbidden APIs through bracket access,
+  such as `this.noticeRepository["create"]` or
+  `const create = this.noticeRepository.create`.
+- service methods that destructure forbidden APIs from repositories, such as
+  `const { create } = this.noticeRepository`.
+- wrapper methods inherited from parent repository classes.
+- repository methods in `BaseRepository` subclasses that call
+  `this.create`, `this.put`, `this.patch`, `this.delete`, bracket-access
+  variants such as `this["patch"]`, or the same methods through `super`.
+
+The guard allows:
+
+- untouched brownfield BaseRepository calls.
+- domain-specific repository command methods such as `createNotice`.
+- same-named methods on repositories that do not extend BaseRepository.
+- same-named methods explicitly implemented by the repository class, as long as
+  they do not wrap the inherited BaseRepository write API.
+
+Use an explicit Prisma command method backed by `TransactionHost.tx` instead of
+calling the inherited BaseRepository write API.

--- a/scripts/base-repository-guard/changed-base-repository-guard.mjs
+++ b/scripts/base-repository-guard/changed-base-repository-guard.mjs
@@ -1,0 +1,1105 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import ts from "typescript";
+
+const DEFAULT_CHANGED_FROM = "origin/dev";
+const DEFAULT_SOURCE = "packages/api/src";
+
+const BASE_REPOSITORY_CLASS_NAMES = new Set([
+  "BaseRepository",
+  "BaseSingleTableRepository",
+  "BaseMultiTableRepository",
+]);
+
+const BASE_REPOSITORY_WRITE_METHODS = new Set([
+  "create",
+  "put",
+  "patch",
+  "delete",
+]);
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const baseRef = resolveBaseRef(args.changedFrom, repoRoot);
+  const diffText = readDiff({
+    baseRef,
+    repoRoot,
+    sourcePaths: args.sources,
+  });
+  const changedFiles = parseChangedFileLineMap(diffText);
+  const violations = findChangedBaseRepositoryViolations({
+    changedFiles,
+    repoRoot,
+  });
+
+  if (violations.length === 0) {
+    console.log(
+      `No BaseRepository guard violations found relative to ${args.changedFrom}.`,
+    );
+    return;
+  }
+
+  console.error(formatViolations(violations));
+  process.exitCode = 1;
+}
+
+export function findChangedBaseRepositoryViolations({
+  changedFiles,
+  repoRoot = process.cwd(),
+}) {
+  const baseRepositoryIndex = buildBaseRepositoryIndex(
+    readApiSources(repoRoot),
+  );
+  const violations = [];
+
+  for (const changedFile of changedFiles) {
+    if (!isApiProductionTypeScriptFile(changedFile.path)) {
+      continue;
+    }
+
+    const currentPath = path.resolve(repoRoot, changedFile.path);
+    if (!fs.existsSync(currentPath)) {
+      continue;
+    }
+
+    const sourceText = fs.readFileSync(currentPath, "utf8");
+    const result = findBaseRepositoryGuardNodes({
+      sourceText,
+      filePath: changedFile.path,
+      baseRepositoryIndex,
+    });
+
+    if (result.parseError) {
+      violations.push({
+        filePath: changedFile.path,
+        line: result.parseError.line,
+        column: result.parseError.column,
+        kind: "parse-error",
+        detected: "TypeScript parse error",
+        reason: result.parseError.message,
+      });
+      continue;
+    }
+
+    for (const node of result.nodes) {
+      if (!isNodeTouchedByChangedLines(node, changedFile)) {
+        continue;
+      }
+
+      violations.push({
+        filePath: changedFile.path,
+        line: node.line,
+        column: node.column,
+        kind: node.kind,
+        detected: node.detected,
+        reason: node.reason,
+      });
+    }
+  }
+
+  return violations.sort(compareViolations);
+}
+
+export function parseChangedFileLineMap(diffText) {
+  const files = new Map();
+  let currentFile = null;
+  let oldLine = 0;
+  let newLine = 0;
+  let insideHunk = false;
+
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      currentFile = null;
+      insideHunk = false;
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      currentFile = parseNewFilePath(line);
+      insideHunk = false;
+
+      if (currentFile && !files.has(currentFile)) {
+        files.set(currentFile, {
+          path: currentFile,
+          addedRanges: [],
+          deletedLines: [],
+        });
+      }
+      continue;
+    }
+
+    const hunk = line.match(
+      /^@@ -(?<oldStart>\d+)(?:,(?<oldCount>\d+))? \+(?<newStart>\d+)(?:,(?<newCount>\d+))? @@/u,
+    );
+
+    if (hunk) {
+      oldLine = Number(hunk.groups.oldStart);
+      newLine = Number(hunk.groups.newStart);
+      insideHunk = true;
+      continue;
+    }
+
+    if (!insideHunk || !currentFile) {
+      continue;
+    }
+
+    const file = files.get(currentFile);
+
+    if (line.startsWith("+")) {
+      addLineRange(file.addedRanges, newLine, newLine);
+      newLine += 1;
+    } else if (line.startsWith("-")) {
+      file.deletedLines.push({
+        oldLine,
+        adjacentLines: [newLine - 1, newLine, newLine + 1].filter(
+          lineNumber => lineNumber > 0,
+        ),
+      });
+      oldLine += 1;
+    } else if (line.startsWith(" ")) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return [...files.values()].filter(
+    file => file.addedRanges.length > 0 || file.deletedLines.length > 0,
+  );
+}
+
+function findBaseRepositoryGuardNodes({
+  sourceText,
+  filePath,
+  baseRepositoryIndex,
+}) {
+  const sourceFile = createSourceFile(sourceText, filePath);
+
+  if (sourceFile.parseDiagnostics.length > 0) {
+    return {
+      nodes: [],
+      parseError: formatParseDiagnostic(sourceFile),
+    };
+  }
+
+  const nodes = [];
+  const record = (node, rangeNode, kind, detected, reason) => {
+    nodes.push(makeNode(sourceFile, node, rangeNode, kind, detected, reason));
+  };
+
+  sourceFile.forEachChild(node => {
+    if (!ts.isClassDeclaration(node) || !node.name) {
+      return;
+    }
+
+    if (isServiceFile(filePath)) {
+      collectServiceBaseRepositoryViolations({
+        sourceFile,
+        classNode: node,
+        baseRepositoryIndex,
+        record,
+      });
+    }
+
+    const classInfo = baseRepositoryIndex.get(node.name.text);
+    if (
+      classInfo?.isBaseRepositoryDescendant &&
+      !isBaseRepositoryImplementationFile(filePath)
+    ) {
+      collectRepositoryBaseRepositoryViolations({
+        sourceFile,
+        classNode: node,
+        record,
+      });
+    }
+  });
+
+  return {
+    nodes: sortNodes(dedupeNodes(nodes)),
+    parseError: null,
+  };
+}
+
+function buildBaseRepositoryIndex(apiSources) {
+  const index = new Map();
+
+  for (const { filePath, sourceText } of apiSources) {
+    const sourceFile = createSourceFile(sourceText, filePath);
+    if (sourceFile.parseDiagnostics.length > 0) continue;
+
+    const visit = node => {
+      if (ts.isClassDeclaration(node) && node.name) {
+        index.set(node.name.text, {
+          className: node.name.text,
+          filePath,
+          extendsName: getExtendsClassName(node),
+          ownMethods: getOwnMethodNames(node),
+          baseWriteWrapperMethods: getBaseWriteWrapperMethodNames(node),
+          isBaseRepositoryDescendant: false,
+        });
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    for (const classInfo of index.values()) {
+      if (classInfo.isBaseRepositoryDescendant) {
+        continue;
+      }
+
+      const parentInfo = classInfo.extendsName
+        ? index.get(classInfo.extendsName)
+        : null;
+
+      if (
+        classInfo.extendsName &&
+        (BASE_REPOSITORY_CLASS_NAMES.has(classInfo.extendsName) ||
+          parentInfo?.isBaseRepositoryDescendant)
+      ) {
+        classInfo.isBaseRepositoryDescendant = true;
+        changed = true;
+      }
+
+      if (parentInfo?.baseWriteWrapperMethods) {
+        for (const methodName of parentInfo.baseWriteWrapperMethods) {
+          if (
+            classInfo.baseWriteWrapperMethods.has(methodName) ||
+            classInfo.ownMethods.has(methodName)
+          ) {
+            continue;
+          }
+
+          classInfo.baseWriteWrapperMethods.add(methodName);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return index;
+}
+
+function collectServiceBaseRepositoryViolations({
+  sourceFile,
+  classNode,
+  baseRepositoryIndex,
+  record,
+}) {
+  const repositoryProperties = getRepositoryProperties(classNode);
+
+  for (const member of classNode.members) {
+    if (!ts.isMethodDeclaration(member)) {
+      continue;
+    }
+
+    const repositoryAliases = new Map();
+
+    const visit = node => {
+      addRepositoryAliases(node, repositoryProperties, repositoryAliases);
+
+      const extraction = getBaseRepositoryWriteExtraction({
+        node,
+        sourceFile,
+        repositoryProperties,
+        repositoryAliases,
+        baseRepositoryIndex,
+      });
+
+      if (extraction) {
+        record(
+          extraction.node,
+          member,
+          "service-base-repository-write",
+          extraction.detected,
+          `service methods must not extract inherited BaseRepository.${extraction.methodName}; move the command into an explicit Prisma repository method`,
+        );
+      }
+
+      if (ts.isCallExpression(node)) {
+        const call = getInheritedBaseRepositoryWriteCall({
+          expression: node.expression,
+          repositoryProperties,
+          repositoryAliases,
+          baseRepositoryIndex,
+        });
+
+        if (call) {
+          record(
+            node.expression,
+            member,
+            "service-base-repository-write",
+            node.expression.getText(sourceFile),
+            `service methods must not call inherited BaseRepository.${call.methodName}; move the command into an explicit Prisma repository method`,
+          );
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(member);
+  }
+}
+
+function collectRepositoryBaseRepositoryViolations({
+  sourceFile,
+  classNode,
+  record,
+}) {
+  for (const member of classNode.members) {
+    if (!ts.isMethodDeclaration(member)) {
+      continue;
+    }
+
+    const visit = node => {
+      if (ts.isCallExpression(node)) {
+        const expression = getBaseRepositoryWriteCallExpression(
+          node.expression,
+        );
+
+        if (expression) {
+          record(
+            expression,
+            member,
+            "repository-base-repository-write",
+            expression.getText(sourceFile),
+            "repository methods must use explicit Prisma commands through TransactionHost.tx instead of calling BaseRepository write APIs",
+          );
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(member);
+  }
+}
+
+function getInheritedBaseRepositoryWriteCall({
+  expression,
+  repositoryProperties,
+  repositoryAliases,
+  baseRepositoryIndex,
+}) {
+  const methodName = getMemberAccessName(expression);
+  const repositoryAccess = getMemberAccessTarget(expression);
+  if (!methodName || !repositoryAccess) {
+    return null;
+  }
+  const repositoryProperty = getRepositoryPropertyName(
+    repositoryAccess,
+    repositoryAliases,
+  );
+  if (!repositoryProperty) {
+    return null;
+  }
+
+  const repositoryClassName = repositoryProperties.get(repositoryProperty);
+  if (!repositoryClassName) {
+    return null;
+  }
+
+  const repositoryInfo = baseRepositoryIndex.get(repositoryClassName);
+  if (!repositoryInfo?.isBaseRepositoryDescendant) {
+    return null;
+  }
+
+  if (!isForbiddenBaseRepositoryMethod(repositoryInfo, methodName)) {
+    return null;
+  }
+
+  return {
+    methodName,
+    repositoryClassName,
+    repositoryProperty,
+  };
+}
+
+function getBaseRepositoryWriteCallExpression(expression) {
+  const methodName = getMemberAccessName(expression);
+  const receiver = getMemberAccessTarget(expression);
+  if (!methodName || !receiver) {
+    return null;
+  }
+
+  if (!BASE_REPOSITORY_WRITE_METHODS.has(methodName)) {
+    return null;
+  }
+
+  if (isThisExpression(receiver) || isSuperExpression(receiver)) {
+    return expression;
+  }
+
+  return null;
+}
+
+function getBaseRepositoryWriteExtraction({
+  node,
+  sourceFile,
+  repositoryProperties,
+  repositoryAliases,
+  baseRepositoryIndex,
+}) {
+  if (!ts.isVariableDeclaration(node)) {
+    return null;
+  }
+
+  if (ts.isIdentifier(node.name) && node.initializer) {
+    const call = getInheritedBaseRepositoryWriteCall({
+      expression: node.initializer,
+      repositoryProperties,
+      repositoryAliases,
+      baseRepositoryIndex,
+    });
+
+    if (!call) {
+      return null;
+    }
+
+    return {
+      ...call,
+      node: node.initializer,
+      detected: node.initializer.getText(sourceFile),
+    };
+  }
+
+  if (!ts.isObjectBindingPattern(node.name) || !node.initializer) {
+    return null;
+  }
+
+  const repositoryProperty = getRepositoryPropertyName(
+    node.initializer,
+    repositoryAliases,
+  );
+  if (!repositoryProperty) {
+    return null;
+  }
+
+  const repositoryClassName = repositoryProperties.get(repositoryProperty);
+  if (!repositoryClassName) {
+    return null;
+  }
+
+  const repositoryInfo = baseRepositoryIndex.get(repositoryClassName);
+  if (!repositoryInfo?.isBaseRepositoryDescendant) {
+    return null;
+  }
+
+  for (const element of node.name.elements) {
+    const methodName = getPropertyNameText(element.propertyName);
+    const bindingName =
+      methodName ?? (ts.isIdentifier(element.name) ? element.name.text : null);
+
+    if (!bindingName) {
+      continue;
+    }
+
+    if (!isForbiddenBaseRepositoryMethod(repositoryInfo, bindingName)) {
+      continue;
+    }
+
+    return {
+      methodName: bindingName,
+      repositoryClassName,
+      repositoryProperty,
+      node: element,
+      detected: `${node.initializer.getText(sourceFile)}.${bindingName}`,
+    };
+  }
+
+  return null;
+}
+
+function isForbiddenBaseRepositoryMethod(repositoryInfo, methodName) {
+  if (repositoryInfo.baseWriteWrapperMethods.has(methodName)) {
+    return true;
+  }
+
+  if (!BASE_REPOSITORY_WRITE_METHODS.has(methodName)) {
+    return false;
+  }
+
+  return !repositoryInfo.ownMethods.has(methodName);
+}
+
+function addRepositoryAliases(node, repositoryProperties, repositoryAliases) {
+  if (!ts.isVariableDeclaration(node)) {
+    return;
+  }
+
+  if (!node.parent || !ts.isVariableDeclarationList(node.parent)) {
+    return;
+  }
+
+  if (!(node.parent.flags & ts.NodeFlags.Const)) {
+    return;
+  }
+
+  if (ts.isIdentifier(node.name)) {
+    const repositoryProperty = getThisRepositoryPropertyName(node.initializer);
+    if (repositoryProperty && repositoryProperties.has(repositoryProperty)) {
+      repositoryAliases.set(node.name.text, repositoryProperty);
+    }
+    return;
+  }
+
+  if (
+    ts.isObjectBindingPattern(node.name) &&
+    node.initializer &&
+    isThisExpression(node.initializer)
+  ) {
+    for (const element of node.name.elements) {
+      if (!ts.isIdentifier(element.name)) {
+        continue;
+      }
+
+      const propertyName =
+        getPropertyNameText(element.propertyName) ?? element.name.text;
+      if (repositoryProperties.has(propertyName)) {
+        repositoryAliases.set(element.name.text, propertyName);
+      }
+    }
+  }
+}
+
+function getRepositoryPropertyName(expression, repositoryAliases) {
+  const directProperty = getThisRepositoryPropertyName(expression);
+  if (directProperty) {
+    return directProperty;
+  }
+
+  if (ts.isIdentifier(expression)) {
+    return repositoryAliases.get(expression.text) ?? null;
+  }
+
+  return null;
+}
+
+function getThisRepositoryPropertyName(expression) {
+  if (!expression || !ts.isPropertyAccessExpression(expression)) {
+    return null;
+  }
+
+  if (!isThisExpression(expression.expression)) {
+    return null;
+  }
+
+  return expression.name.text;
+}
+
+function getMemberAccessName(expression) {
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  if (ts.isElementAccessExpression(expression)) {
+    return getStringLiteralText(expression.argumentExpression);
+  }
+
+  return null;
+}
+
+function getMemberAccessTarget(expression) {
+  if (
+    ts.isPropertyAccessExpression(expression) ||
+    ts.isElementAccessExpression(expression)
+  ) {
+    return expression.expression;
+  }
+
+  return null;
+}
+
+function getStringLiteralText(expression) {
+  if (ts.isStringLiteral(expression)) {
+    return expression.text;
+  }
+
+  return null;
+}
+
+function getRepositoryProperties(classNode) {
+  const repositoryProperties = new Map();
+
+  for (const member of classNode.members) {
+    if (ts.isConstructorDeclaration(member)) {
+      for (const parameter of member.parameters) {
+        if (!ts.isIdentifier(parameter.name)) continue;
+        if (!hasAccessModifier(parameter)) continue;
+
+        const className = getTypeReferenceIdentifierText(parameter.type);
+        if (className?.endsWith("Repository")) {
+          repositoryProperties.set(parameter.name.text, className);
+        }
+      }
+    }
+
+    if (ts.isPropertyDeclaration(member) && ts.isIdentifier(member.name)) {
+      const className = getTypeReferenceIdentifierText(member.type);
+      if (className?.endsWith("Repository")) {
+        repositoryProperties.set(member.name.text, className);
+      }
+    }
+  }
+
+  return repositoryProperties;
+}
+
+function getTypeReferenceIdentifierText(typeNode) {
+  if (!typeNode || !ts.isTypeReferenceNode(typeNode)) {
+    return null;
+  }
+
+  if (ts.isIdentifier(typeNode.typeName)) {
+    return typeNode.typeName.text;
+  }
+
+  return null;
+}
+
+function isThisExpression(node) {
+  return node.kind === ts.SyntaxKind.ThisKeyword;
+}
+
+function isSuperExpression(node) {
+  return node.kind === ts.SyntaxKind.SuperKeyword;
+}
+
+function getOwnMethodNames(classNode) {
+  const methodNames = new Set();
+
+  for (const member of classNode.members) {
+    if (ts.isMethodDeclaration(member)) {
+      const methodName = getPropertyNameText(member.name);
+      if (methodName) {
+        methodNames.add(methodName);
+      }
+      continue;
+    }
+
+    if (ts.isPropertyDeclaration(member)) {
+      const propertyName = getPropertyNameText(member.name);
+      if (
+        propertyName &&
+        member.initializer &&
+        (ts.isArrowFunction(member.initializer) ||
+          ts.isFunctionExpression(member.initializer))
+      ) {
+        methodNames.add(propertyName);
+      }
+    }
+  }
+
+  return methodNames;
+}
+
+function getBaseWriteWrapperMethodNames(classNode) {
+  const methodNames = new Set();
+
+  for (const member of classNode.members) {
+    if (!ts.isMethodDeclaration(member)) {
+      continue;
+    }
+
+    const methodName = getPropertyNameText(member.name);
+    if (methodName && methodContainsBaseRepositoryWriteCall(member)) {
+      methodNames.add(methodName);
+    }
+  }
+
+  return methodNames;
+}
+
+function methodContainsBaseRepositoryWriteCall(method) {
+  let hasBaseRepositoryWriteCall = false;
+
+  const visit = node => {
+    if (hasBaseRepositoryWriteCall) {
+      return;
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      getBaseRepositoryWriteCallExpression(node.expression)
+    ) {
+      hasBaseRepositoryWriteCall = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(method);
+
+  return hasBaseRepositoryWriteCall;
+}
+
+function getExtendsClassName(classNode) {
+  const heritageClause = classNode.heritageClauses?.find(
+    clause => clause.token === ts.SyntaxKind.ExtendsKeyword,
+  );
+  const heritageType = heritageClause?.types[0];
+  if (!heritageType) {
+    return null;
+  }
+
+  const expression = heritageType.expression;
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  return null;
+}
+
+function readApiSources(repoRoot) {
+  const sourceRoot = path.resolve(repoRoot, DEFAULT_SOURCE);
+  if (!fs.existsSync(sourceRoot)) {
+    return [];
+  }
+
+  return walkFiles(sourceRoot)
+    .map(filePath => path.relative(repoRoot, filePath))
+    .filter(filePath => isApiProductionTypeScriptFile(filePath))
+    .map(filePath => ({
+      filePath,
+      sourceText: fs.readFileSync(path.resolve(repoRoot, filePath), "utf8"),
+    }));
+}
+
+function walkFiles(directory) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function resolveBaseRef(changedFrom, repoRoot) {
+  try {
+    return execFileSync("git", ["merge-base", changedFrom, "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    throw new Error(
+      `Could not resolve merge-base for ${changedFrom}. Run 'git fetch origin dev' and try again.`,
+      { cause: error },
+    );
+  }
+}
+
+function readDiff({ baseRef, repoRoot, sourcePaths }) {
+  const args = [
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--diff-filter=ACMR",
+    baseRef,
+    "--",
+    ...sourcePaths,
+  ];
+
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+}
+
+function lineRangesOverlapAny(node, ranges) {
+  return ranges.some(
+    range => node.startLine <= range.endLine && range.startLine <= node.endLine,
+  );
+}
+
+function isNodeTouchedByChangedLines(node, changedFile) {
+  return (
+    lineRangesOverlapAny(node, changedFile.addedRanges) ||
+    changedFile.deletedLines.some(deletedLine =>
+      isDeletionTouchingNode(deletedLine, node),
+    )
+  );
+}
+
+function isDeletionTouchingNode(deletedLine, node) {
+  return deletedLine.adjacentLines.some(line => isLineInsideRange(line, node));
+}
+
+function isLineInsideRange(line, range) {
+  return range.startLine <= line && line <= range.endLine;
+}
+
+function addLineRange(ranges, startLine, endLine) {
+  const lastRange = ranges[ranges.length - 1];
+
+  if (lastRange && lastRange.endLine + 1 === startLine) {
+    lastRange.endLine = endLine;
+    return;
+  }
+
+  ranges.push({ startLine, endLine });
+}
+
+function parseNewFilePath(line) {
+  const filePath = line.slice("+++ ".length).trim();
+
+  if (filePath === "/dev/null") {
+    return null;
+  }
+
+  return filePath.startsWith("b/") ? filePath.slice(2) : filePath;
+}
+
+function hasAccessModifier(parameter) {
+  return parameter.modifiers?.some(modifier =>
+    [
+      ts.SyntaxKind.PrivateKeyword,
+      ts.SyntaxKind.ProtectedKeyword,
+      ts.SyntaxKind.PublicKeyword,
+    ].includes(modifier.kind),
+  );
+}
+
+function getPropertyNameText(name) {
+  if (!name) {
+    return null;
+  }
+
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text;
+  }
+
+  return null;
+}
+
+function makeNode(sourceFile, node, rangeNode, kind, detected, reason) {
+  const start = node.getStart(sourceFile);
+  const rangeStart = rangeNode.getStart(sourceFile);
+  const rangeEnd = rangeNode.getEnd();
+  const startPosition = sourceFile.getLineAndCharacterOfPosition(start);
+  const rangeStartPosition =
+    sourceFile.getLineAndCharacterOfPosition(rangeStart);
+  const rangeEndPosition = sourceFile.getLineAndCharacterOfPosition(
+    Math.max(rangeStart, rangeEnd - 1),
+  );
+
+  return {
+    kind,
+    detected,
+    reason,
+    line: startPosition.line + 1,
+    column: startPosition.character + 1,
+    startLine: rangeStartPosition.line + 1,
+    endLine: rangeEndPosition.line + 1,
+  };
+}
+
+function dedupeNodes(nodes) {
+  const seen = new Set();
+  const unique = [];
+
+  for (const node of nodes) {
+    const key = [
+      node.kind,
+      node.detected,
+      node.line,
+      node.column,
+      node.reason,
+    ].join("\0");
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(node);
+  }
+
+  return unique;
+}
+
+function sortNodes(nodes) {
+  return nodes.sort(
+    (left, right) =>
+      left.startLine - right.startLine ||
+      left.line - right.line ||
+      left.column - right.column ||
+      left.kind.localeCompare(right.kind),
+  );
+}
+
+function createSourceFile(sourceText, filePath) {
+  return ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath),
+  );
+}
+
+function getScriptKind(filePath) {
+  switch (path.extname(filePath)) {
+    case ".tsx":
+      return ts.ScriptKind.TSX;
+    case ".jsx":
+      return ts.ScriptKind.JSX;
+    case ".js":
+    case ".mjs":
+    case ".cjs":
+      return ts.ScriptKind.JS;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+function formatParseDiagnostic(sourceFile) {
+  const [diagnostic] = sourceFile.parseDiagnostics;
+  const position = sourceFile.getLineAndCharacterOfPosition(
+    diagnostic.start ?? 0,
+  );
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+
+  return {
+    line: position.line + 1,
+    column: position.character + 1,
+    message,
+  };
+}
+
+function isApiProductionTypeScriptFile(filePath) {
+  return (
+    toPosixPath(filePath).startsWith("packages/api/src/") &&
+    /\.ts$/u.test(filePath) &&
+    !/\.(?:spec|test)\.ts$/u.test(filePath)
+  );
+}
+
+function isServiceFile(filePath) {
+  const posixPath = toPosixPath(filePath);
+  return (
+    posixPath.includes("/service/") ||
+    posixPath.includes("/publicService/") ||
+    /\.service\.ts$/u.test(posixPath)
+  );
+}
+
+function isBaseRepositoryImplementationFile(filePath) {
+  return toPosixPath(filePath).startsWith("packages/api/src/common/base/");
+}
+
+function formatViolations(violations) {
+  const lines = [
+    "BaseRepository guard violations found.",
+    "Changed service/repository methods must not newly rely on inherited BaseRepository write APIs.",
+    "",
+  ];
+
+  for (const violation of violations.sort(compareViolations)) {
+    lines.push(`${violation.filePath}:${violation.line}:${violation.column}`);
+    lines.push(`  kind: ${violation.kind}`);
+    lines.push(`  detected: ${violation.detected}`);
+    lines.push(`  reason: ${violation.reason}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function compareViolations(left, right) {
+  return (
+    left.filePath.localeCompare(right.filePath) ||
+    left.line - right.line ||
+    left.column - right.column
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    changedFrom: DEFAULT_CHANGED_FROM,
+    sources: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--changed-from") {
+      args.changedFrom = readValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--source" || arg === "-s") {
+      args.sources.push(readValue(argv, index, arg));
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.sources.length === 0) {
+    args.sources.push(DEFAULT_SOURCE);
+  }
+
+  return args;
+}
+
+function readValue(argv, index, arg) {
+  const value = argv[index + 1];
+
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${arg} requires a value.`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm base-repository-guard:changed [options]
+
+Options:
+  --changed-from <ref>  Base ref for changed-method detection (default: origin/dev)
+  --source <path>      Source path to inspect (default: packages/api/src)
+  -h, --help           Show this help message
+`);
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/base-repository-guard/changed-base-repository-guard.test.mjs
+++ b/scripts/base-repository-guard/changed-base-repository-guard.test.mjs
@@ -1,0 +1,659 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findChangedBaseRepositoryViolations,
+  parseChangedFileLineMap,
+} from "./changed-base-repository-guard.mjs";
+
+const SERVICE_PATH =
+  "packages/api/src/feature/notice/service/notice.service.ts";
+const REPOSITORY_PATH =
+  "packages/api/src/feature/notice/repository/notice.repository.ts";
+const CUSTOM_REPOSITORY_PATH =
+  "packages/api/src/feature/funding/repository/funding.repository.ts";
+
+test("fails when a changed service calls an inherited BaseRepository write method", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository.create(input);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "this.noticeRepository.create");
+});
+
+test("fails when a changed BaseRepository subclass method calls this.patch", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async normalizeNotice(id: number) {
+    return this.patch({ id }, notice => notice);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "repository-base-repository-write");
+  assert.equal(violations[0].detected, "this.patch");
+});
+
+test("fails when a changed BaseRepository subclass method calls super.delete", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async removeNotice(id: number) {
+    return super.delete({ id });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "repository-base-repository-write");
+  assert.equal(violations[0].detected, "super.delete");
+});
+
+test("fails when a changed line is inside an existing service method that calls BaseRepository", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    const normalized = input;
+    return this.noticeRepository.create(normalized);
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    const normalized = { ...input };
+    return this.noticeRepository.create(normalized);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+});
+
+test("fails when a changed service calls a BaseRepository write wrapper with Tx suffix", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async createTx(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return this.create(input, tx);
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return this.noticeRepository.createTx(input, tx);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "this.noticeRepository.createTx");
+});
+
+test("fails when a changed service aliases a repository before calling inherited BaseRepository write", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    const repository = this.noticeRepository;
+    return repository.create(input);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "repository.create");
+});
+
+test("fails when a changed service calls inherited BaseRepository write with bracket access", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository["create"](input);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, 'this.noticeRepository["create"]');
+});
+
+test("fails when a changed service extracts an inherited BaseRepository write method", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    const create = this.noticeRepository.create;
+    return create(input);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "this.noticeRepository.create");
+});
+
+test("fails when a changed service destructures an inherited BaseRepository write method", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    const { create } = this.noticeRepository;
+    return create(input);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "this.noticeRepository.create");
+});
+
+test("fails when a changed service calls an inherited wrapper from a parent repository class", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export abstract class BaseNoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async createTx(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return this.create(input, tx);
+  }
+}
+
+export class NoticeRepository extends BaseNoticeRepository {}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate, tx: PrismaTransactionClient) {
+    return this.noticeRepository.createTx(input, tx);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "service-base-repository-write");
+  assert.equal(violations[0].detected, "this.noticeRepository.createTx");
+});
+
+test("fails when a changed BaseRepository subclass method calls this patch with bracket access", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async normalizeNotice(id: number) {
+    return this["patch"]({ id }, notice => notice);
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "repository-base-repository-write");
+  assert.equal(violations[0].detected, 'this["patch"]');
+});
+
+test("passes when a service calls a domain command implemented on the repository", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async createNotice(input: INoticeCreate) {
+    return this.txHost.tx.notice.create({ data: input });
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository.createNotice(input);
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when a service calls a same-named method on a non-BaseRepository class", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    CUSTOM_REPOSITORY_PATH,
+    `
+export class FundingRepository {
+  async put(id: number, body: unknown) {
+    return { id, body };
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class FundingService {
+  constructor(private readonly fundingRepository: FundingRepository) {}
+
+  async updateFunding(id: number, body: unknown) {
+    return body;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class FundingService {
+  constructor(private readonly fundingRepository: FundingRepository) {}
+
+  async updateFunding(id: number, body: unknown) {
+    return this.fundingRepository.put(id, body);
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when a BaseRepository subclass overrides the same-named method", () => {
+  const workspace = makeGitWorkspace();
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async create(input: INoticeCreate) {
+    return this.txHost.tx.notice.create({ data: input });
+  }
+}
+`,
+  );
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return input;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository.create(input);
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when untouched legacy BaseRepository calls remain", () => {
+  const workspace = makeGitWorkspace();
+  writeBaseRepositorySubclass(workspace);
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository.create(input);
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeFile(
+    workspace,
+    SERVICE_PATH,
+    `
+export class NoticeService {
+  constructor(private readonly noticeRepository: NoticeRepository) {}
+
+  async syncNotice(input: INoticeCreate) {
+    return this.noticeRepository.create(input);
+  }
+
+  label() {
+    return "notice";
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+function runGuard(workspace) {
+  const diff = execFileSync(
+    "git",
+    ["diff", "--unified=0", "--no-color", "--diff-filter=ACMR", "HEAD", "--"],
+    { cwd: workspace, encoding: "utf8" },
+  );
+
+  return findChangedBaseRepositoryViolations({
+    changedFiles: parseChangedFileLineMap(diff),
+    repoRoot: workspace,
+  });
+}
+
+function makeGitWorkspace() {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), "base-repository-guard-"),
+  );
+
+  execFileSync("git", ["init"], { cwd: workspace, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: workspace,
+  });
+  execFileSync("git", ["config", "user.name", "Test User"], {
+    cwd: workspace,
+  });
+
+  return workspace;
+}
+
+function writeBaseRepositorySubclass(workspace) {
+  writeFile(
+    workspace,
+    REPOSITORY_PATH,
+    `
+export class NoticeRepository extends BaseSingleTableRepository<MNotice, INoticeCreate, NoticeQuery> {
+  async findNotice(id: number) {
+    return this.txHost.tx.notice.findFirst({ where: { id } });
+  }
+}
+`,
+  );
+}
+
+function writeFile(workspace, filePath, sourceText) {
+  const absolutePath = path.join(workspace, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, sourceText.trimStart());
+}
+
+function commitAll(workspace, message) {
+  execFileSync("git", ["add", "."], { cwd: workspace });
+  execFileSync("git", ["commit", "-m", message], {
+    cwd: workspace,
+    stdio: "ignore",
+  });
+}

--- a/scripts/soft-delete-guard/README.md
+++ b/scripts/soft-delete-guard/README.md
@@ -1,0 +1,45 @@
+# Soft Delete Guard
+
+`soft-delete-guard` prevents newly touched API production code from querying
+soft-delete models without an explicit deleted-row intent.
+
+The guard reads `packages/api/prisma/schema.prisma` and treats every model with a
+`deletedAt` field as a soft-delete model.
+
+## Usage
+
+```sh
+pnpm soft-delete-guard:changed
+```
+
+By default, the script compares the current branch against `origin/dev`.
+
+## Scope
+
+The default source scope is `packages/api/src`.
+
+The guard checks production TypeScript files only:
+
+- included: `packages/api/src/**/*.ts`
+- excluded: `*.spec.ts`, `*.test.ts`
+
+## Policy
+
+Reads and writes against soft-delete models must explicitly choose one of these
+intents:
+
+- active rows: `where: activeOnly({ id })`
+- deleted rows: `where: onlyDeleted({ id })`
+- active and deleted rows: `where: withDeleted({ id })`
+- inline condition: `where: { id, deletedAt: null }`
+
+The guard fails when changed lines touch:
+
+- `findMany`, `findFirst`, `count`, `groupBy`, or `aggregate` without explicit
+  soft-delete intent
+- `update`, `updateMany`, or `upsert` without explicit soft-delete intent
+- `findUnique` or `findUniqueOrThrow` without explicit include-deleted intent
+- `delete` or `deleteMany` on a soft-delete model
+
+Untouched legacy omissions are allowed so existing code can be migrated
+incrementally.

--- a/scripts/soft-delete-guard/changed-soft-delete-guard.mjs
+++ b/scripts/soft-delete-guard/changed-soft-delete-guard.mjs
@@ -1,0 +1,713 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import ts from "typescript";
+
+const DEFAULT_CHANGED_FROM = "origin/dev";
+const DEFAULT_SOURCE = "packages/api/src";
+const DEFAULT_SCHEMA = "packages/api/prisma/schema.prisma";
+
+const READ_OPERATIONS = new Set([
+  "aggregate",
+  "count",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "groupBy",
+]);
+const UNIQUE_OPERATIONS = new Set(["findUnique", "findUniqueOrThrow"]);
+const UPDATE_OPERATIONS = new Set(["update", "updateMany", "upsert"]);
+const HARD_DELETE_OPERATIONS = new Set(["delete", "deleteMany"]);
+const EXPLICIT_SOFT_DELETE_HELPERS = new Set([
+  "activeOnly",
+  "onlyDeleted",
+  "withDeleted",
+]);
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const baseRef = resolveBaseRef(args.changedFrom, repoRoot);
+  const diffText = readDiff({
+    baseRef,
+    repoRoot,
+    sourcePaths: args.sources,
+  });
+  const changedFiles = parseChangedFileLineMap(diffText);
+  const violations = findChangedSoftDeleteViolations({
+    changedFiles,
+    repoRoot,
+    schemaPath: args.schema,
+  });
+
+  if (violations.length === 0) {
+    console.log(
+      `No soft-delete guard violations found relative to ${args.changedFrom}.`,
+    );
+    return;
+  }
+
+  console.error(formatViolations(violations));
+  process.exitCode = 1;
+}
+
+export function findChangedSoftDeleteViolations({
+  changedFiles,
+  repoRoot = process.cwd(),
+  schemaPath = DEFAULT_SCHEMA,
+}) {
+  const softDeleteDelegates = readSoftDeleteDelegates(repoRoot, schemaPath);
+  const violations = [];
+
+  for (const changedFile of changedFiles) {
+    if (!isApiProductionTypeScriptFile(changedFile.path)) {
+      continue;
+    }
+
+    const currentPath = path.resolve(repoRoot, changedFile.path);
+    if (!fs.existsSync(currentPath)) {
+      continue;
+    }
+
+    const sourceText = fs.readFileSync(currentPath, "utf8");
+    const result = findSoftDeleteGuardNodes({
+      sourceText,
+      filePath: changedFile.path,
+      softDeleteDelegates,
+    });
+
+    if (result.parseError) {
+      violations.push({
+        filePath: changedFile.path,
+        line: result.parseError.line,
+        column: result.parseError.column,
+        kind: "parse-error",
+        detected: "TypeScript parse error",
+        reason: result.parseError.message,
+      });
+      continue;
+    }
+
+    for (const node of result.nodes) {
+      if (!isNodeTouchedByChangedLines(node, changedFile)) {
+        continue;
+      }
+
+      violations.push({
+        filePath: changedFile.path,
+        line: node.line,
+        column: node.column,
+        kind: node.kind,
+        detected: node.detected,
+        reason: node.reason,
+      });
+    }
+  }
+
+  return violations.sort(compareViolations);
+}
+
+export function parseChangedFileLineMap(diffText) {
+  const files = new Map();
+  let currentFile = null;
+  let oldLine = 0;
+  let newLine = 0;
+  let insideHunk = false;
+
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      currentFile = null;
+      insideHunk = false;
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      currentFile = parseNewFilePath(line);
+      insideHunk = false;
+
+      if (currentFile && !files.has(currentFile)) {
+        files.set(currentFile, {
+          path: currentFile,
+          addedRanges: [],
+          deletedLines: [],
+        });
+      }
+      continue;
+    }
+
+    const hunk = line.match(
+      /^@@ -(?<oldStart>\d+)(?:,(?<oldCount>\d+))? \+(?<newStart>\d+)(?:,(?<newCount>\d+))? @@/u,
+    );
+
+    if (hunk) {
+      oldLine = Number(hunk.groups.oldStart);
+      newLine = Number(hunk.groups.newStart);
+      insideHunk = true;
+      continue;
+    }
+
+    if (!insideHunk || !currentFile) {
+      continue;
+    }
+
+    const file = files.get(currentFile);
+
+    if (line.startsWith("+")) {
+      addLineRange(file.addedRanges, newLine, newLine);
+      newLine += 1;
+    } else if (line.startsWith("-")) {
+      file.deletedLines.push({
+        oldLine,
+        adjacentLines: [newLine - 1, newLine, newLine + 1].filter(
+          lineNumber => lineNumber > 0,
+        ),
+      });
+      oldLine += 1;
+    } else if (line.startsWith(" ")) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return [...files.values()].filter(
+    file => file.addedRanges.length > 0 || file.deletedLines.length > 0,
+  );
+}
+
+function findSoftDeleteGuardNodes({
+  sourceText,
+  filePath,
+  softDeleteDelegates,
+}) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  if (sourceFile.parseDiagnostics.length > 0) {
+    return {
+      nodes: [],
+      parseError: formatParseDiagnostic(sourceFile),
+    };
+  }
+
+  const nodes = [];
+  const record = (node, kind, detected, reason) => {
+    nodes.push(makeNode(sourceFile, node, kind, detected, reason));
+  };
+
+  const visit = node => {
+    if (ts.isCallExpression(node)) {
+      const call = getSoftDeletePrismaCall(
+        node.expression,
+        softDeleteDelegates,
+      );
+
+      if (call) {
+        const detected = node.expression.getText(sourceFile);
+
+        if (HARD_DELETE_OPERATIONS.has(call.operation)) {
+          record(
+            node,
+            "hard-delete-soft-delete-model",
+            detected,
+            "soft-delete models must be deleted by setting deletedAt instead of using Prisma hard delete APIs",
+          );
+        } else if (UNIQUE_OPERATIONS.has(call.operation)) {
+          if (!hasExplicitSoftDeleteIntent(node.arguments[0])) {
+            record(
+              node,
+              "ambiguous-find-unique",
+              detected,
+              "findUnique on a soft-delete model includes deleted rows unless the query explicitly uses withDeleted/deletedAt intent; use findFirst with activeOnly for active rows",
+            );
+          }
+        } else if (
+          READ_OPERATIONS.has(call.operation) ||
+          UPDATE_OPERATIONS.has(call.operation)
+        ) {
+          if (!hasExplicitSoftDeleteIntent(node.arguments[0])) {
+            record(
+              node,
+              "missing-soft-delete-intent",
+              detected,
+              "soft-delete model queries must explicitly choose activeOnly, onlyDeleted, withDeleted, or a deletedAt condition",
+            );
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return {
+    nodes: sortNodes(dedupeNodes(nodes)),
+    parseError: null,
+  };
+}
+
+function getSoftDeletePrismaCall(expression, softDeleteDelegates) {
+  if (!ts.isPropertyAccessExpression(expression)) return null;
+
+  const chain = getPropertyAccessChain(expression);
+  const call = getPrismaModelOperation(chain);
+
+  if (!call || !softDeleteDelegates.has(call.modelDelegate)) {
+    return null;
+  }
+
+  return call;
+}
+
+function getPrismaModelOperation(chain) {
+  if (chain.length >= 4 && chain[0] === "this" && chain[1] === "prisma") {
+    return {
+      modelDelegate: chain[2],
+      operation: chain[3],
+    };
+  }
+
+  if (
+    chain.length >= 5 &&
+    chain[0] === "this" &&
+    chain[1] === "txHost" &&
+    chain[2] === "tx"
+  ) {
+    return {
+      modelDelegate: chain[3],
+      operation: chain[4],
+    };
+  }
+
+  if (chain.length >= 3 && ["prisma", "tx"].includes(chain[0])) {
+    return {
+      modelDelegate: chain[1],
+      operation: chain[2],
+    };
+  }
+
+  return null;
+}
+
+function hasExplicitSoftDeleteIntent(argument) {
+  if (!argument || !ts.isObjectLiteralExpression(argument)) {
+    return false;
+  }
+
+  const where = findPropertyAssignment(argument, "where");
+  if (!where) {
+    return false;
+  }
+
+  return expressionHasSoftDeleteIntent(where.initializer);
+}
+
+function expressionHasSoftDeleteIntent(expression) {
+  if (ts.isParenthesizedExpression(expression)) {
+    return expressionHasSoftDeleteIntent(expression.expression);
+  }
+
+  if (ts.isAsExpression(expression) || ts.isSatisfiesExpression(expression)) {
+    return expressionHasSoftDeleteIntent(expression.expression);
+  }
+
+  if (ts.isCallExpression(expression)) {
+    return isSoftDeleteHelperCall(expression);
+  }
+
+  if (!ts.isObjectLiteralExpression(expression)) {
+    return false;
+  }
+
+  for (const property of expression.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      if (expressionHasSoftDeleteIntent(property.expression)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+
+    const propertyName = getPropertyNameText(property.name);
+    if (
+      propertyName === "deletedAt" &&
+      !isUndefinedExpression(property.initializer)
+    ) {
+      return true;
+    }
+
+    if (
+      ["AND", "OR", "NOT"].includes(propertyName) &&
+      logicalExpressionHasSoftDeleteIntent(property.initializer)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function logicalExpressionHasSoftDeleteIntent(expression) {
+  if (ts.isArrayLiteralExpression(expression)) {
+    return expression.elements.some(element =>
+      expressionHasSoftDeleteIntent(element),
+    );
+  }
+
+  return expressionHasSoftDeleteIntent(expression);
+}
+
+function isSoftDeleteHelperCall(expression) {
+  const callee = expression.expression;
+
+  if (ts.isIdentifier(callee)) {
+    return EXPLICIT_SOFT_DELETE_HELPERS.has(callee.text);
+  }
+
+  return (
+    ts.isPropertyAccessExpression(callee) &&
+    EXPLICIT_SOFT_DELETE_HELPERS.has(callee.name.text)
+  );
+}
+
+function findPropertyAssignment(objectLiteral, propertyName) {
+  return objectLiteral.properties.find(
+    property =>
+      ts.isPropertyAssignment(property) &&
+      getPropertyNameText(property.name) === propertyName,
+  );
+}
+
+function isUndefinedExpression(expression) {
+  return (
+    (ts.isIdentifier(expression) && expression.text === "undefined") ||
+    (ts.isVoidExpression(expression) &&
+      ts.isNumericLiteral(expression.expression) &&
+      expression.expression.text === "0")
+  );
+}
+
+function readSoftDeleteDelegates(repoRoot, schemaPath) {
+  const absoluteSchemaPath = path.resolve(repoRoot, schemaPath);
+
+  if (!fs.existsSync(absoluteSchemaPath)) {
+    throw new Error(`Prisma schema not found: ${schemaPath}`);
+  }
+
+  const schema = fs.readFileSync(absoluteSchemaPath, "utf8");
+  const delegates = new Set();
+  const modelRegex = /\bmodel\s+([A-Za-z][A-Za-z0-9_]*)\s*\{/gu;
+  let match;
+
+  while ((match = modelRegex.exec(schema)) !== null) {
+    const modelName = match[1];
+    const bodyStart = modelRegex.lastIndex;
+    const bodyEnd = findMatchingBrace(schema, bodyStart - 1);
+
+    if (bodyEnd === -1) {
+      continue;
+    }
+
+    const body = schema.slice(bodyStart, bodyEnd);
+    if (/^\s*deletedAt\s+/mu.test(body)) {
+      delegates.add(toPrismaDelegateName(modelName));
+    }
+  }
+
+  return delegates;
+}
+
+function findMatchingBrace(text, openingBraceIndex) {
+  let depth = 0;
+
+  for (let index = openingBraceIndex; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function toPrismaDelegateName(modelName) {
+  return `${modelName.charAt(0).toLowerCase()}${modelName.slice(1)}`;
+}
+
+function resolveBaseRef(changedFrom, repoRoot) {
+  try {
+    return execFileSync("git", ["merge-base", changedFrom, "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    throw new Error(
+      `Could not resolve merge-base for ${changedFrom}. Run 'git fetch origin dev' and try again.`,
+      { cause: error },
+    );
+  }
+}
+
+function readDiff({ baseRef, repoRoot, sourcePaths }) {
+  const args = [
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--diff-filter=ACMR",
+    baseRef,
+    "--",
+    ...sourcePaths,
+  ];
+
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+}
+
+function lineRangesOverlapAny(node, ranges) {
+  return ranges.some(
+    range => node.startLine <= range.endLine && range.startLine <= node.endLine,
+  );
+}
+
+function isNodeTouchedByChangedLines(node, changedFile) {
+  return (
+    lineRangesOverlapAny(node, changedFile.addedRanges) ||
+    changedFile.deletedLines.some(deletedLine =>
+      isDeletionTouchingNode(deletedLine, node),
+    )
+  );
+}
+
+function isDeletionTouchingNode(deletedLine, node) {
+  return deletedLine.adjacentLines.some(line => isLineInsideRange(line, node));
+}
+
+function isLineInsideRange(line, range) {
+  return range.startLine <= line && line <= range.endLine;
+}
+
+function addLineRange(ranges, startLine, endLine) {
+  const lastRange = ranges[ranges.length - 1];
+
+  if (lastRange && lastRange.endLine + 1 === startLine) {
+    lastRange.endLine = endLine;
+    return;
+  }
+
+  ranges.push({ startLine, endLine });
+}
+
+function parseNewFilePath(line) {
+  const filePath = line.slice(4).trim();
+
+  if (filePath === "/dev/null") {
+    return null;
+  }
+
+  return filePath.startsWith("b/") ? filePath.slice(2) : filePath;
+}
+
+function isApiProductionTypeScriptFile(filePath) {
+  return (
+    toPosixPath(filePath).startsWith("packages/api/src/") &&
+    /\.ts$/u.test(filePath) &&
+    !/\.(?:spec|test)\.ts$/u.test(filePath)
+  );
+}
+
+function formatViolations(violations) {
+  const lines = [
+    "Soft-delete guard violations found.",
+    "Queries against models with deletedAt must explicitly choose activeOnly, onlyDeleted, withDeleted, or a deletedAt condition.",
+    "",
+  ];
+
+  for (const violation of violations.sort(compareViolations)) {
+    lines.push(`${violation.filePath}:${violation.line}:${violation.column}`);
+    lines.push(`  kind: ${violation.kind}`);
+    lines.push(`  detected: ${violation.detected}`);
+    lines.push(`  reason: ${violation.reason}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function compareViolations(left, right) {
+  return (
+    left.filePath.localeCompare(right.filePath) ||
+    left.line - right.line ||
+    left.column - right.column
+  );
+}
+
+function makeNode(sourceFile, node, kind, detected, reason) {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
+
+  return {
+    kind,
+    detected,
+    reason,
+    line: start.line + 1,
+    column: start.character + 1,
+    startLine: start.line + 1,
+    endLine: end.line + 1,
+  };
+}
+
+function sortNodes(nodes) {
+  return nodes.sort(
+    (left, right) =>
+      left.startLine - right.startLine ||
+      left.column - right.column ||
+      left.kind.localeCompare(right.kind),
+  );
+}
+
+function dedupeNodes(nodes) {
+  const seen = new Set();
+  const unique = [];
+
+  for (const node of nodes) {
+    const key = [
+      node.kind,
+      node.detected,
+      node.line,
+      node.column,
+      node.reason,
+    ].join("\0");
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(node);
+  }
+
+  return unique;
+}
+
+function getPropertyAccessChain(node) {
+  const chain = [];
+  let current = node;
+
+  while (ts.isPropertyAccessExpression(current)) {
+    chain.unshift(current.name.text);
+    current = current.expression;
+  }
+
+  chain.unshift(current.getText(current.getSourceFile()));
+  return chain;
+}
+
+function getPropertyNameText(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+
+  return null;
+}
+
+function formatParseDiagnostic(sourceFile) {
+  const diagnostic = sourceFile.parseDiagnostics[0];
+  const start = diagnostic.start ?? 0;
+  const position = sourceFile.getLineAndCharacterOfPosition(start);
+
+  return {
+    line: position.line + 1,
+    column: position.character + 1,
+    message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    changedFrom: DEFAULT_CHANGED_FROM,
+    schema: DEFAULT_SCHEMA,
+    sources: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--changed-from") {
+      args.changedFrom = readValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--schema") {
+      args.schema = readValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--source" || arg === "-s") {
+      args.sources.push(readValue(argv, index, arg));
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.sources.length === 0) {
+    args.sources.push(DEFAULT_SOURCE);
+  }
+
+  return args;
+}
+
+function readValue(argv, index, arg) {
+  const value = argv[index + 1];
+
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${arg} requires a value.`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm soft-delete-guard:changed [options]
+
+Options:
+  --changed-from <ref>  Base ref for changed-line detection (default: origin/dev)
+  --schema <path>      Prisma schema path (default: packages/api/prisma/schema.prisma)
+  --source <path>      Source path to inspect (default: packages/api/src)
+  -h, --help           Show this help message
+`);
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/soft-delete-guard/changed-soft-delete-guard.test.mjs
+++ b/scripts/soft-delete-guard/changed-soft-delete-guard.test.mjs
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findChangedSoftDeleteViolations,
+  parseChangedFileLineMap,
+} from "./changed-soft-delete-guard.mjs";
+
+const SOURCE_PATH = "packages/api/src/feature/example.repository.ts";
+const SCHEMA_PATH = "packages/api/prisma/schema.prisma";
+
+test("fails when a changed soft-delete model read has no explicit deletedAt intent", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: { clubId },
+    });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "missing-soft-delete-intent");
+  assert.equal(violations[0].detected, "this.txHost.tx.activity.findMany");
+});
+
+test("passes when a changed soft-delete model read uses activeOnly", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: activeOnly({ clubId }),
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when deleted records are explicitly included", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: withDeleted({ clubId }),
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when deleted records are explicitly selected", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: onlyDeleted({ clubId }),
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when a where object explicitly contains deletedAt", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: { clubId, deletedAt: null },
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("fails when findUnique is used on a soft-delete model without explicit include-deleted intent", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async get() {
+    return null;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async get(id) {
+    return this.txHost.tx.activity.findUnique({
+      where: { id },
+    });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "ambiguous-find-unique");
+});
+
+test("passes when findUnique uses withDeleted explicitly", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async get() {
+    return null;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async get(id) {
+    return this.txHost.tx.activity.findUnique({
+      where: withDeleted({ id }),
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("fails when hard delete is used on a soft-delete model", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async remove() {
+    return true;
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async remove(id) {
+    return this.txHost.tx.activity.deleteMany({
+      where: activeOnly({ id }),
+    });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, "hard-delete-soft-delete-model");
+});
+
+test("fails when a changed tx alias query has no explicit deletedAt intent", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    const tx = this.txHost.tx;
+
+    return tx.activity.findMany({
+      where: { clubId },
+    });
+  }
+}
+`,
+  );
+
+  const violations = runGuard(workspace);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].detected, "tx.activity.findMany");
+});
+
+test("passes when non soft-delete model queries omit deletedAt", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class FileRepository {
+  async list() {
+    return [];
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class FileRepository {
+  async list(id) {
+    return this.prisma.file.findMany({
+      where: { id },
+    });
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+test("passes when untouched legacy soft-delete omissions remain", () => {
+  const workspace = makeGitWorkspace();
+  writeSchema(workspace);
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: { clubId },
+    });
+  }
+}
+`,
+  );
+  commitAll(workspace, "base");
+
+  writeSource(
+    workspace,
+    `
+export class ActivityRepository {
+  async list(clubId) {
+    return this.txHost.tx.activity.findMany({
+      where: { clubId },
+    });
+  }
+
+  label() {
+    return "activity";
+  }
+}
+`,
+  );
+
+  assert.deepEqual(runGuard(workspace), []);
+});
+
+function runGuard(workspace) {
+  const diff = execFileSync(
+    "git",
+    ["diff", "--unified=0", "--no-color", "--diff-filter=ACMR", "HEAD", "--"],
+    { cwd: workspace, encoding: "utf8" },
+  );
+
+  return findChangedSoftDeleteViolations({
+    changedFiles: parseChangedFileLineMap(diff),
+    repoRoot: workspace,
+  });
+}
+
+function makeGitWorkspace() {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), "soft-delete-guard-"),
+  );
+
+  execFileSync("git", ["init"], { cwd: workspace, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: workspace,
+  });
+  execFileSync("git", ["config", "user.name", "Test User"], {
+    cwd: workspace,
+  });
+
+  return workspace;
+}
+
+function writeSchema(workspace) {
+  writeFile(
+    workspace,
+    SCHEMA_PATH,
+    `
+model Activity {
+  id        Int       @id @default(autoincrement())
+  clubId    Int
+  deletedAt DateTime?
+}
+
+model File {
+  id String @id
+}
+`,
+  );
+}
+
+function writeSource(workspace, sourceText) {
+  writeFile(workspace, SOURCE_PATH, sourceText);
+}
+
+function writeFile(workspace, filePath, sourceText) {
+  const absolutePath = path.join(workspace, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, sourceText.trimStart());
+}
+
+function commitAll(workspace, message) {
+  execFileSync("git", ["add", "."], { cwd: workspace });
+  execFileSync("git", ["commit", "-m", message], {
+    cwd: workspace,
+    stdio: "ignore",
+  });
+}


### PR DESCRIPTION
## Summary
- 변경된 API 코드에서 inherited BaseRepository write API 사용을 막는 BaseRepository 가드를 추가했습니다.
- soft-delete 모델 조회/수정에 명시적 deletedAt 의도를 요구하는 changed-line 가드를 추가했습니다.
- 값 레벨 문자열 bracket 접근을 피하도록 ESLint `dot-notation`을 명시하고, 관련 테스트를 추가했습니다.

## Test Plan
- [x] pnpm test:base-repository-guard
- [x] pnpm test:soft-delete-guard
- [x] pnpm test:eslint-config
- [x] pnpm base-repository-guard:changed
- [x] pnpm soft-delete-guard:changed
- [x] pnpm transaction-guard:changed
- [x] pnpm prisma-query:changed
- [x] pnpm mcdc:changed --fail-on-missing
- [x] pnpm format:check:changed
- [x] pnpm turbo run lint --force
- [x] pnpm --filter api build
- [x] git diff --check

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text: Base Repository 제거 작업을 안전하게 진행하기 위한 코드 가드를 추가했습니다.
<!-- clubs:patch-note:end -->
