### PR TITLE
[TU-338] 인증 과정 학적 구분 로직 개선

### DIFF
--- a/packages/api/src/feature/auth/repository/auth.repository.spec.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.spec.ts
@@ -1,0 +1,149 @@
+import { AuthRepository } from "./auth.repository";
+
+describe("AuthRepository", () => {
+  const currentDate = new Date("2026-06-10T00:00:00.000Z");
+
+  const createRepository = ({
+    studentNumber = 20245642,
+    studentTerms = [
+      {
+        studentId: 29943,
+        studentEnum: 3,
+      },
+    ],
+  }: {
+    studentNumber?: number;
+    studentTerms?: { studentId: number; studentEnum: number }[];
+  } = {}) => {
+    const prisma = {
+      $executeRaw: jest.fn().mockResolvedValue(undefined),
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      user: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 2494,
+            sid: "sid",
+            name: "조현준",
+            email: "hyunjun@example.com",
+          },
+        ]),
+      },
+      semesterD: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 19,
+            startTerm: new Date("2026-03-01T00:00:00.000Z"),
+            endTerm: new Date("2026-08-31T23:59:59.000Z"),
+          },
+        ]),
+      },
+      student: {
+        findMany: jest
+          .fn()
+          .mockResolvedValueOnce([
+            {
+              id: 29943,
+              number: studentNumber,
+            },
+          ])
+          .mockResolvedValue([
+            {
+              id: 29943,
+              number: studentNumber,
+            },
+          ]),
+      },
+      studentT: {
+        findMany: jest.fn().mockResolvedValue(studentTerms),
+      },
+      executive: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      professor: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      employee: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    const repository = new AuthRepository(prisma as never);
+    Object.defineProperty(repository, "clock", {
+      value: { now: () => currentDate },
+    });
+
+    return { repository, prisma };
+  };
+
+  it("uses the current student_t enum when returning student profiles after login", async () => {
+    const { repository } = createRepository();
+
+    const result = await repository.findOrCreateUser(
+      "hyunjun@example.com",
+      "20245642",
+      "sid",
+      "조현준",
+      "Student",
+      "1234",
+      "S",
+      "재학",
+      "2",
+    );
+
+    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
+    expect(result.master).toBeUndefined();
+  });
+
+  it("uses the current student_t enum when returning student profiles for token refresh", async () => {
+    const { repository } = createRepository();
+
+    const result = await repository.findUserById(2494);
+
+    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
+    expect(result.master).toBeUndefined();
+  });
+
+  it("classifies 5000-range students as doctors when falling back to student number", async () => {
+    const { repository } = createRepository({ studentTerms: [] });
+
+    const result = await repository.findOrCreateUser(
+      "hyunjun@example.com",
+      "20245642",
+      "sid",
+      "조현준",
+      "Student",
+      "1234",
+      "S",
+      "재학",
+      null,
+    );
+
+    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
+    expect(result.master).toBeUndefined();
+    expect(result.undergraduate).toBeUndefined();
+  });
+
+  it("rejects 6000-range students when falling back to student number", async () => {
+    const { repository } = createRepository({
+      studentNumber: 20246001,
+      studentTerms: [],
+    });
+
+    await expect(
+      repository.findOrCreateUser(
+        "exchange@example.com",
+        "20246001",
+        "sid",
+        "교환학생",
+        "Student",
+        "1234",
+        "S",
+        "재학",
+        null,
+      ),
+    ).rejects.toThrow(
+      "교환학생의 학적 정보를 추적할 수 없습니다. 관리자에게 문의해주세요.",
+    );
+  });
+});

