### PR TITLE
[TU-459] 활동보고서 테이블 승인 칸 너비 축소

### DIFF
--- a/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/CurrentActivityReportTable.tsx
@@ -33,7 +33,7 @@ const columns = [
         width="64px"
       />
     ),
-    size: 110,
+    size: 14,
   }),
   columnHelper.accessor("activityStatusEnumId", {
     header: "집행부 승인",
@@ -44,13 +44,13 @@ const columns = [
         width="64px"
       />
     ),
-    size: 110,
+    size: 14,
   }),
   columnHelper.accessor("name", {
     id: "activity",
     header: "활동명",
     cell: info => info.getValue(),
-    size: 20,
+    size: 30,
   }),
   columnHelper.accessor("activityTypeEnumId", {
     header: "활동 분류",
@@ -58,7 +58,7 @@ const columns = [
       const { color, text } = getTagDetail(info.getValue(), ActTypeTagList);
       return <Tag color={color}>{text}</Tag>;
     },
-    size: 32,
+    size: 18,
   }),
   columnHelper.accessor(
     row =>
@@ -67,7 +67,7 @@ const columns = [
       id: "date-range",
       header: "활동 기간",
       cell: info => info.getValue(),
-      size: 48,
+      size: 24,
     },
   ),
 ];

--- a/packages/web/src/features/activity-report/components/activityReportTableColumnWidth.spec.ts
+++ b/packages/web/src/features/activity-report/components/activityReportTableColumnWidth.spec.ts
@@ -1,0 +1,48 @@
+import * as assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const tableFiles = [
+  {
+    fileName: "CurrentActivityReportTable.tsx",
+    maxApprovalSize: 14,
+  },
+  {
+    fileName: "professor/ProfessorActivityReportTable.tsx",
+    maxApprovalSize: 16,
+  },
+];
+
+const extractColumnSizes = (source: string) =>
+  Array.from(source.matchAll(/header:\s*"([^"]+)"[\s\S]*?size:\s*(\d+)/gu)).map(
+    match => ({
+      header: match[1],
+      size: Number(match[2]),
+    }),
+  );
+
+describe("activity report table column widths", () => {
+  tableFiles.forEach(({ fileName, maxApprovalSize }) => {
+    it(`${fileName} keeps approval columns compact`, () => {
+      const source = readFileSync(new URL(fileName, import.meta.url), "utf8");
+      const columns = extractColumnSizes(source);
+      const totalSize = columns.reduce(
+        (total, column) => total + column.size,
+        0,
+      );
+      const approvalColumns = columns.filter(column =>
+        column.header.includes("승인"),
+      );
+
+      assert.equal(totalSize, 100);
+      assert.ok(approvalColumns.length > 0);
+
+      approvalColumns.forEach(column => {
+        assert.ok(
+          column.size <= maxApprovalSize,
+          `${column.header} should be ${maxApprovalSize}% or narrower`,
+        );
+      });
+    });
+  });
+});

--- a/packages/web/src/features/activity-report/components/professor/ProfessorActivityReportTable.tsx
+++ b/packages/web/src/features/activity-report/components/professor/ProfessorActivityReportTable.tsx
@@ -41,13 +41,13 @@ const columns = [
         width="64px"
       />
     ),
-    size: 110,
+    size: 16,
   }),
   columnHelper.accessor("name", {
     id: "activity",
     header: "활동명",
     cell: info => info.getValue(),
-    size: 20,
+    size: 36,
   }),
   columnHelper.accessor("activityTypeEnumId", {
     header: "활동 분류",
@@ -55,7 +55,7 @@ const columns = [
       const { color, text } = getTagDetail(info.getValue(), ActTypeTagList);
       return <Tag color={color}>{text}</Tag>;
     },
-    size: 32,
+    size: 20,
   }),
   columnHelper.accessor(
     row =>
@@ -64,7 +64,7 @@ const columns = [
       id: "date-range",
       header: "활동 기간",
       cell: info => info.getValue(),
-      size: 48,
+      size: 28,
     },
   ),
 ];


### PR DESCRIPTION
## Summary
- 활동보고서 목록 테이블의 승인 상태 컬럼 폭을 줄였습니다.
- 작은 해상도에서 활동명, 활동 분류, 활동 기간이 더 잘 보이도록 컬럼 비율을 재배분했습니다.
- 컬럼 폭 배분이 다시 커지지 않도록 회귀 테스트를 추가했습니다.

## Task Context
- Task ID: TU-459
- Notion: https://app.notion.com/p/38cc25603b0b818fbaa7f18d66ae2125

## Patch Note

<!-- clubs:patch-note:start -->
category: fix
text: 활동보고서 목록에서 승인 상태 칸이 과하게 넓어 활동 정보가 잘리던 문제를 수정했습니다.
<!-- clubs:patch-note:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted activity report table column widths for a cleaner, more balanced layout.
  * Improved visibility for activity names while tightening narrower columns such as approval, classification, and date range fields.
* **Tests**
  * Added coverage to verify activity report table column widths stay within expected limits and total sizing remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->