### PR TITLE
[TU-451] pre-push 검증 병렬 실행 추가

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,12 +7,4 @@ fi
 
 set -e
 
-pnpm format:check:changed
-pnpm web-page-allowlist:check
-pnpm lint
-pnpm base-repository-guard:changed
-pnpm prisma-query:changed
-pnpm repository-domain-guard:changed
-pnpm soft-delete-guard:changed
-pnpm transaction-guard:changed
-pnpm mcdc:changed --fail-on-missing
+pnpm pre-push:parallel

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev-no-d": "turbo run dev:setup && turbo run dev --no-daemon",
     "build": "turbo run build --force",
     "build:api": "turbo run build --filter=api",
-    "pre-push:parallel": "node scripts/pre-push-parallel.mjs",
+    "pre-push:parallel": "node scripts/pre-push-parallel.mjs --profile pre-push",
+    "check:diff-line-convention-guards": "node scripts/pre-push-parallel.mjs --profile diff-line-convention-guards",
     "format:check:changed": "node scripts/check-format-changed.mjs",
     "web-page-allowlist:check": "node scripts/web-page-allowlist-guard/web-page-allowlist-guard.mjs",
     "mcdc": "node scripts/mcdc/cli.mjs",
@@ -54,7 +55,8 @@
     "test:api": "turbo run test --filter=api"
   },
   "_scriptComments": {
-    "pre-push:parallel": "Runs pre-push checks with read-only migration guards in parallel and side-effecting MC/DC checks afterward.",
+    "pre-push:parallel": "Runs the full pre-push check pipeline with parallel groups where safe.",
+    "check:diff-line-convention-guards": "Runs changed-line migration convention guards in parallel.",
     "base-repository-guard:changed": "Pre-push validator. Blocks changed service/repository methods from relying on inherited BaseRepository write APIs.",
     "prisma-query:changed": "Pre-push validator. Blocks Prisma raw SQL APIs on changed packages/api/src lines while allowing untouched brownfield raw SQL debt.",
     "repository-domain-guard:changed": "Pre-push validator. Blocks changed repository Prisma queries from crossing feature boundaries.",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev-no-d": "turbo run dev:setup && turbo run dev --no-daemon",
     "build": "turbo run build --force",
     "build:api": "turbo run build --filter=api",
+    "pre-push:parallel": "node scripts/pre-push-parallel.mjs",
     "format:check:changed": "node scripts/check-format-changed.mjs",
     "web-page-allowlist:check": "node scripts/web-page-allowlist-guard/web-page-allowlist-guard.mjs",
     "mcdc": "node scripts/mcdc/cli.mjs",
@@ -37,6 +38,7 @@
     "prepare": "husky",
     "test": "turbo run test --filter=api",
     "test:mcdc": "node --test scripts/mcdc/*.test.mjs",
+    "test:pre-push-parallel": "node --test scripts/pre-push-parallel.test.mjs",
     "test:database-url-safety": "node --test scripts/*database-url*.test.mjs scripts/sync-dev-db-safety.test.mjs",
     "test:base-repository-guard": "node --test scripts/base-repository-guard/*.test.mjs",
     "test:eslint-config": "node --test packages/eslint-config/*.test.mjs packages/eslint-config/custom_rules/*.test.mjs",
@@ -52,6 +54,7 @@
     "test:api": "turbo run test --filter=api"
   },
   "_scriptComments": {
+    "pre-push:parallel": "Runs pre-push checks with read-only migration guards in parallel and side-effecting MC/DC checks afterward.",
     "base-repository-guard:changed": "Pre-push validator. Blocks changed service/repository methods from relying on inherited BaseRepository write APIs.",
     "prisma-query:changed": "Pre-push validator. Blocks Prisma raw SQL APIs on changed packages/api/src lines while allowing untouched brownfield raw SQL debt.",
     "repository-domain-guard:changed": "Pre-push validator. Blocks changed repository Prisma queries from crossing feature boundaries.",

--- a/scripts/pre-push-parallel.mjs
+++ b/scripts/pre-push-parallel.mjs
@@ -2,9 +2,43 @@
 
 import { spawn } from "node:child_process";
 
+const profileNames = new Set(["pre-push", "diff-line-convention-guards"]);
+
+export const DIFF_LINE_CONVENTION_GUARD_GROUP = {
+  name: "diff-line convention guards",
+  mode: "parallel",
+  tasks: [
+    {
+      name: "base-repository-guard:changed",
+      command: "pnpm",
+      args: ["base-repository-guard:changed"],
+    },
+    {
+      name: "prisma-query:changed",
+      command: "pnpm",
+      args: ["prisma-query:changed"],
+    },
+    {
+      name: "repository-domain-guard:changed",
+      command: "pnpm",
+      args: ["repository-domain-guard:changed"],
+    },
+    {
+      name: "soft-delete-guard:changed",
+      command: "pnpm",
+      args: ["soft-delete-guard:changed"],
+    },
+    {
+      name: "transaction-guard:changed",
+      command: "pnpm",
+      args: ["transaction-guard:changed"],
+    },
+  ],
+};
+
 export const DEFAULT_GROUPS = [
   {
-    name: "quick checks",
+    name: "static checks",
     mode: "parallel",
     tasks: [
       {
@@ -17,33 +51,9 @@ export const DEFAULT_GROUPS = [
         command: "pnpm",
         args: ["web-page-allowlist:check"],
       },
-      {
-        name: "base-repository-guard:changed",
-        command: "pnpm",
-        args: ["base-repository-guard:changed"],
-      },
-      {
-        name: "prisma-query:changed",
-        command: "pnpm",
-        args: ["prisma-query:changed"],
-      },
-      {
-        name: "repository-domain-guard:changed",
-        command: "pnpm",
-        args: ["repository-domain-guard:changed"],
-      },
-      {
-        name: "soft-delete-guard:changed",
-        command: "pnpm",
-        args: ["soft-delete-guard:changed"],
-      },
-      {
-        name: "transaction-guard:changed",
-        command: "pnpm",
-        args: ["transaction-guard:changed"],
-      },
     ],
   },
+  DIFF_LINE_CONVENTION_GUARD_GROUP,
   {
     name: "lint",
     mode: "serial",
@@ -61,6 +71,46 @@ export const DEFAULT_GROUPS = [
     ],
   },
 ];
+
+export function selectPrePushGroups(argv = []) {
+  const args = parseArgs(argv);
+
+  if (args.profile === "diff-line-convention-guards") {
+    return [DIFF_LINE_CONVENTION_GUARD_GROUP];
+  }
+
+  return DEFAULT_GROUPS;
+}
+
+function parseArgs(argv) {
+  const args = {
+    profile: "pre-push",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--profile") {
+      args.profile = readValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!profileNames.has(args.profile)) {
+    throw new Error(
+      `Unknown profile: ${args.profile}. Expected one of ${[
+        ...profileNames,
+      ].join(", ")}.`,
+    );
+  }
+
+  return args;
+}
 
 export async function runPrePushGroups(
   groups = DEFAULT_GROUPS,
@@ -228,7 +278,33 @@ function formatSignal(signal) {
   return signal ? ` (${signal})` : "";
 }
 
+function readValue(argv, index, arg) {
+  const value = argv[index + 1];
+
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${arg} requires a value.`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm pre-push:parallel [options]
+
+Options:
+  --profile <name>  pre-push | diff-line-convention-guards (default: pre-push)
+  -h, --help        Show this help message
+`);
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const result = await runPrePushGroups();
-  process.exitCode = result.exitCode;
+  try {
+    const result = await runPrePushGroups(
+      selectPrePushGroups(process.argv.slice(2)),
+    );
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
 }

--- a/scripts/pre-push-parallel.mjs
+++ b/scripts/pre-push-parallel.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+export const DEFAULT_GROUPS = [
+  {
+    name: "quick checks",
+    mode: "parallel",
+    tasks: [
+      {
+        name: "format:check:changed",
+        command: "pnpm",
+        args: ["format:check:changed"],
+      },
+      {
+        name: "web-page-allowlist:check",
+        command: "pnpm",
+        args: ["web-page-allowlist:check"],
+      },
+      {
+        name: "base-repository-guard:changed",
+        command: "pnpm",
+        args: ["base-repository-guard:changed"],
+      },
+      {
+        name: "prisma-query:changed",
+        command: "pnpm",
+        args: ["prisma-query:changed"],
+      },
+      {
+        name: "repository-domain-guard:changed",
+        command: "pnpm",
+        args: ["repository-domain-guard:changed"],
+      },
+      {
+        name: "soft-delete-guard:changed",
+        command: "pnpm",
+        args: ["soft-delete-guard:changed"],
+      },
+      {
+        name: "transaction-guard:changed",
+        command: "pnpm",
+        args: ["transaction-guard:changed"],
+      },
+    ],
+  },
+  {
+    name: "lint",
+    mode: "serial",
+    tasks: [{ name: "lint", command: "pnpm", args: ["lint"] }],
+  },
+  {
+    name: "runtime evidence checks",
+    mode: "serial",
+    tasks: [
+      {
+        name: "mcdc:changed --fail-on-missing",
+        command: "pnpm",
+        args: ["mcdc:changed", "--fail-on-missing"],
+      },
+    ],
+  },
+];
+
+export async function runPrePushGroups(
+  groups = DEFAULT_GROUPS,
+  {
+    runTask = runCommandTask,
+    stdout = process.stdout,
+    stderr = process.stderr,
+  } = {},
+) {
+  const completedGroups = [];
+  const skippedGroups = [];
+
+  for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
+    const group = groups[groupIndex];
+    stdout.write(`\n== ${group.name} (${group.mode}) ==\n`);
+
+    const results =
+      group.mode === "parallel"
+        ? await Promise.all(group.tasks.map(task => runTask(task)))
+        : await runTasksSerially(group.tasks, runTask);
+
+    completedGroups.push({ group, results });
+    writeGroupSummary(results, stdout);
+
+    const failures = results.filter(result => result.status !== 0);
+
+    if (failures.length > 0) {
+      writeFailureDetails(failures, stderr);
+      skippedGroups.push(...groups.slice(groupIndex + 1));
+
+      for (const skippedGroup of skippedGroups) {
+        stdout.write(`SKIP ${skippedGroup.name}\n`);
+      }
+
+      return {
+        completedGroups,
+        exitCode: 1,
+        skippedGroups,
+      };
+    }
+  }
+
+  return {
+    completedGroups,
+    exitCode: 0,
+    skippedGroups,
+  };
+}
+
+async function runTasksSerially(tasks, runTask) {
+  const results = [];
+
+  for (const task of tasks) {
+    results.push(await runTask(task));
+  }
+
+  return results;
+}
+
+export function runCommandTask(task) {
+  const startTime = process.hrtime.bigint();
+
+  return new Promise(resolve => {
+    const child = spawn(task.command, task.args, {
+      cwd: task.cwd ?? process.cwd(),
+      env: { ...process.env, ...task.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    child.stdout.on("data", chunk => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", chunk => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", error => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve({
+        durationMs: elapsedMs(startTime),
+        error,
+        signal: null,
+        status: 1,
+        stderr: `${stderr}${error.message}\n`,
+        stdout,
+        task,
+      });
+    });
+
+    child.on("close", (status, signal) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve({
+        durationMs: elapsedMs(startTime),
+        signal,
+        status: status ?? 1,
+        stderr,
+        stdout,
+        task,
+      });
+    });
+  });
+}
+
+function writeGroupSummary(results, stdout) {
+  for (const result of results) {
+    const label = result.status === 0 ? "PASS" : "FAIL";
+    stdout.write(
+      `${label} ${result.task.name} ${formatDuration(result.durationMs)}\n`,
+    );
+  }
+}
+
+function writeFailureDetails(failures, stderr) {
+  stderr.write("\nPre-push checks failed.\n");
+
+  for (const failure of failures) {
+    stderr.write(`\n--- ${failure.task.name} ---\n`);
+
+    if (failure.stdout) {
+      stderr.write(failure.stdout);
+      if (!failure.stdout.endsWith("\n")) {
+        stderr.write("\n");
+      }
+    }
+
+    if (failure.stderr) {
+      stderr.write(failure.stderr);
+      if (!failure.stderr.endsWith("\n")) {
+        stderr.write("\n");
+      }
+    }
+
+    if (!failure.stdout && !failure.stderr) {
+      stderr.write(
+        `Command exited with status ${failure.status}${formatSignal(
+          failure.signal,
+        )}.\n`,
+      );
+    }
+  }
+}
+
+function elapsedMs(startTime) {
+  return Number(process.hrtime.bigint() - startTime) / 1_000_000;
+}
+
+function formatDuration(durationMs) {
+  return `${(durationMs / 1000).toFixed(2)}s`;
+}
+
+function formatSignal(signal) {
+  return signal ? ` (${signal})` : "";
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = await runPrePushGroups();
+  process.exitCode = result.exitCode;
+}

--- a/scripts/pre-push-parallel.test.mjs
+++ b/scripts/pre-push-parallel.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runPrePushGroups } from "./pre-push-parallel.mjs";
+
+test("parallel groups run every task before skipping later groups on failure", async () => {
+  const events = [];
+  const output = [];
+  const groups = [
+    {
+      name: "read-only checks",
+      mode: "parallel",
+      tasks: [
+        { name: "format", command: "pnpm", args: ["format:check:changed"] },
+        {
+          name: "soft-delete",
+          command: "pnpm",
+          args: ["soft-delete-guard:changed"],
+        },
+      ],
+    },
+    {
+      name: "runtime evidence checks",
+      mode: "serial",
+      tasks: [{ name: "mcdc", command: "pnpm", args: ["mcdc:changed"] }],
+    },
+  ];
+
+  const completions = new Map();
+  const runPromise = runPrePushGroups(groups, {
+    runTask: task => {
+      events.push(`start:${task.name}`);
+
+      return new Promise(resolve => {
+        completions.set(task.name, () => {
+          events.push(`end:${task.name}`);
+          resolve({
+            task,
+            status: task.name === "soft-delete" ? 1 : 0,
+            durationMs: task.name === "soft-delete" ? 21 : 13,
+            stdout: task.name === "format" ? "format ok\n" : "",
+            stderr: task.name === "soft-delete" ? "soft-delete failed\n" : "",
+          });
+        });
+      });
+    },
+    stdout: { write: chunk => output.push(chunk) },
+    stderr: { write: chunk => output.push(chunk) },
+  });
+
+  await new Promise(resolve => {
+    setImmediate(resolve);
+  });
+
+  assert.deepEqual(events, ["start:format", "start:soft-delete"]);
+  completions.get("soft-delete")();
+  completions.get("format")();
+
+  const result = await runPromise;
+
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(events, [
+    "start:format",
+    "start:soft-delete",
+    "end:soft-delete",
+    "end:format",
+  ]);
+  assert.equal(result.skippedGroups[0].name, "runtime evidence checks");
+  assert.match(output.join(""), /soft-delete failed/u);
+});
+
+test("serial groups run tasks in order after earlier parallel groups pass", async () => {
+  const events = [];
+  const groups = [
+    {
+      name: "quick checks",
+      mode: "parallel",
+      tasks: [
+        { name: "format", command: "pnpm", args: ["format:check:changed"] },
+        { name: "lint", command: "pnpm", args: ["lint"] },
+      ],
+    },
+    {
+      name: "runtime evidence checks",
+      mode: "serial",
+      tasks: [
+        { name: "mcdc", command: "pnpm", args: ["mcdc:changed"] },
+        { name: "final", command: "pnpm", args: ["final-check"] },
+      ],
+    },
+  ];
+
+  const result = await runPrePushGroups(groups, {
+    runTask: async task => {
+      events.push(task.name);
+
+      return {
+        task,
+        status: 0,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+      };
+    },
+    stdout: { write() {} },
+    stderr: { write() {} },
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(events.slice(0, 2).sort(), ["format", "lint"]);
+  assert.deepEqual(events.slice(2), ["mcdc", "final"]);
+  assert.deepEqual(result.skippedGroups, []);
+});

--- a/scripts/pre-push-parallel.test.mjs
+++ b/scripts/pre-push-parallel.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { runPrePushGroups } from "./pre-push-parallel.mjs";
+import { runPrePushGroups, selectPrePushGroups } from "./pre-push-parallel.mjs";
 
 test("parallel groups run every task before skipping later groups on failure", async () => {
   const events = [];
@@ -110,4 +110,44 @@ test("serial groups run tasks in order after earlier parallel groups pass", asyn
   assert.deepEqual(events.slice(0, 2).sort(), ["format", "lint"]);
   assert.deepEqual(events.slice(2), ["mcdc", "final"]);
   assert.deepEqual(result.skippedGroups, []);
+});
+
+test("diff-line convention guard profile runs only changed-line migration guards", () => {
+  const groups = selectPrePushGroups([
+    "--profile",
+    "diff-line-convention-guards",
+  ]);
+
+  assert.deepEqual(
+    groups.map(group => group.name),
+    ["diff-line convention guards"],
+  );
+  assert.deepEqual(
+    groups.flatMap(group => group.tasks.map(task => task.name)),
+    [
+      "base-repository-guard:changed",
+      "prisma-query:changed",
+      "repository-domain-guard:changed",
+      "soft-delete-guard:changed",
+      "transaction-guard:changed",
+    ],
+  );
+});
+
+test("pre-push profile keeps MC/DC in a separate runtime evidence group", () => {
+  const groups = selectPrePushGroups(["--profile", "pre-push"]);
+
+  assert.deepEqual(
+    groups.map(group => group.name),
+    [
+      "static checks",
+      "diff-line convention guards",
+      "lint",
+      "runtime evidence checks",
+    ],
+  );
+  assert.deepEqual(
+    groups.at(-1).tasks.map(task => task.name),
+    ["mcdc:changed --fail-on-missing"],
+  );
 });


### PR DESCRIPTION
## Summary
- pre-push 검증을 병렬 runner로 실행하도록 변경
- `check:diff-line-convention-guards`로 changed-line migration convention guard만 따로 실행할 수 있도록 분리
- full pre-push에서는 static checks, diff-line convention guards, lint, MC/DC를 단계별로 실행
- runner 동작을 검증하는 Node test 추가

## Task Context
- Task ID: TU-451
- Notion: https://app.notion.com/p/374c25603b0b813aa1c1e66ba3c262a4

## Patch Note

<!-- clubs:patch-note:start -->
category: internal
text: 사용자에게 직접 보이는 변경은 없습니다.
<!-- clubs:patch-note:end -->