--- a/packages/api/src/feature/auth/repository/auth.repository.spec.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.spec.ts
@@ -2,12 +2,17 @@ import { AuthRepository } from "./auth.repository";
 
 describe("AuthRepository", () => {
   const currentDate = new Date("2026-06-10T00:00:00.000Z");
+  const mockUserId = 900001;
+  const mockStudentId = 900002;
+  const mockSid = "test-sid";
+  const mockStudentName = "테스트 학생";
+  const defaultStudentNumber = 20995042;
 
   const createRepository = ({
-    studentNumber = 20245642,
+    studentNumber = defaultStudentNumber,
     studentTerms = [
       {
-        studentId: 29943,
+        studentId: mockStudentId,
         studentEnum: 3,
       },
     ],
@@ -21,10 +26,10 @@ describe("AuthRepository", () => {
       user: {
         findMany: jest.fn().mockResolvedValue([
           {
-            id: 2494,
-            sid: "sid",
-            name: "조현준",
-            email: "hyunjun@example.com",
+            id: mockUserId,
+            sid: mockSid,
+            name: mockStudentName,
+            email: "test-student@example.com",
           },
         ]),
       },
@@ -42,13 +47,13 @@ describe("AuthRepository", () => {
           .fn()
           .mockResolvedValueOnce([
             {
-              id: 29943,
+              id: mockStudentId,
               number: studentNumber,
             },
           ])
           .mockResolvedValue([
             {
-              id: 29943,
+              id: mockStudentId,
               number: studentNumber,
             },
           ]),
@@ -80,10 +85,10 @@ describe("AuthRepository", () => {
     const { repository } = createRepository();
 
     const result = await repository.findOrCreateUser(
-      "hyunjun@example.com",
-      "20245642",
-      "sid",
-      "조현준",
+      "test-student@example.com",
+      defaultStudentNumber.toString(),
+      mockSid,
+      mockStudentName,
       "Student",
       "1234",
       "S",
@@ -91,21 +96,24 @@ describe("AuthRepository", () => {
       "2",
     );
 
-    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
+    expect(result.doctor).toEqual({
+      id: mockStudentId,
+      number: defaultStudentNumber,
+    });
     expect(result.master).toBeUndefined();
   });
 
   it("uses SSO V2 as source of truth during login when it conflicts with current student_t", async () => {
     const { repository, prisma } = createRepository();
     prisma.studentT.findMany
-      .mockResolvedValueOnce([{ studentId: 29943, studentEnum: 3 }])
-      .mockResolvedValueOnce([{ studentId: 29943, studentEnum: 2 }]);
+      .mockResolvedValueOnce([{ studentId: mockStudentId, studentEnum: 3 }])
+      .mockResolvedValueOnce([{ studentId: mockStudentId, studentEnum: 2 }]);
 
     const result = await repository.findOrCreateUser(
-      "hyunjun@example.com",
-      "20245642",
-      "sid",
-      "조현준",
+      "test-student@example.com",
+      defaultStudentNumber.toString(),
+      mockSid,
+      mockStudentName,
       "Student",
       "1234",
       "S",
@@ -119,16 +127,22 @@ describe("AuthRepository", () => {
 
     expect(studentTermUpsert?.values[1]).toBe(2);
     expect(studentTermUpsert?.values[7]).toBe(2);
-    expect(result.master).toEqual({ id: 29943, number: 20245642 });
+    expect(result.master).toEqual({
+      id: mockStudentId,
+      number: defaultStudentNumber,
+    });
     expect(result.doctor).toBeUndefined();
   });
 
   it("uses the current student_t enum when returning student profiles for token refresh", async () => {
     const { repository } = createRepository();
 
-    const result = await repository.findUserById(2494);
+    const result = await repository.findUserById(mockUserId);
 
-    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
+    expect(result.doctor).toEqual({
+      id: mockStudentId,
+      number: defaultStudentNumber,
+    });
     expect(result.master).toBeUndefined();
   });
 
@@ -141,14 +155,14 @@ describe("AuthRepository", () => {
     async (_, studentNumber, studentEnum, expectedProfileKey) => {
       const { repository } = createRepository({
         studentNumber,
-        studentTerms: [{ studentId: 29943, studentEnum }],
+        studentTerms: [{ studentId: mockStudentId, studentEnum }],
       });
 
       const result = await repository.findOrCreateUser(
         "student@example.com",
         studentNumber.toString(),
-        "sid",
-        "학생",
+        mockSid,
+        mockStudentName,
         "Student",
         "1234",
         "S",
@@ -157,7 +171,7 @@ describe("AuthRepository", () => {
       );
 
       expect(result[expectedProfileKey]).toEqual({
-        id: 29943,
+        id: mockStudentId,
         number: studentNumber,
       });
     },
@@ -180,8 +194,8 @@ describe("AuthRepository", () => {
       const result = await repository.findOrCreateUser(
         "student@example.com",
         studentNumber.toString(),
-        "sid",
-        "학생",
+        mockSid,
+        mockStudentName,
         "Student",
         "1234",
         "S",
@@ -190,7 +204,7 @@ describe("AuthRepository", () => {
       );
 
       expect(result[expectedProfileKey]).toEqual({
-        id: 29943,
+        id: mockStudentId,
         number: studentNumber,
       });
     },
@@ -199,15 +213,15 @@ describe("AuthRepository", () => {
   it("rejects HP students before SSO, DB, or fallback classification", async () => {
     const { repository } = createRepository({
       studentNumber: 20996901,
-      studentTerms: [{ studentId: 29943, studentEnum: 2 }],
+      studentTerms: [{ studentId: mockStudentId, studentEnum: 2 }],
     });
 
     await expect(
       repository.findOrCreateUser(
         "hp@example.com",
         "20996901",
-        "sid",
-        "HP 학생",
+        mockSid,
+        mockStudentName,
         "Student",
         "1234",
         "S",
@@ -232,8 +246,8 @@ describe("AuthRepository", () => {
         repository.findOrCreateUser(
           "exchange@example.com",
           studentNumber.toString(),
-          "sid",
-          "교환학생",
+          mockSid,
+          mockStudentName,
           "Student",
           "1234",
           "S",

--- a/packages/api/src/feature/auth/repository/auth.repository.spec.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.spec.ts
@@ -95,6 +95,34 @@ describe("AuthRepository", () => {
     expect(result.master).toBeUndefined();
   });
 
+  it("uses SSO V2 as source of truth during login when it conflicts with current student_t", async () => {
+    const { repository, prisma } = createRepository();
+    prisma.studentT.findMany
+      .mockResolvedValueOnce([{ studentId: 29943, studentEnum: 3 }])
+      .mockResolvedValueOnce([{ studentId: 29943, studentEnum: 2 }]);
+
+    const result = await repository.findOrCreateUser(
+      "hyunjun@example.com",
+      "20245642",
+      "sid",
+      "조현준",
+      "Student",
+      "1234",
+      "S",
+      "재학",
+      "1",
+    );
+
+    const studentTermUpsert = prisma.$executeRaw.mock.calls
+      .map(([query]) => query as { strings: string[]; values: unknown[] })
+      .find(query => query.strings.join("").includes("INSERT INTO student_t"));
+
+    expect(studentTermUpsert?.values[1]).toBe(2);
+    expect(studentTermUpsert?.values[7]).toBe(2);
+    expect(result.master).toEqual({ id: 29943, number: 20245642 });
+    expect(result.doctor).toBeUndefined();
+  });
+
   it("uses the current student_t enum when returning student profiles for token refresh", async () => {
     const { repository } = createRepository();
 
@@ -121,6 +149,29 @@ describe("AuthRepository", () => {
 
     expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
     expect(result.master).toBeUndefined();
+    expect(result.undergraduate).toBeUndefined();
+  });
+
+  it("classifies 2000-range students as masters when falling back to student number", async () => {
+    const { repository } = createRepository({
+      studentNumber: 20242001,
+      studentTerms: [],
+    });
+
+    const result = await repository.findOrCreateUser(
+      "master@example.com",
+      "20242001",
+      "sid",
+      "석사생",
+      "Student",
+      "1234",
+      "S",
+      "재학",
+      null,
+    );
+
+    expect(result.master).toEqual({ id: 29943, number: 20242001 });
+    expect(result.doctor).toBeUndefined();
     expect(result.undergraduate).toBeUndefined();
   });
 

--- a/packages/api/src/feature/auth/repository/auth.repository.spec.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.spec.ts
@@ -132,69 +132,117 @@ describe("AuthRepository", () => {
     expect(result.master).toBeUndefined();
   });
 
-  it("classifies 5000-range students as doctors when falling back to student number", async () => {
-    const { repository } = createRepository({ studentTerms: [] });
+  it.each([
+    ["6000-6899 undergraduate", 20996167, 1, "undergraduate"],
+    ["6000-6899 master", 20996614, 2, "master"],
+    ["7000+ doctor", 20998109, 3, "doctor"],
+  ] as const)(
+    "uses the current student_t enum for %s when login has no SSO V2 degree",
+    async (_, studentNumber, studentEnum, expectedProfileKey) => {
+      const { repository } = createRepository({
+        studentNumber,
+        studentTerms: [{ studentId: 29943, studentEnum }],
+      });
 
-    const result = await repository.findOrCreateUser(
-      "hyunjun@example.com",
-      "20245642",
-      "sid",
-      "조현준",
-      "Student",
-      "1234",
-      "S",
-      "재학",
-      null,
-    );
-
-    expect(result.doctor).toEqual({ id: 29943, number: 20245642 });
-    expect(result.master).toBeUndefined();
-    expect(result.undergraduate).toBeUndefined();
-  });
-
-  it("classifies 2000-range students as masters when falling back to student number", async () => {
-    const { repository } = createRepository({
-      studentNumber: 20242001,
-      studentTerms: [],
-    });
-
-    const result = await repository.findOrCreateUser(
-      "master@example.com",
-      "20242001",
-      "sid",
-      "석사생",
-      "Student",
-      "1234",
-      "S",
-      "재학",
-      null,
-    );
-
-    expect(result.master).toEqual({ id: 29943, number: 20242001 });
-    expect(result.doctor).toBeUndefined();
-    expect(result.undergraduate).toBeUndefined();
-  });
-
-  it("rejects 6000-range students when falling back to student number", async () => {
-    const { repository } = createRepository({
-      studentNumber: 20246001,
-      studentTerms: [],
-    });
-
-    await expect(
-      repository.findOrCreateUser(
-        "exchange@example.com",
-        "20246001",
+      const result = await repository.findOrCreateUser(
+        "student@example.com",
+        studentNumber.toString(),
         "sid",
-        "교환학생",
+        "학생",
         "Student",
         "1234",
         "S",
         "재학",
         null,
+      );
+
+      expect(result[expectedProfileKey]).toEqual({
+        id: 29943,
+        number: studentNumber,
+      });
+    },
+  );
+
+  it.each([
+    ["0000-1999", "undergraduate", 20991001],
+    ["2000-2999", "master", 20992001],
+    ["3000-3999", "master", 20993001],
+    ["4000-4999", "master", 20994001],
+    ["5000-5999", "doctor", 20995001],
+  ] as const)(
+    "classifies %s as %s when falling back to student number",
+    async (_, expectedProfileKey, studentNumber) => {
+      const { repository } = createRepository({
+        studentNumber,
+        studentTerms: [],
+      });
+
+      const result = await repository.findOrCreateUser(
+        "student@example.com",
+        studentNumber.toString(),
+        "sid",
+        "학생",
+        "Student",
+        "1234",
+        "S",
+        "재학",
+        null,
+      );
+
+      expect(result[expectedProfileKey]).toEqual({
+        id: 29943,
+        number: studentNumber,
+      });
+    },
+  );
+
+  it("rejects HP students before SSO, DB, or fallback classification", async () => {
+    const { repository } = createRepository({
+      studentNumber: 20996901,
+      studentTerms: [{ studentId: 29943, studentEnum: 2 }],
+    });
+
+    await expect(
+      repository.findOrCreateUser(
+        "hp@example.com",
+        "20996901",
+        "sid",
+        "HP 학생",
+        "Student",
+        "1234",
+        "S",
+        "재학",
+        "1",
       ),
-    ).rejects.toThrow(
-      "교환학생의 학적 정보를 추적할 수 없습니다. 관리자에게 문의해주세요.",
-    );
+    ).rejects.toThrow("HP 학번은 로그인할 수 없습니다.");
   });
+
+  it.each([
+    ["6000-6899", 20996001],
+    ["7000+", 20997001],
+  ] as const)(
+    "rejects %s students when falling back to student number",
+    async (_, studentNumber) => {
+      const { repository } = createRepository({
+        studentNumber,
+        studentTerms: [],
+      });
+
+      await expect(
+        repository.findOrCreateUser(
+          "exchange@example.com",
+          studentNumber.toString(),
+          "sid",
+          "교환학생",
+          "Student",
+          "1234",
+          "S",
+          "재학",
+          null,
+        ),
+      ).rejects.toThrow(
+        "교환학생의 학적 정보를 추적할 수 없습니다. 관리자에게 문의해주세요.",
+      );
+    },
+  );
 });

--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -34,6 +34,25 @@ interface FindOrCreateUserReturn {
   };
 }
 
+type StudentProfile = Pick<
+  FindOrCreateUserReturn,
+  "undergraduate" | "master" | "doctor"
+>;
+
+type StudentProfileKey = keyof StudentProfile;
+
+const studentProfileKeyByEnum = new Map<number, StudentProfileKey>([
+  [1, "undergraduate"],
+  [2, "master"],
+  [3, "doctor"],
+]);
+
+const getStudentNumberSuffix = (studentNumber: string | number) =>
+  Number(studentNumber.toString().slice(-4));
+
+const FALLBACK_STUDENT_ENUM_ERROR_MESSAGE =
+  "교환학생의 학적 정보를 추적할 수 없습니다. 관리자에게 문의해주세요.";
+
 @Injectable()
 export class AuthRepository {
   @Inject(CLOCK) private readonly clock: Clock;
@@ -91,13 +110,21 @@ export class AuthRepository {
       ((type === "Student" || type === "Ex-employee") &&
         !typeV2.startsWith("P")) // V1 fallback
     ) {
+      const studentNumberSuffix = getStudentNumberSuffix(studentNumber);
+
       //HP 학번(6900~6999)인 경우 로그인 불가
-      if (
-        parseInt(studentNumber.slice(-4)) >= 6900 &&
-        parseInt(studentNumber.slice(-4)) < 7000
-      ) {
+      if (studentNumberSuffix >= 6900) {
+        if (studentNumberSuffix < 7000) {
+          throw new HttpException(
+            "HP 학번은 로그인할 수 없습니다.",
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+      }
+
+      if (Number.isNaN(studentNumberSuffix)) {
         throw new HttpException(
-          "HP 학번은 로그인할 수 없습니다.",
+          "학번 형식이 올바르지 않습니다.",
           HttpStatus.BAD_REQUEST,
         );
       }
@@ -120,8 +147,6 @@ export class AuthRepository {
         .then(takeOne);
 
       //v2info 기반 학적 상태 및 학위 구분
-      // v2Info 없는 경우, studentNumber의 뒤 네자리가 2000 미만일 경우 studentEnum을 1, 5000미만일 경우 2, 6000미만일 경우 1, 나머지는 3으로 설정
-      let studentEnum = 3;
       let studentStatusEnum = 2;
 
       // 학적 상태 판별 (v2info)
@@ -129,53 +154,20 @@ export class AuthRepository {
         studentStatusEnum = 1;
       }
 
-      // 학위 구분 (v2info 기반)
-      if (progCodeV2) {
-        if (progCodeV2 === "0") studentEnum = 1;
-        else if (progCodeV2 === "1") studentEnum = 2;
-        else if (progCodeV2 === "2") studentEnum = 3;
-        // v2Info 없는 경우 기존 학번 기반 로직으로 fallback
-      } else if (parseInt(studentNumber.slice(-4)) < 2000) {
-        studentEnum = 1;
-        studentStatusEnum = 1;
-      } else if (parseInt(studentNumber.slice(-4)) < 5000) {
-        studentEnum = 2;
-      } else if (parseInt(studentNumber.slice(-4)) < 6000) {
-        studentEnum = 1;
-      }
-
-      // student 테이블에서 해당 user id를 모두 검색
-      // undergraduate, master, doctor 중 해당하는 경우 result에 추가
-      const students = await this.prisma.student.findMany({
-        where: { userId: user.id, deletedAt: null },
+      const existingStudentEnum = await this.getCurrentStudentEnumByStudentId([
+        student.id,
+      ]);
+      const studentEnum = this.resolveStudentEnum({
+        existingStudentEnum: existingStudentEnum.get(student.id),
+        progCodeV2,
+        studentNumber,
       });
 
-      /* eslint-disable no-shadow */
-      // eslint-disable-next-line no-restricted-syntax
-      for (const student of students) {
-        let studentEnum = 3;
-        if (student.number % 10000 < 2000) studentEnum = 1;
-        else if (student.number % 10000 < 6000) studentEnum = 2;
-        else if (student.number % 10000 < 7000) studentEnum = 2;
-
+      if (!progCodeV2) {
         if (studentEnum === 1) {
-          result = {
-            ...result,
-            undergraduate: { id: student.id, number: student.number },
-          };
-        } else if (studentEnum === 2) {
-          result = {
-            ...result,
-            master: { id: student.id, number: student.number },
-          };
-        } else if (studentEnum === 3) {
-          result = {
-            ...result,
-            doctor: { id: student.id, number: student.number },
-          };
+          studentStatusEnum = 1;
         }
       }
-      /* eslint-enable no-shadow */
 
       // 부서 ID를 안전하게 정수로 변환 (NaN 방지)
       const departmentId =
@@ -188,6 +180,32 @@ export class AuthRepository {
         VALUES (${student.id}, ${studentEnum}, ${studentStatusEnum}, ${departmentId}, ${semester.id}, ${semester.startTerm}, ${semester.endTerm})
         ON DUPLICATE KEY UPDATE student_enum = ${studentEnum}, student_status_enum = ${studentStatusEnum}, department = ${departmentId}
       `);
+
+      // student 테이블에서 해당 user id를 모두 검색
+      // undergraduate, master, doctor 중 해당하는 경우 result에 추가
+      const students = await this.prisma.student.findMany({
+        where: { userId: user.id, deletedAt: null },
+      });
+
+      const studentEnumByStudentId =
+        await this.getCurrentStudentEnumByStudentId(
+          students.map(studentRow => studentRow.id),
+        );
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const studentRow of students) {
+        const resolvedStudentEnum = this.resolveStudentEnum({
+          existingStudentEnum: studentEnumByStudentId.get(studentRow.id),
+          progCodeV2: null,
+          studentNumber: studentRow.number,
+        });
+
+        result = this.withStudentProfile(result, {
+          id: studentRow.id,
+          number: studentRow.number,
+          studentEnum: resolvedStudentEnum,
+        });
+      }
 
       // type이 "Student"인 경우 executive table에서 해당 studentNumber이 있는지 확인
       // 있으면 해당 칼럼의 user_id를 업데이트
@@ -367,20 +385,23 @@ export class AuthRepository {
       where: { userId: id, deletedAt: null },
     });
 
+    const studentEnumByStudentId = await this.getCurrentStudentEnumByStudentId(
+      students.map(student => student.id),
+    );
+
     // eslint-disable-next-line no-restricted-syntax
     for (const student of students) {
-      let studentEnum = 3;
-      if (student.number % 10000 < 2000) studentEnum = 1;
-      else if (student.number % 10000 < 6000) studentEnum = 2;
-      else if (student.number % 10000 < 7000) studentEnum = 1;
+      const resolvedStudentEnum = this.resolveStudentEnum({
+        existingStudentEnum: studentEnumByStudentId.get(student.id),
+        progCodeV2: null,
+        studentNumber: student.number,
+      });
 
-      if (studentEnum === 1) {
-        result.undergraduate = { id: student.id, number: student.number };
-      } else if (studentEnum === 2) {
-        result.master = { id: student.id, number: student.number };
-      } else if (studentEnum === 3) {
-        result.doctor = { id: student.id, number: student.number };
-      }
+      this.withStudentProfile(result, {
+        id: student.id,
+        number: student.number,
+        studentEnum: resolvedStudentEnum,
+      });
     }
 
     const executive = await this.prisma.executive
@@ -423,6 +444,126 @@ export class AuthRepository {
     }
 
     return result;
+  }
+
+  private async getCurrentStudentEnumByStudentId(studentIds: number[]) {
+    if (studentIds.length === 0) {
+      return new Map<number, number>();
+    }
+
+    const currentDate = this.clock.now();
+    const studentTerms = await this.prisma.studentT.findMany({
+      where: {
+        studentId: { in: studentIds },
+        startTerm: { lte: currentDate },
+        OR: [{ endTerm: null }, { endTerm: { gte: currentDate } }],
+        deletedAt: null,
+      },
+      orderBy: [{ startTerm: "desc" }, { id: "desc" }],
+      select: { studentId: true, studentEnum: true },
+    });
+
+    const studentEnumByStudentId = new Map<number, number>();
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const studentTerm of studentTerms) {
+      if (!studentEnumByStudentId.has(studentTerm.studentId)) {
+        studentEnumByStudentId.set(
+          studentTerm.studentId,
+          studentTerm.studentEnum,
+        );
+      }
+    }
+
+    return studentEnumByStudentId;
+  }
+
+  private resolveStudentEnum({
+    existingStudentEnum,
+    progCodeV2,
+    studentNumber,
+  }: {
+    existingStudentEnum?: number;
+    progCodeV2: string | null;
+    studentNumber: string | number;
+  }) {
+    const ssoStudentEnum = this.getStudentEnumFromProgCodeV2(progCodeV2);
+    if (ssoStudentEnum !== undefined) {
+      return ssoStudentEnum;
+    }
+
+    if (existingStudentEnum !== undefined) {
+      return existingStudentEnum;
+    }
+
+    return this.getFallbackStudentEnumFromStudentNumber(studentNumber);
+  }
+
+  private getStudentEnumFromProgCodeV2(progCodeV2: string | null) {
+    if (progCodeV2 === "0") {
+      return 1;
+    }
+
+    if (progCodeV2 === "1") {
+      return 2;
+    }
+
+    if (progCodeV2 === "2") {
+      return 3;
+    }
+
+    return undefined;
+  }
+
+  private getFallbackStudentEnumFromStudentNumber(
+    studentNumber: string | number,
+  ) {
+    const suffix = getStudentNumberSuffix(studentNumber);
+
+    if (Number.isNaN(suffix)) {
+      throw new HttpException(
+        "학번 형식이 올바르지 않습니다.",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (suffix < 2000) {
+      return 1;
+    }
+
+    if (suffix < 3000) {
+      throw new HttpException(
+        FALLBACK_STUDENT_ENUM_ERROR_MESSAGE,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (suffix < 5000) {
+      return 2;
+    }
+
+    if (suffix < 6000) {
+      return 3;
+    }
+
+    throw new HttpException(
+      FALLBACK_STUDENT_ENUM_ERROR_MESSAGE,
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+
+  private withStudentProfile<T extends StudentProfile>(
+    result: T,
+    student: { id: number; number: number; studentEnum: number },
+  ) {
+    const profileKey = studentProfileKeyByEnum.get(student.studentEnum);
+    if (profileKey === undefined) {
+      return result;
+    }
+
+    return Object.assign(result, {
+      [profileKey]: { id: student.id, number: student.number },
+    });
   }
 
   async findUserAndRefreshToken(

--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -531,13 +531,6 @@ export class AuthRepository {
       return 1;
     }
 
-    if (suffix < 3000) {
-      throw new HttpException(
-        FALLBACK_STUDENT_ENUM_ERROR_MESSAGE,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
     if (suffix < 5000) {
       return 2;
     }

--- a/packages/api/test/integration/app.spec.ts
+++ b/packages/api/test/integration/app.spec.ts
@@ -32,7 +32,7 @@ describe("AppController (integration)", () => {
     beforeEach(async () => {
       // 각 seeding 테스트 전에 DB 초기화
       await clearDatabase();
-    });
+    }, 60000);
 
     it("should seed test environment successfully", async () => {
       const testData = await seedTestEnvironment();


### PR DESCRIPTION
## Summary
- 인증 profile 생성 시 현재 학기 student_t.student_enum을 우선 사용하도록 수정했습니다.
- SSO V2, 기존 DB, 학번 fallback 순서로 학적 구분을 정리하고 5000번대 fallback을 박사로 보정했습니다.
- integration DB cleanup hook timeout을 명시해 기본 API 테스트를 안정화했습니다.

## Task Context
- Task ID: TU-338
- Notion: https://app.notion.com/p/276c25603b0b8038be8cf404e17f92b0

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 로그인 후 우측 상단에 학적 과정이 잘못 표시될 수 있던 문제를 수정했습니다.
<!-- clubs:patch-note:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified student classification and profile assignment for consistent role/status resolution.
  * Added explicit validation for student number formats and unified fallback/error messaging.

* **Tests**
  * New comprehensive tests for login and token refresh covering SSO vs current records, fallback rules, conflict handling, and rejection cases (HP and exchange students).
  * Increased test timeout for data seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->