### PR TITLE
[TU-452] 학기 관리 페이지 production 접근 허용

### DIFF
--- a/packages/web/src/constants/paths.ts
+++ b/packages/web/src/constants/paths.ts
@@ -59,7 +59,8 @@ export const productionReadyPaths: {
     "/my/register-club",
     "/executive/register-club",
     "/executive/register-member",
-    // 활동기간 / 등록 마감일 관리
+    // 학기 / 활동반기 / 등록 마감일 관리
+    "/executive/semester",
     "/executive/activity-duration",
     "/executive/registration/deadline",
     // 상임동아리 대표자 대시보드


### PR DESCRIPTION
## Summary
- Add `/executive/semester` to production-ready web paths.
- Fix the deployed semester management route rendering the generic NotFound page in non-dev app modes.

## Validation
- `pnpm format:check:changed`
- `pnpm --filter web lint`
- pre-push: format, lint, base-repository/prisma-query/soft-delete/transaction/MC/DC guards

## Patch Note
<!-- clubs:patch-note:start -->
category: fix
text: 집행부 학기 관리 페이지가 존재하지 않는 페이지로 표시되던 문제를 수정했습니다.
<!-- clubs:patch-note:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added production support for executive semester operations, enabling access to new executive-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->